### PR TITLE
build: fix failure on ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project (tcmu-runner VERSION 1.1.3 LANGUAGES C)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=c99")
 
 include(GNUInstallDirs)
+include(CheckIncludeFile)
 
 set(tcmu-runner_HANDLER_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/tcmu-runner")
 
@@ -168,6 +169,8 @@ if (with-qcow)
 	  PROPERTIES
 	  PREFIX ""
 	  )
+
+	CHECK_INCLUDE_FILE("linux/falloc.h" HAVE_LINUX_FALLOC)
 	if (HAVE_LINUX_FALLOC)
 		set_target_properties(handler_qcow
 		  PROPERTIES


### PR DESCRIPTION
On my ubuntu 14.04 I got following error on the fresh building:

/home/yliu/tcmu-runner/qcow.c: In function ‘qcow2_block_alloc’:
/home/yliu/tcmu-runner/qcow.c:1008:27: error: ‘FALLOC_FL_ZERO_RANGE’ undeclared (first use in this function)
    ret = fallocate(s->fd, FALLOC_FL_ZERO_RANGE, cluster, s->cluster_size);
                           ^
/home/yliu/tcmu-runner/qcow.c:1008:27: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [CMakeFiles/handler_qcow.dir/qcow.c.o] Error 1
make[1]: *** [CMakeFiles/handler_qcow.dir/all] Error 2

This is because we don't pass on HAVE_LINUX_FALLOC, which can be automatically
detected by cmake module function, to compiler.

So the reasonable fix is to add the include-file-check.

Signed-off-by: Liu Yuan <liuyuan@cmss.chinamobile.com>