### PR TITLE
build: fix tcmu-runner_HANDLER_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=c99")
 
 include(GNUInstallDirs)
 
-set(tcmu-runner_HANDLER_PATH "${CMAKE_INSTALL_LIBDIR}/tcmu-runner")
+set(tcmu-runner_HANDLER_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/tcmu-runner")
 
 option(with-glfs "build Gluster glfs handler" true)
 option(with-qcow "build qcow handler" true)


### PR DESCRIPTION
Currently, tcmu-runner fails with below error
$ ./tcmu-runner
couldn't open handlers

This is because the 'handler_path' is DEFAULT_HANDLER_PATH, which is
\#define DEFAULT_HANDLER_PATH "@tcmu-runner_HANDLER_PATH@"
which inturn set to '${CMAKE_INSTALL_LIBDIR}/tcmu-runner' this on
expanding gives 'lib64/tcmu-runner' excluding the CMAKE_INSTALL_PREFIX

As a result the tcmu-runner binary can't locate the handlers unless an explicit
--handler-path parameter is specified.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>