### PR TITLE
Introduce generic_handle_cmd() and add ceph rbd handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(tcmu-runner_HANDLER_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/tc
 
 option(with-glfs "build Gluster glfs handler" true)
 option(with-qcow "build qcow handler" true)
+option(with-rbd "build Ceph rbd handler" true)
 
 find_library(LIBNL_LIB nl-3)
 find_library(LIBNL_GENL_LIB nl-genl-3)
@@ -148,6 +149,24 @@ add_executable(consumer
   consumer.c
   )
 target_link_libraries(consumer tcmu)
+
+if (with-rbd)
+	find_library(LIBRBD rbd)
+
+	# Stuff for building the rbd handler
+	add_library(handler_rbd
+	  SHARED
+	  rbd.c
+	  )
+	set_target_properties(handler_rbd
+	  PROPERTIES
+	  PREFIX ""
+	  )
+	target_link_libraries(handler_rbd
+	  ${LIBRBD}
+	  )
+	install(TARGETS handler_rbd DESTINATION ${CMAKE_INSTALL_LIBDIR}/tcmu-runner)
+endif (with-rbd)
 
 if (with-glfs)
 	find_library(GFAPI gfapi)

--- a/README.md
+++ b/README.md
@@ -72,14 +72,27 @@ difference is who is responsible for the event loop.
 
 ##### tcmu-runner plugin handler
 
-With a tcmu-runner handler, tcmu-runner is in charge of the event loop
+There are two different ways to write a tcmu-runner plugin handler:
+
+1. one can register .handle_cmd to take the full control of command handling
+2. or else one can register .{read, write, flush, ...} to only handle storage
+   IO stuff.
+
+With the option 1, tcmu-runner is in charge of the event loop
 for your plugin, and your handler's `handle_cmd` function is called
 repeatedly to respond to each incoming SCSI command. While your
 handler sees all SCSI commands, there are helper functions provided
 that save each handler from writing boilerplate code for mandatory
 SCSI commands, if desired.
 
-The `glfs`, `qcow`, and `file` handlers are examples of this type.
+The `qcow` and `file`  handlers are examples of this type.
+
+With the option 2, tcmu-runner is in charge of the event loop and SCSI command
+handling for your plugin, and your handler's registered functions are called
+repeatedly to handle storage requests as required by the upper SCSI layer, which
+will handle most of the SCSI commands for you.
+
+The `glfs` and `rbd` handlers are examples of this type.
 
 ##### tcmulib
 

--- a/file_example.c
+++ b/file_example.c
@@ -417,7 +417,7 @@ static struct tcmur_handler file_handler = {
 };
 
 /* Entry point must be named "handler_init". */
-void handler_init(void)
+int handler_init(void)
 {
-	tcmur_register_handler(&file_handler);
+	return tcmur_register_handler(&file_handler);
 }

--- a/glfs.c
+++ b/glfs.c
@@ -305,253 +305,27 @@ static void tcmu_glfs_close(struct tcmu_device *dev)
 	free(gfsp);
 }
 
-static int set_medium_error(uint8_t *sense)
+static ssize_t tcmu_glfs_read(struct tcmu_device *dev, struct iovec *iov,
+			      size_t iov_cnt, off_t offset)
 {
-	return tcmu_set_sense_data(sense, MEDIUM_ERROR, ASC_READ_ERROR, NULL);
+        struct glfs_state *state = tcmu_get_dev_private(dev);
+
+        return glfs_preadv(state->gfd, iov, iov_cnt, offset, SEEK_SET);
 }
 
