### PR TITLE
Don't call handler->check_config if NULL

### DIFF
--- a/libtcmu-register.c
+++ b/libtcmu-register.c
@@ -78,7 +78,9 @@ tcmulib_check_config(TCMUService1 *interface,
 	char *reason = NULL;
 	bool ok;
 
-	ok = handler->check_config(cfgstring, &reason);
+	ok = handler->check_config ?
+		handler->check_config(cfgstring, &reason) :
+		TRUE;
 	g_dbus_method_invocation_return_value(invocation,
 		g_variant_new("(bs)", ok, reason ? : (ok ? "OK" : "unknown")));
 	free(reason);

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -235,7 +235,8 @@ static int add_device(struct tcmulib_context *ctx,
 		goto err_free;
 	}
 
-	if (!dev->handler->check_config(dev->cfgstring, &reason)) {
+	if (dev->handler->check_config &&
+	    !dev->handler->check_config(dev->cfgstring, &reason)) {
 		/* It may be handled by other handlers */
 		tcmu_errp(ctx, "check_config failed for %s because of %s\n", dev->dev_name, reason);
 		free(reason);


### PR DESCRIPTION
The documentation of tcmulib_handler.check_config says "this function is
optional", handlers don't implement this should be handled gracefully.

Signed-off-by: Fam Zheng <famz@redhat.com>