### PR TITLE
build: add cscope support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,16 @@ add_custom_command(
   MAIN_DEPENDENCY tcmu-handler.xml
   )
 
+add_custom_target(
+  cscope
+  COMMAND find -name '*.[ch]' > cscope.files
+  COMMAND cscope -bq
+  )
+set_directory_properties(
+  PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES
+  "cscope.files;cscope.in.out;cscope.out;cscope.po.out"
+  )
+
 # Stuff for building the file handler
 add_library(handler_file
   SHARED


### PR DESCRIPTION
This will create a new target in the Makefile, allowing devvers to enjoy cscope
utility just by typing 'make cscope'.

'make clean' will also clean up the intermediate cscope files.

Signed-off-by: Liu Yuan <liuyuan@cmss.chinamobile.com>