-/*
- * Return scsi status or TCMU_NOT_HANDLED
- */
-int tcmu_glfs_handle_cmd(
-	struct tcmu_device *dev,
-	struct tcmulib_cmd *tcmulib_cmd)
+static ssize_t tcmu_glfs_write(struct tcmu_device *dev, struct iovec *iov,
+			       size_t iov_cnt, off_t offset)
 {
-	uint8_t *cdb = tcmulib_cmd->cdb;
-	struct iovec *iovec = tcmulib_cmd->iovec;
-	size_t iov_cnt = tcmulib_cmd->iov_cnt;
-	uint8_t *sense = tcmulib_cmd->sense_buf;
 	struct glfs_state *state = tcmu_get_dev_private(dev);
-	uint32_t block_size = tcmu_get_dev_block_size(dev);
-	uint64_t num_lbas = tcmu_get_dev_num_lbas(dev);
-	uint8_t cmd;
 
-	glfs_fd_t *gfd = state->gfd;
-	int ret;
-	uint32_t length;
-	int result = SAM_STAT_GOOD;
-	char *tmpbuf;
-	uint64_t offset = block_size * tcmu_get_lba(cdb);
-	uint32_t tl     = block_size * tcmu_get_xfer_length(cdb);
-	int do_verify = 0;
-	uint32_t cmp_offset;
-	ret = length = 0;
+        return glfs_pwritev(state->gfd, iov, iov_cnt, offset, ALLOWED_BSOFLAGS);
+}
 
