### PR TITLE
build: fix RPATH settings for shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ set_target_properties(tcmu
   PROPERTIES
   SOVERSION "1"
   )
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 target_include_directories(tcmu
   PUBLIC ${LIBNL_INCLUDE_DIR}
   PUBLIC ${GLIB_INCLUDE_DIRS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,8 +194,8 @@ install(FILES libtcmu.h libtcmu_common.h tcmu-runner.h
 install(FILES org.kernel.TCMUService1.service
   DESTINATION /usr/share/dbus-1/system-services)
 install(FILES tcmu-runner.conf DESTINATION /etc/dbus-1/system.d)
-if (SUPPORT_SYSTEMD)
+if (IS_DIRECTORY /usr/lib/systemd/system)
   install(FILES tcmu-runner.service DESTINATION /usr/lib/systemd/system/)
-endif (SUPPORT_SYSTEMD)
+endif ()
 install(FILES tcmu-runner.8
     DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man8)

--- a/org.kernel.TCMUService1.service
+++ b/org.kernel.TCMUService1.service
@@ -3,6 +3,6 @@
 
 [D-BUS Service]
 Name=org.kernel.TCMUService1
-Exec=/usr/bin/tcmu-runner
+Exec=/usr/local/bin/tcmu-runner
 User=root
 SystemdService=tcmu-runner.service

--- a/tcmu-runner.service
+++ b/tcmu-runner.service
@@ -4,4 +4,4 @@ Description=LIO Userspace-passthrough daemon
 [Service]
 Type=dbus
 BusName=org.kernel.TCMUService1
-ExecStart=/usr/bin/tcmu-runner
+ExecStart=/usr/local/bin/tcmu-runner


### PR DESCRIPTION
Currently,
$ tcmu-runner
tcmu-runner: error while loading shared libraries: libtcmu.so.1: cannot
open shared object file: No such file or directory

This patch set CMAKE_INSTALL_RPATH to required LIBRARY PATH,
as a result there will be no issues while loading shared libraries.

Signed-off-by: Prasanna Kumar Kalever prasanna.kalever@redhat.com
