### PR TITLE
Fix some caller of tcmu_get_device_size() and tcmu_get_attribute()

### DIFF
--- a/api.c
+++ b/api.c
@@ -578,13 +578,13 @@ int tcmu_emulate_evpd_inquiry(
 		memcpy(&data[2], &val16, 2);
 
 		block_size = tcmu_get_attribute(dev, "hw_block_size");
-		if (block_size == -1) {
+		if (block_size < 0) {
 			return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
 						   ASC_INVALID_FIELD_IN_CDB, NULL);
 		}
 
 		max_sectors = tcmu_get_attribute(dev, "hw_max_sectors");
-		if (max_sectors == -1) {
+		if (max_sectors < 0) {
 			return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
 						   ASC_INVALID_FIELD_IN_CDB, NULL);
 		}

--- a/qcow.c
+++ b/qcow.c
@@ -1422,13 +1422,13 @@ static int qcow_open(struct tcmu_device *dev)
 	tcmu_set_dev_private(dev, bdev);
 
 	bdev->block_size = tcmu_get_attribute(dev, "hw_block_size");
-	if (bdev->block_size == -1) {
+	if (bdev->block_size < 0) {
 		errp("Could not get device block size\n");
 		goto err;
 	}
 
 	bdev->size = tcmu_get_device_size(dev);
-	if (bdev->size == -1) {
+	if (bdev->size < 0) {
 		errp("Could not get device size\n");
 		goto err;
 	}


### PR DESCRIPTION
The function tcmu_get_device_size() and tcmu_get_attribute() returns -EINVAL when not correct,but some caller compare it with -1,so fix it.

Signed-off-by: JianfeiHu hujianfei@cmss.chinamobile.com