-	cmd = cdb[0];
+static int tcmu_glfs_flush(struct tcmu_device *dev)
+{
+	struct glfs_state *state = tcmu_get_dev_private(dev);
 
-	switch (cmd) {
-	case INQUIRY:
-		return tcmu_emulate_inquiry(dev, cdb, iovec, iov_cnt, sense);
-		break;
-	case TEST_UNIT_READY:
-		return tcmu_emulate_test_unit_ready(cdb, iovec, iov_cnt, sense);
-		break;
-	case SERVICE_ACTION_IN_16:
-		if (cdb[1] == READ_CAPACITY_16) {
-			return tcmu_emulate_read_capacity_16(num_lbas, block_size,
-							     cdb, iovec, iov_cnt, sense);
-		} else {
-			return TCMU_NOT_HANDLED;
-		}
-		break;
-	case READ_CAPACITY:
-		if ((cdb[1] & 0x01) || (cdb[8] & 0x01)) {
-			/* Reserved bits for MM logical units */
-			return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
-						   ASC_INVALID_FIELD_IN_CDB,
-						   NULL);
-		} else {
-			return tcmu_emulate_read_capacity_10(num_lbas,
-							     block_size,
-							     cdb, iovec,
-							     iov_cnt, sense);
-		}
-	case MODE_SENSE:
-	case MODE_SENSE_10:
-		return tcmu_emulate_mode_sense(cdb, iovec, iov_cnt, sense);
-		break;
-	case START_STOP:
-		return tcmu_emulate_start_stop(dev, cdb, sense);
-		break;
-	case MODE_SELECT:
-	case MODE_SELECT_10:
-		return tcmu_emulate_mode_select(cdb, iovec, iov_cnt, sense);
-		break;
-	case COMPARE_AND_WRITE:
-		/* Blocks are transferred twice, first the set that
-		 * we compare to the existing data, and second the set
-		 * to write if the compare was successful.
-		 */
-		length = tl / 2;
-
-		tmpbuf = malloc(length);
-		if (!tmpbuf) {
-			result = tcmu_set_sense_data(sense, HARDWARE_ERROR,
-						     ASC_INTERNAL_TARGET_FAILURE, NULL);
-			break;
-		}
-
-		ret = glfs_pread(gfd, tmpbuf, length, offset, SEEK_SET);
-
-		if (ret != length) {
-			result = set_medium_error(sense);
-			free(tmpbuf);
-			break;
-		}
-
-		cmp_offset = tcmu_compare_with_iovec(tmpbuf, iovec, length);
-		if (cmp_offset != -1) {
-			result = tcmu_set_sense_data(sense, MISCOMPARE,
-						     ASC_MISCOMPARE_DURING_VERIFY_OPERATION,
-						     &cmp_offset);
-			free(tmpbuf);
-			break;
-		}
-
-		free(tmpbuf);
-
-		tcmu_seek_in_iovec(iovec, length);
-		goto write;
-	case SYNCHRONIZE_CACHE:
-	case SYNCHRONIZE_CACHE_16:
-		if (cdb[1] & 0x2)
-			result = tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
-						     ASC_INVALID_FIELD_IN_CDB, NULL);
-		else
-			glfs_fdatasync(gfd);
-		break;
-	case WRITE_VERIFY:
-	case WRITE_VERIFY_12:
-	case WRITE_VERIFY_16:
-		do_verify = 1;
-	case WRITE_6:
-	case WRITE_10:
-	case WRITE_12:
-	case WRITE_16:
-		length = tl;
-write:
-		ret = glfs_pwritev(gfd, iovec, iov_cnt, offset, ALLOWED_BSOFLAGS);
-
-		if (ret == length) {
-			/* Sync if FUA */
-			if ((cmd != WRITE_6) && (cdb[1] & 0x8))
-				glfs_fdatasync(gfd);
-		} else {
-			errp("Error on write %x %x\n", ret, length);
-			result = set_medium_error(sense);
-			break;
-		}
-
-		if (!do_verify)
-			break;
-
-		tmpbuf = malloc(length);
-		if (!tmpbuf) {
-			result = tcmu_set_sense_data(sense, HARDWARE_ERROR,
-						     ASC_INTERNAL_TARGET_FAILURE, NULL);
-			break;
-		}
-
-		ret = glfs_pread(gfd, tmpbuf, length, offset, ALLOWED_BSOFLAGS);
-
-		if (ret != length) {
-			result = set_medium_error(sense);
-			free(tmpbuf);
-			break;
-		}
-
-		cmp_offset = tcmu_compare_with_iovec(tmpbuf, iovec, length);
-		if (cmp_offset != -1)
-			result = tcmu_set_sense_data(sense, MISCOMPARE,
-					    ASC_MISCOMPARE_DURING_VERIFY_OPERATION,
-					    &cmp_offset);
-		free(tmpbuf);
-		break;
-
-	case WRITE_SAME:
-	case WRITE_SAME_16:
-		errp("WRITE_SAME called, but has vpd b2 been implemented?\n");
-		result = tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
-					     ASC_INVALID_FIELD_IN_CDB, NULL);
-		break;
-
-#if 0
-		/* WRITE_SAME used to punch hole in file */
-		if (cdb[1] & 0x08) {
-			ret = glfs_discard(gfd, offset, tl);
-			if (ret != 0) {
-				result = tcmu_set_sense_data(sense, HARDWARE_ERROR,
-						    ASC_INTERNAL_TARGET_FAILURE, NULL);
-			}
-			break;
-		}
-		while (tl > 0) {
-			size_t blocksize = block_size;
-			uint32_t val32;
-			uint64_t val64;
-
-			assert(iovec->iov_len >= 8);
-
-			switch (cdb[1] & 0x06) {
-			case 0x02: /* PBDATA==0 LBDATA==1 */
-				val32 = htobe32(offset);
-				memcpy(iovec->iov_base, &val32, 4);
-				break;
-			case 0x04: /* PBDATA==1 LBDATA==0 */
-				/* physical sector format */
-				/* hey this is wrong val! But how to fix? */
-				val64 = htobe64(offset);
-				memcpy(iovec->iov_base, &val64, 8);
-				break;
-			default:
-				/* FIXME */
-				errp("PBDATA and LBDATA set!!!\n");
-			}
-
-			ret = glfs_pwritev(gfd, iovec, blocksize,
-					offset, ALLOWED_BSOFLAGS);
-
-			if (ret != blocksize)
-				result = set_medium_error(sense);
-
-			offset += blocksize;
-			tl     -= blocksize;
-		}
-		break;
-#endif
-	case READ_6:
-	case READ_10:
-	case READ_12:
-	case READ_16:
-		length = tcmu_iovec_length(iovec, iov_cnt);
-		ret = glfs_preadv(gfd, iovec, iov_cnt, offset, SEEK_SET);
-
-		if (ret != length) {
-			errp("Error on read %x %x\n", ret, length);
-			result = set_medium_error(sense);
-		}
-		break;
-	case UNMAP:
-		/* TODO: implement UNMAP */
-		result = tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
-					     ASC_INVALID_FIELD_IN_CDB, NULL);
-		break;
-	default:
-		result = TCMU_NOT_HANDLED;
-		break;
-	}
-
-	dbgp("io done %p %x %d %u\n", cdb, cmd, result, length);
-
-	if (result == TCMU_NOT_HANDLED)
-		dbgp("io not handled %p %x %x %d %d %llu\n",
-		     cdb, result, cmd, ret, length, (unsigned long long)offset);
-	else if (result != SAM_STAT_GOOD) {
-		errp("io error %p %x %x %d %d %llu\n",
-		     cdb, result, cmd, ret, length, (unsigned long long)offset);
-	}
-
-	return result;
+	return glfs_fdatasync(state->gfd);
 }
 
 static const char glfs_cfg_desc[] =
@@ -563,15 +337,17 @@ static const char glfs_cfg_desc[] =
 	"  filename:  The backing file";
 
 struct tcmur_handler glfs_handler = {
-	.name = "Gluster glfs handler",
-	.subtype = "glfs",
-	.cfg_desc = glfs_cfg_desc,
+	.name 		= "Gluster glfs handler",
+	.subtype 	= "glfs",
+	.cfg_desc	= glfs_cfg_desc,
 
-	.check_config = glfs_check_config,
+	.check_config 	= glfs_check_config,
 
-	.open = tcmu_glfs_open,
-	.close = tcmu_glfs_close,
-	.handle_cmd = tcmu_glfs_handle_cmd,
+	.open 		= tcmu_glfs_open,
+	.close 		= tcmu_glfs_close,
+	.read 		= tcmu_glfs_read,
+	.write		= tcmu_glfs_write,
+	.flush		= tcmu_glfs_flush,
 };
 
 /* Entry point must be named "handler_init". */

--- a/glfs.c
+++ b/glfs.c
@@ -351,7 +351,7 @@ struct tcmur_handler glfs_handler = {
 };
 
 /* Entry point must be named "handler_init". */
-void handler_init(void)
+int handler_init(void)
 {
-	tcmur_register_handler(&glfs_handler);
+	return tcmur_register_handler(&glfs_handler);
 }

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -516,6 +516,26 @@ void tcmu_set_dev_private(struct tcmu_device *dev, void *private)
 	dev->hm_private = private;
 }
 
+void tcmu_set_dev_num_lbas(struct tcmu_device *dev, uint64_t num_lbas)
+{
+	dev->num_lbas = num_lbas;
+}
+
+uint64_t tcmu_get_dev_num_lbas(struct tcmu_device *dev)
+{
+	return dev->num_lbas;
+}
+
+void tcmu_set_dev_block_size(struct tcmu_device *dev, uint32_t block_size)
+{
+	dev->block_size = block_size;
+}
+
+uint32_t tcmu_get_dev_block_size(struct tcmu_device *dev)
+{
+	return dev->block_size;
+}
+
 int tcmu_get_dev_fd(struct tcmu_device *dev)
 {
 	return dev->fd;

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -45,6 +45,10 @@ void *tcmu_get_dev_private(struct tcmu_device *dev);
 void tcmu_set_dev_private(struct tcmu_device *dev, void *priv);
 int tcmu_get_dev_fd(struct tcmu_device *dev);
 char *tcmu_get_dev_cfgstring(struct tcmu_device *dev);
+void tcmu_set_dev_num_lbas(struct tcmu_device *dev, uint64_t num_lbas);
+uint64_t tcmu_get_dev_num_lbas(struct tcmu_device *dev);
+void tcmu_set_dev_block_size(struct tcmu_device *dev, uint32_t block_size);
+uint32_t tcmu_get_dev_block_size(struct tcmu_device *dev);
 struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev);
 
 /* Helper routines for processing commands */

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -56,6 +56,9 @@ struct tcmu_device {
 	size_t map_len;
 	uint32_t cmd_tail;
 
+	uint64_t num_lbas;
+	uint32_t block_size;
+
 	char dev_name[16]; /* e.g. "uio14" */
 	char tcm_hba_name[16]; /* e.g. "user_8" */
 	char tcm_dev_name[128]; /* e.g. "backup2" */

--- a/main.c
+++ b/main.c
@@ -95,6 +95,12 @@ static struct tcmur_handler *find_handler_by_subtype(gchar *subtype)
 
 void tcmur_register_handler(struct tcmur_handler *handler)
 {
+	if (handler->handle_cmd &&
+	    (handler->read || handler->write || handler->flush)) {
+		errp("Skip bad handler: %s\n", handler->name);
+		return;
+	}
+
 	darray_append(g_runner_handlers, handler);
 }
 

--- a/main.c
+++ b/main.c
@@ -36,6 +36,7 @@
 #include <gio/gio.h>
 #include <getopt.h>
 #include <poll.h>
+#include <scsi/scsi.h>
 
 #include <libkmod.h>
 #include <linux/target_core_user.h>
@@ -179,6 +180,125 @@ static void thread_cleanup(void *arg)
 	free(dev);
 }
 
+static int generic_handle_cmd(struct tcmu_device *dev,
+			      struct tcmulib_cmd *tcmulib_cmd)
+{
+	struct tcmulib_handler *handler = tcmu_get_dev_handler(dev);
+	struct tcmur_handler *store = handler->hm_private;
+	uint8_t *cdb = tcmulib_cmd->cdb;
+	struct iovec *iovec = tcmulib_cmd->iovec;
+	size_t iov_cnt = tcmulib_cmd->iov_cnt;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
+	uint32_t block_size = tcmu_get_dev_block_size(dev);
+	uint64_t num_lbas = tcmu_get_dev_num_lbas(dev);
+	uint8_t cmd;
+	ssize_t ret, l = tcmu_iovec_length(iovec, iov_cnt);
+	off_t offset = block_size * tcmu_get_lba(cdb);
+	struct iovec iov;
+	size_t half = l / 2;
+	uint32_t cmp_offset;
+
+	cmd = cdb[0];
+
+	switch (cmd) {
+	case INQUIRY:
+		return tcmu_emulate_inquiry(dev, cdb, iovec, iov_cnt, sense);
+	case TEST_UNIT_READY:
+		return tcmu_emulate_test_unit_ready(cdb, iovec, iov_cnt, sense);
+	case SERVICE_ACTION_IN_16:
+		if (cdb[1] == READ_CAPACITY_16)
+			return tcmu_emulate_read_capacity_16(num_lbas,
+							     block_size,
+							     cdb, iovec,
+							     iov_cnt, sense);
+		else
+			return TCMU_NOT_HANDLED;
+	case READ_CAPACITY:
+		if ((cdb[1] & 0x01) || (cdb[8] & 0x01))
+			/* Reserved bits for MM logical units */
+			return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
+						   ASC_INVALID_FIELD_IN_CDB,
+						   NULL);
+		else
+			return tcmu_emulate_read_capacity_10(num_lbas,
+							     block_size,
+							     cdb, iovec,
+							     iov_cnt, sense);
+	case MODE_SENSE:
+	case MODE_SENSE_10:
+		return tcmu_emulate_mode_sense(cdb, iovec, iov_cnt, sense);
+	case START_STOP:
+		return tcmu_emulate_start_stop(dev, cdb, sense);
+	case MODE_SELECT:
+	case MODE_SELECT_10:
+		return tcmu_emulate_mode_select(cdb, iovec, iov_cnt, sense);
+	case READ_6:
+	case READ_10:
+	case READ_12:
+	case READ_16:
+		ret = store->read(dev, iovec, iov_cnt, offset);
+		if (ret != l) {
+			errp("Error on read %x, %x\n", ret, l);
+			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+						   ASC_READ_ERROR, NULL);
+		} else
+			return SAM_STAT_GOOD;
+	case WRITE_6:
+	case WRITE_10:
+	case WRITE_12:
+	case WRITE_16:
+		ret = store->write(dev, iovec, iov_cnt, offset);
+		if (ret != l) {
+			errp("Error on write %x, %x\n", ret, l);
+			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+						   ASC_READ_ERROR, NULL);
+		} else
+			return SAM_STAT_GOOD;
+	case SYNCHRONIZE_CACHE:
+	case SYNCHRONIZE_CACHE_16:
+		ret = store->flush(dev);
+		if (ret < 0) {
+			errp("Error on flush %x\n", ret);
+			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+						   ASC_READ_ERROR, NULL);
+		} else
+			return SAM_STAT_GOOD;
+	case COMPARE_AND_WRITE:
+		iov.iov_base = malloc(half);
+		if (!iov.iov_base) {
+			errp("out of memory\n");
+			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+						   ASC_READ_ERROR, NULL);
+		}
+		iov.iov_len = half;
+		ret = store->read(dev, &iov, 1, offset);
+		if (ret != l) {
+			errp("Error on read %x, %x\n", ret, l);
+			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+						   ASC_READ_ERROR, NULL);
+		}
+		cmp_offset = tcmu_compare_with_iovec(iov.iov_base, iovec, half);
+		if (cmp_offset != -1) {
+			return tcmu_set_sense_data(sense, MISCOMPARE,
+					ASC_MISCOMPARE_DURING_VERIFY_OPERATION,
+					&cmp_offset);
+		}
+		free(iov.iov_base);
+
+		tcmu_seek_in_iovec(iovec, half);
+		ret = store->write(dev, iovec, iov_cnt, offset);
+		if (ret != half) {
+			errp("Error on write %x, %x\n", ret, half);
+			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+						   ASC_READ_ERROR, NULL);
+		} else
+			return SAM_STAT_GOOD;
+	default:
+		errp("unknown command %x\n", cdb[0]);
+		return TCMU_NOT_HANDLED;
+	}
+}
+
 static void *thread_start(void *arg)
 {
 	struct tcmu_device *dev = arg;
@@ -204,7 +324,10 @@ static void *thread_start(void *arg)
 			}
 			dbgp("\n");
 
-			ret = r_handler->handle_cmd(dev, cmd);
+			if (r_handler->handle_cmd)
+				ret = r_handler->handle_cmd(dev, cmd);
+			else
+				ret = generic_handle_cmd(dev, cmd);
 			if (ret != TCMU_ASYNC_HANDLED) {
 				tcmulib_command_complete(dev, cmd, ret);
 				completed = 1;

--- a/qcow.c
+++ b/qcow.c
@@ -1582,7 +1582,7 @@ static struct tcmur_handler qcow_handler = {
 };
 
 /* Entry point must be named "handler_init". */
-void handler_init(void)
+int handler_init(void)
 {
-	tcmur_register_handler(&qcow_handler);
+	return tcmur_register_handler(&qcow_handler);
 }

--- a/rbd.c
+++ b/rbd.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2016, China Mobile, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define _GNU_SOURCE
+#include <inttypes.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <endian.h>
+#include <scsi/scsi.h>
+#include <errno.h>
+
+#include "tcmu-runner.h"
+#include "libtcmu.h"
+
+#include <rbd/librbd.h>
+
+struct tcmu_rbd_state {
+	rados_t cluster;
+	rados_ioctx_t io_ctx;
+	rbd_image_t image;
+};
+
+static int tcmu_rbd_open(struct tcmu_device *dev)
+{
+
+	char *pool, *name;
+	char *config;
+	struct tcmu_rbd_state *state;
+	uint64_t size, rbd_size;
+	int ret, block_size;
+
+	state = calloc(1, sizeof(*state));
+	if (!state)
+		return -ENOMEM;
+
+	tcmu_set_dev_private(dev, state);
+
+	config = strchr(tcmu_get_dev_cfgstring(dev), '/');
+	dbgp("tcmu_rbd_open config %s\n", config);
+
+	if (!config) {
+		errp("no configuration found in cfgstring\n");
+		ret = -EINVAL;
+		goto free_state;
+	}
+	config += 1; /* get past '/' */
+
+	block_size = tcmu_get_attribute(dev, "hw_block_size");
+	if (block_size < 0) {
+		errp("Could not get hw_block_size\n");
+		ret = -EINVAL;
+		goto free_state;
+	}
+	tcmu_set_dev_block_size(dev, block_size);
+
+	size = tcmu_get_device_size(dev);
+	if (size < 0) {
+		errp("Could not get device size\n");
+		goto free_state;
+	}
+	tcmu_set_dev_num_lbas(dev, size / block_size);
+
+	pool = strtok(config, "/");
+	if (!pool) {
+		ret = -EINVAL;
+		goto free_state;
+	}
+	name = strtok(NULL, "/");
+	if (!name) {
+		ret = -EINVAL;
+		goto free_state;
+	}
+
+	ret = rados_create(&state->cluster, NULL);
+	if (ret < 0) {
+		errp("error initializing\n");
+		goto free_state;
+	}
+
+	/* Fow now, we will only read /etc/ceph/ceph.conf */
+	rados_conf_read_file(state->cluster, NULL);
+	rados_conf_set(state->cluster, "rbd_cache", "false");
+
+	ret = rados_connect(state->cluster);
+	if (ret < 0) {
+		errp("error connecting\n");
+		goto rados_shutdown;
+	}
+
+	ret = rados_ioctx_create(state->cluster, pool, &state->io_ctx);
+	if (ret < 0) {
+		errp("error opening pool %s\n", pool);
+		goto rados_destroy;
+	}
+
+	ret = rbd_open(state->io_ctx, name, &state->image, NULL);
+	if (ret < 0) {
+		errp("error reading header from %s\n", name);
+		goto rados_destroy;
+	}
+
+	ret = rbd_get_size(state->image, &rbd_size);
+	if(ret < 0) {
+		errp("error get rbd_size %s\n", name);
+		goto rados_destroy;
+	}
+	dbgp("rbd size %lld\n", rbd_size);
+
+	if(size != rbd_size) {
+		errp("device size and backing size disagree: "
+		     "device %lld backing %lld\n",
+		     size,
+		     rbd_size);
+		ret = -EIO;
+		goto rbd_close;
+	}
+
+	return 0;
+
+rbd_close:
+	rbd_close(state->image);
+rados_destroy:
+	rados_ioctx_destroy(state->io_ctx);
+rados_shutdown:
+	rados_shutdown(state->cluster);
+free_state:
+	free(state);
+	return ret;
+}
+
+static void tcmu_rbd_close(struct tcmu_device *dev)
+{
+	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
+
+	rbd_close(state->image);
+	rados_ioctx_destroy(state->io_ctx);
+	rados_shutdown(state->cluster);
+	free(state);
+}
+
+static ssize_t tcmu_rbd_read(struct tcmu_device *dev, struct iovec *iov,
+			     size_t iov_cnt, off_t offset)
+{
+	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
+	size_t length = tcmu_iovec_length(iov, iov_cnt);
+	void *buf = malloc(length);
+	ssize_t ret = -ENOMEM;
+
+	if (!buf)
+		goto out;
+	ret = rbd_read(state->image, offset, length, buf);
+	if (ret != length)
+		goto out;
+
+	tcmu_memcpy_into_iovec(iov, iov_cnt, buf, length);
+out:
+	free(buf);
+	return ret;
+}
+
+static ssize_t tcmu_rbd_write(struct tcmu_device *dev, struct iovec *iov,
+			      size_t iov_cnt, off_t offset)
+{
+	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
+	size_t length = tcmu_iovec_length(iov, iov_cnt);
+	void *buf = malloc(length);
+	ssize_t ret = -ENOMEM;
+
+	if (!buf)
+		goto out;
+	tcmu_memcpy_from_iovec(buf, length, iov, iov_cnt);
+	ret = rbd_write(state->image, offset, length, buf);
+out:
+	free(buf);
+	return ret;
+}
+
+static int tcmu_rbd_flush(struct tcmu_device *dev)
+{
+	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
+
+	return rbd_flush(state->image);
+}
+
+/*
+ * For backstore creation
+ *
+ * Specify poolname/devicename, e.g,
+ *
+ * $ targetcli create /backstores/user:rbd/test 2G rbd/test
+ *
+ * poolname must be the name of an existing rados pool.
+ *
+ * devicename is the name of the rbd image.
+ */
+static const char tcmu_rbd_cfg_desc[] =
+	"RBD config string is of the form:\n"
+	"poolname/devicename\n"
+	"where:\n"
+	"poolname:	Existing RADOS pool\n"
+	"devicename:	Name of the RBD image\n";
+
+struct tcmur_handler tcmu_rbd_handler = {
+	.name		= "Ceph RBD handler",
+	.subtype	= "rbd",
+	.cfg_desc	= tcmu_rbd_cfg_desc,
+	.open		= tcmu_rbd_open,
+	.close		= tcmu_rbd_close,
+	.read		= tcmu_rbd_read,
+	.write		= tcmu_rbd_write,
+	.flush		= tcmu_rbd_flush,
+};
+
+void handler_init(void)
+{
+	tcmur_register_handler(&tcmu_rbd_handler);
+}

--- a/rbd.c
+++ b/rbd.c
@@ -232,7 +232,7 @@ struct tcmur_handler tcmu_rbd_handler = {
 	.flush		= tcmu_rbd_flush,
 };
 
-void handler_init(void)
+int handler_init(void)
 {
-	tcmur_register_handler(&tcmu_rbd_handler);
+	return tcmur_register_handler(&tcmu_rbd_handler);
 }

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -66,6 +66,11 @@ struct tcmur_handler {
 	 * - TCMU_ASYNC_HANDLED if optcode is handled asynchronously
 	 */
 	int (*handle_cmd)(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
+
+	/* Below callbacks are only exected called by generic_handle_cmd */
+	ssize_t (*write)(struct tcmu_device *, struct iovec *, size_t, off_t);
+	ssize_t (*read)(struct tcmu_device *, struct iovec *, size_t, off_t);
+	int (*flush)(struct tcmu_device *);
 };
 
 /*

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -82,7 +82,7 @@ void tcmur_handler_init(void);
 /*
  * APIs for tcmur only
  */
-void tcmur_register_handler(struct tcmur_handler *handler);
+int tcmur_register_handler(struct tcmur_handler *handler);
 bool tcmur_unregister_handler(struct tcmur_handler *handler);
 void dbgp(const char *fmt, ...);
 void errp(const char *fmt, ...);


### PR DESCRIPTION
Currently storage engine plugins tightly couple with the iscsi command handling
which not only duplicate lines of code but also make plugin writing painful.

we can avoid it by adding one more indirction, a generic_handle_cmd(), which is
optional and can coexist with current command handling logic. With this added,
the command process can be split into two category:

1. one can register .handle_cmd to take the full control of command handling as
   before
2. or else one can register .{read, write, flush} to only handle storage IO
   stuff.

and then iscsi command handling can sit on top of the storage layer, meaning
that we can handle most of the commands without involving plugins, for e.g
COMPARE AND WRITE is implemented just by generic_handle_cmd().

What make it complex is how we deal with async storage APIs. We could start with
async APIs and build sync ones on top of them to have storage plugin only
implement async APIs. But initially I plan to start with sync APIs instead of
async ones because

1. it's simple and easy to verify the correctness.
2. it's easy to add async api later once upper iscsi layer is matured.
3. Pre-optimization is root of eveil.

Following patches will implement a rbd handler from scratch and adopt glfs
handler to generic_handle_cmd, leaving file and qcow handlers alone.

Todo:
1. add unmap(discard) operation
2. handle more commands (WRITE SAME, WRITE VERIFY, etc.)
3. redesign with or add async APIs.
