### PR TITLE
Add logger and system config features support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(tcmu
   libtcmu-register.c
   tcmuhandler-generated.c
   libtcmu_log.c
+  libtcmu_config.c
   )
 set_target_properties(tcmu
   PROPERTIES
@@ -64,6 +65,7 @@ add_library(tcmu_static
   libtcmu-register.c
   tcmuhandler-generated.c
   libtcmu_log.c
+  libtcmu_config.c
   )
 target_include_directories(tcmu_static
   PUBLIC ${LIBNL_INCLUDE_DIR}
@@ -236,6 +238,8 @@ configure_file (
 
 install(FILES libtcmu.h libtcmu_common.h tcmu-runner.h
   DESTINATION include)
+install(FILES tcmu.conf
+  DESTINATION /etc/tcmu)
 install(FILES org.kernel.TCMUService1.service
   DESTINATION /usr/share/dbus-1/system-services)
 install(FILES tcmu-runner.conf DESTINATION /etc/dbus-1/system.d)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(tcmu
   libtcmu.c
   libtcmu-register.c
   tcmuhandler-generated.c
+  libtcmu_log.c
   )
 set_target_properties(tcmu
   PROPERTIES
@@ -62,6 +63,7 @@ add_library(tcmu_static
   libtcmu.c
   libtcmu-register.c
   tcmuhandler-generated.c
+  libtcmu_log.c
   )
 target_include_directories(tcmu_static
   PUBLIC ${LIBNL_INCLUDE_DIR}

--- a/api.c
+++ b/api.c
@@ -30,6 +30,7 @@
 #include <endian.h>
 #include <errno.h>
 
+#include "libtcmu_log.h"
 #include "libtcmu_common.h"
 #include "libtcmu_priv.h"
 
@@ -55,20 +56,20 @@ int tcmu_get_attribute(struct tcmu_device *dev, const char *name)
 
 	fd = open(path, O_RDONLY);
 	if (fd == -1) {
-		tcmu_errp(dev->ctx, "Could not open configfs to read attribute %s\n", name);
+		tcmu_err("Could not open configfs to read attribute %s\n", name);
 		return -EINVAL;
 	}
 
 	ret = read(fd, buf, sizeof(buf));
 	close(fd);
 	if (ret == -1) {
-		tcmu_errp(dev->ctx, "Could not read configfs to read attribute %s\n", name);
+		tcmu_err("Could not read configfs to read attribute %s\n", name);
 		return -EINVAL;
 	}
 
 	val = strtoul(buf, NULL, 0);
 	if (val == ULONG_MAX) {
-		tcmu_errp(dev->ctx, "could not convert string to value\n");
+		tcmu_err("could not convert string to value\n");
 		return -EINVAL;
 	}
 
@@ -95,14 +96,14 @@ static char *tcmu_get_wwn(struct tcmu_device *dev)
 
 	fd = open(path, O_RDONLY);
 	if (fd == -1) {
-		tcmu_errp(dev->ctx, "Could not open configfs to read unit serial\n");
+		tcmu_err("Could not open configfs to read unit serial\n");
 		return NULL;
 	}
 
 	ret = read(fd, buf, sizeof(buf));
 	close(fd);
 	if (ret == -1) {
-		tcmu_errp(dev->ctx, "Could not read configfs to read unit serial\n");
+		tcmu_err("Could not read configfs to read unit serial\n");
 		return NULL;
 	}
 
@@ -112,7 +113,7 @@ static char *tcmu_get_wwn(struct tcmu_device *dev)
 	/* Skip to the good stuff */
 	ret = asprintf(&ret_buf, "%s", &buf[28]);
 	if (ret == -1) {
-		tcmu_errp(dev->ctx, "could not convert string to value\n");
+		tcmu_err("could not convert string to value\n");
 		return NULL;
 	}
 
@@ -133,28 +134,28 @@ long long tcmu_get_device_size(struct tcmu_device *dev)
 
 	fd = open(path, O_RDONLY);
 	if (fd == -1) {
-		tcmu_errp(dev->ctx, "Could not open configfs to read dev info\n");
+		tcmu_err("Could not open configfs to read dev info\n");
 		return -EINVAL;
 	}
 
 	ret = read(fd, buf, sizeof(buf));
 	close(fd);
 	if (ret == -1) {
-		tcmu_errp(dev->ctx, "Could not read configfs to read dev info\n");
+		tcmu_err("Could not read configfs to read dev info\n");
 		return -EINVAL;
 	}
 	buf[sizeof(buf)-1] = '\0'; /* paranoid? Ensure null terminated */
 
 	rover = strstr(buf, " Size: ");
 	if (!rover) {
-		tcmu_errp(dev->ctx, "Could not find \" Size: \" in %s\n", path);
+		tcmu_err("Could not find \" Size: \" in %s\n", path);
 		return -EINVAL;
 	}
 	rover += 7; /* get to the value */
 
 	size = strtoull(rover, NULL, 0);
 	if (size == ULLONG_MAX) {
-		tcmu_errp(dev->ctx, "Could not get size\n");
+		tcmu_err("Could not get size\n");
 		return -EINVAL;
 	}
 

--- a/file_example.c
+++ b/file_example.c
@@ -190,14 +190,14 @@ static int file_open(struct tcmu_device *dev)
 
 	block_size = tcmu_get_attribute(dev, "hw_block_size");
 	if (block_size < 0) {
-		errp("Could not get device block size\n");
+		tcmu_err("Could not get device block size\n");
 		goto err;
 	}
 	tcmu_set_dev_block_size(dev, block_size);
 
 	size = tcmu_get_device_size(dev);
 	if (size < 0) {
-		errp("Could not get device size\n");
+		tcmu_err("Could not get device size\n");
 		goto err;
 	}
 
@@ -205,14 +205,14 @@ static int file_open(struct tcmu_device *dev)
 
 	config = strchr(tcmu_get_dev_cfgstring(dev), '/');
 	if (!config) {
-		errp("no configuration found in cfgstring\n");
+		tcmu_err("no configuration found in cfgstring\n");
 		goto err;
 	}
 	config += 1; /* get past '/' */
 
 	state->fd = open(config, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
 	if (state->fd == -1) {
-		errp("could not open %s: %m\n", config);
+		tcmu_err("could not open %s: %m\n", config);
 		goto err;
 	}
 
@@ -348,7 +348,7 @@ static int file_handle_cmd(
 
 		ret = pread(state->fd, buf, length, offset);
 		if (ret == -1) {
-			errp("read failed: %m\n");
+			tcmu_err("read failed: %m\n");
 			free(buf);
 			return set_medium_error(sense);
 		}
@@ -377,7 +377,7 @@ static int file_handle_cmd(
 
 			ret = pwrite(state->fd, iovec->iov_base, to_copy, offset);
 			if (ret == -1) {
-				errp("Could not write: %m\n");
+				tcmu_err("Could not write: %m\n");
 				return set_medium_error(sense);
 			}
 
@@ -390,7 +390,7 @@ static int file_handle_cmd(
 	}
 	break;
 	default:
-		errp("unknown command %x\n", cdb[0]);
+		tcmu_err("unknown command %x\n", cdb[0]);
 		return TCMU_NOT_HANDLED;
 	}
 }

--- a/glfs.c
+++ b/glfs.c
@@ -341,7 +341,7 @@ static glfs_t* tcmu_create_glfs_object(char *config, gluster_server **hosts)
     int ret = -1;
 
 	if (parse_imagepath(config, hosts) == -1) {
-		errp("hostaddr, volname, or path missing\n");
+		tcmu_err("hostaddr, volname, or path missing\n");
 		goto fail;
 	}
 	entry = *hosts;
@@ -352,13 +352,13 @@ static glfs_t* tcmu_create_glfs_object(char *config, gluster_server **hosts)
 
 	fs = glfs_new(entry->volname);
 	if (!fs) {
-		errp("glfs_new failed\n");
+		tcmu_err("glfs_new failed\n");
 		goto fail;
 	}
 
 	ret = gluster_cache_add(entry, fs, config);
 	if (ret) {
-		errp("gluster_cache_add failed: %m\n");
+		tcmu_err("gluster_cache_add failed: %m\n");
 		goto fail;
 	}
 
@@ -367,14 +367,14 @@ static glfs_t* tcmu_create_glfs_object(char *config, gluster_server **hosts)
 				entry->server->u.inet.addr,
 				atoi(entry->server->u.inet.port));
 	if (ret) {
-		errp("glfs_set_volfile_server failed: %m\n");
+		tcmu_err("glfs_set_volfile_server failed: %m\n");
 		goto unref;
 	}
 
 
 	ret = glfs_init(fs);
 	if (ret) {
-		errp("glfs_init failed: %m\n");
+		tcmu_err("glfs_init failed: %m\n");
 		goto unref;
 	}
 
@@ -395,7 +395,7 @@ static char* tcmu_get_path( struct tcmu_device *dev)
 
 	config = strchr(tcmu_get_dev_cfgstring(dev), '/');
 	if (!config) {
-		errp("no configuration found in cfgstring\n");
+		tcmu_err("no configuration found in cfgstring\n");
 		return NULL;
 	}
 	config += 1; /* get past '/' */
@@ -423,7 +423,7 @@ static bool glfs_check_config(const char *cfgstring, char **reason)
 
 	fs = tcmu_create_glfs_object(path, &hosts);
 	if (!fs) {
-		errp("tcmu_create_glfs_object failed\n");
+		tcmu_err("tcmu_create_glfs_object failed\n");
 		goto done;
 	}
 
@@ -472,14 +472,14 @@ static int tcmu_glfs_open(struct tcmu_device *dev)
 
 	block_size = tcmu_get_attribute(dev, "hw_block_size");
 	if (block_size < 0) {
-		errp("Could not get hw_block_size setting\n");
+		tcmu_err("Could not get hw_block_size setting\n");
 		goto fail;
 	}
 	tcmu_set_dev_block_size(dev, block_size);
 
 	size = tcmu_get_device_size(dev);
 	if (size < 0) {
-		errp("Could not get device size\n");
+		tcmu_err("Could not get device size\n");
 		goto fail;
 	}
 	tcmu_set_dev_num_lbas(dev, size / block_size);
@@ -491,24 +491,24 @@ static int tcmu_glfs_open(struct tcmu_device *dev)
 
 	gfsp->fs = tcmu_create_glfs_object(config, &gfsp->hosts);
 	if (!gfsp->fs) {
-		errp("tcmu_create_glfs_object failed\n");
+		tcmu_err("tcmu_create_glfs_object failed\n");
 		goto fail;
 	}
 
 	gfsp->gfd = glfs_open(gfsp->fs, gfsp->hosts->path, ALLOWED_BSOFLAGS);
 	if (!gfsp->gfd) {
-		errp("glfs_open failed: %m\n");
+		tcmu_err("glfs_open failed: %m\n");
 		goto unref;
 	}
 
 	ret = glfs_lstat(gfsp->fs, gfsp->hosts->path, &st);
 	if (ret) {
-		errp("glfs_lstat failed: %m\n");
+		tcmu_err("glfs_lstat failed: %m\n");
 		goto unref;
 	}
 
 	if (st.st_size != tcmu_get_device_size(dev)) {
-		errp("device size and backing size disagree: "
+		tcmu_err("device size and backing size disagree: "
 		       "device %lld backing %lld\n",
 		       tcmu_get_device_size(dev),
 		       (long long) st.st_size);

--- a/libtcmu-register.c
+++ b/libtcmu-register.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 
 #include "libtcmu.h"
+#include "libtcmu_log.h"
 #include "libtcmu_priv.h"
 #include "tcmuhandler-generated.h"
 
@@ -43,7 +44,7 @@ tcmulib_register_handler(struct tcmulib_context *ctx,
 		g_variant_type_new("(bs)"),
 		G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
 	if (!result) {
-		tcmu_errp(ctx, "Failed to call register method for '%s(%s)': %s",
+		tcmu_err("Failed to call register method for '%s(%s)': %s",
 			  handler->name,
 			  handler->subtype,
 			  error->message);
@@ -51,7 +52,7 @@ tcmulib_register_handler(struct tcmulib_context *ctx,
 	}
 	g_variant_get(result, "(b&s)", &succeeded, &reason);
 	if (!succeeded) {
-		tcmu_errp(ctx, "Failed to register method for '%s(%s)': %s",
+		tcmu_err("Failed to register method for '%s(%s)': %s",
 			  handler->name,
 			  handler->subtype,
 			  reason);
@@ -189,9 +190,7 @@ tcmulib_reg_name_vanished(GDBusConnection *connection,
 			  const gchar     *name,
 			  gpointer         user_data)
 {
-	struct tcmulib_context *ctx = user_data;
-
-	tcmu_errp(ctx, "Failed to get bus %s\n", name);
+	tcmu_err("Failed to get bus %s\n", name);
 }
 
 void tcmulib_register(struct tcmulib_context *ctx)

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -30,6 +30,7 @@ extern "C" {
 #include <sys/uio.h>
 
 #include "libtcmu_common.h"
+#include "libtcmu_log.h"
 
 struct tcmulib_handler {
 	const char *name;	/* Human-friendly name */
@@ -74,8 +75,7 @@ struct tcmulib_context;
 /* Claim subtypes you wish to handle. Returns libtcmu's master fd or -error.*/
 struct tcmulib_context *tcmulib_initialize(
 	struct tcmulib_handler *handlers,
-	size_t handler_count,
-	void (*err_print)(const char *fmt, ...));
+	size_t handler_count);
 
 /* Register to TCMU DBus service, for the claimed subtypes to be configurable
  * in targetcli. */

--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2016, China Mobile, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <stdbool.h>
+
+#include "libtcmu_config.h"
+#include "libtcmu_log.h"
+
+static struct tcmu_conf_option tcmu_options[] = {
+	{
+		.key = "log_level",
+		.type = TCMU_OPT_INT,
+		{
+			.opt_int = 2,
+		},
+	},
+	/* Add new options here */
+	{
+		.key = NULL,
+		.type = TCMU_OPT_NONE,
+		{},
+	},
+};
+
+static int tcmu_get_option_index(const char *key)
+{
+	int i = 0;
+
+	while (tcmu_options[i].key != NULL) {
+		if (!strcmp(tcmu_options[i].key, key))
+			return i;
+		i++;
+	}
+
+	return -1;
+}
+
+#define TCMU_PARSE_CFG_INT(cfg, key) \
+do { \
+	int ind = tcmu_get_option_index(#key); \
+	if (ind >= 0) { \
+		cfg->key = tcmu_options[ind].opt_int; \
+	} \
+} while (0)
+
+#define TCMU_PARSE_CFG_BOOL(cfg, key) \
+do { \
+	int ind = tcmu_get_option_index(#key); \
+	if (ind >= 0) { \
+		cfg->key = tcmu_options[ind].opt_bool; \
+	} \
+} while (0)
+
+#define TCMU_PARSE_CFG_STR(cfg, key) \
+do { \
+	int ind = tcmu_get_option_index(#key); \
+	if (ind >= 0) { \
+		cfg->key = strdup(tcmu_options[ind].opt_str); } \
+} while (0);
+
+#define TCMU_FREE_CFG_STR(cfg, key) \
+do { \
+	cfg->key = NULL; \
+	free(tcmu_options[i]->opt_str); \
+} while (0);
+
+#define TCMU_CONF_CHECK_LOG_LEVEL(key) \
+do { \
+	int ind = tcmu_get_option_index(#key); \
+	if (tcmu_options[ind].opt_int > TCMU_CONF_LOG_LEVEL_MAX) { \
+		tcmu_options[ind].opt_int = TCMU_CONF_LOG_LEVEL_MAX; \
+	} else if (tcmu_options[ind].opt_int < TCMU_CONF_LOG_LEVEL_MIN) { \
+		tcmu_options[ind].opt_int = TCMU_CONF_LOG_LEVEL_MIN; \
+	} \
+} while (0);
+
+static void tcmu_conf_set_options(struct tcmu_config *cfg)
+{
+	TCMU_PARSE_CFG_INT(cfg, log_level);
+	TCMU_CONF_CHECK_LOG_LEVEL(log_level);
+	/* add your new config options */
+}
+
+struct tcmu_config *tcmu_config_new(void)
+{
+	struct tcmu_config *cfg;
+
+	cfg = calloc(1, sizeof(*cfg));
+	if (cfg == NULL) {
+		tcmu_err("Alloc TCMU config failed!\n");
+		return NULL;
+	}
+
+	return cfg;
+}
+
+void tcmu_config_destroy(struct tcmu_config *cfg)
+{
+	/* TCMU_FREE_CFG_STR(cfg, "__STR__"); */
+
+	cfree(cfg);
+}
+
+#define TCMU_MAX_CFG_FILE_SIZE (2 * 1024 * 1024)
+static int tcmu_read_config(int fd, char *buf, int count)
+{
+	ssize_t len;
+	int save = errno;
+
+	do {
+		len = read(fd, buf, count);
+	} while (errno == EAGAIN);
+
+	errno = save;
+	return len;
+}
+
+/* end of line */
+#define __EOL(c) (((c) == '\n') || ((c) == '\r'))
+
+#define TCMU_TO_LINE_END(x, y) \
+	do { while ((x) < (y) && !__EOL(*(x))) { \
+		(x)++; } \
+	} while (0);
+
+/* skip blank lines */
+#define TCMU_SKIP_BLANK_LINES(x, y) \
+	do { while ((x) < (y) && (isblank(*(x)) || __EOL(*(x)))) { \
+		(x)++; } \
+	} while (0);
+
+/* skip comment line with '#' */
+#define TCMU_SKIP_COMMENT_LINE(x, y) \
+	do { while ((x) < (y) && !__EOL(*x)) { \
+		(x)++; } \
+	     (x)++; \
+	} while (0);
+
+/* skip comment lines with '#' */
+#define TCMU_SKIP_COMMENT_LINES(x, y) \
+	do { while ((x) < (y) && *(x) == '#') { \
+		TCMU_SKIP_COMMENT_LINE((x), (y)); } \
+	} while (0);
+
+#define MAX_KEY_LEN 64
+#define MAX_VAL_STR_LEN 256
+
+static void tcmu_parse_option(char **cur, const char *end)
+{
+	char *p = *cur, *q = *cur, *r, *s;
+	int ind;
+
+	while (isblank(*p))
+		p++;
+
+	TCMU_TO_LINE_END(q, end);
+	*q = '\0';
+	*cur = q + 1;
+
+	s = r = strchr(p, '=');
+	if (!r) {
+		/* one boolean type option at file end or line end */
+		r = p;
+		while (!isblank(*r) && r < q)
+			r++;
+		*r = '\0';
+		ind = tcmu_get_option_index(p);
+		if (ind < 0)
+			return;
+
+		tcmu_options[ind].opt_bool = true;
+
+		return;
+	}
+
+	while (isblank(*r) || *r == '=')
+		r--;
+	r++;
+	*r = '\0';
+	ind = tcmu_get_option_index(p);
+	if (ind < 0)
+		return;
+
+	switch (tcmu_options[ind].type) {
+		/* one int type option */
+		case TCMU_OPT_INT:
+			while (!isdigit(*s))
+				s++;
+			r = s;
+			while (isdigit(*r))
+				r++;
+			*r= '\0';
+			tcmu_options[ind].opt_int = atoi(s);
+			break;
+		/* one string type option */
+		case TCMU_OPT_STR:
+			s++;
+			while (isblank(*s))
+				s++;
+			/* skip first " or ' if exist */
+			if (*s == '"' || *s == '\'')
+				s++;
+			r = q - 1;
+			while (isblank(*r))
+				r--;
+			/* skip last " or ' if exist */
+			if (*r == '"' || *r == '\'')
+				*r = '\0';
+
+			tcmu_options[ind].opt_str = strdup(s);
+			break;
+		default:
+			break;
+	}
+}
+
+static void tcmu_parse_options(struct tcmu_config *cfg, char *buf, int len)
+{
+    char *cur = buf, *end = buf + len;
+
+    while (cur < end) {
+	    /* skip blanks lines */
+	    TCMU_SKIP_BLANK_LINES(cur, end);
+
+	    /* skip comments with '#' */
+	    TCMU_SKIP_COMMENT_LINES(cur, end);
+
+	    if (cur >= end)
+		    break;
+
+	    if (!isalpha(*cur))
+		    continue;
+
+	    /* parse the options from config file to tcmu_options[] */
+	    tcmu_parse_option(&cur, end);
+    }
+
+    /* parse the options from tcmu_options[] to struct tcmu_config */
+    tcmu_conf_set_options(cfg);
+
+}
+
+int tcmu_load_config(struct tcmu_config *cfg, const char *path)
+{
+	char buf[TCMU_MAX_CFG_FILE_SIZE];
+	int fd, len;
+
+	if (!path)
+		path = "/etc/tcmu/tcmu.conf"; /* the default config file */
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		tcmu_err("Failed to open file '%s'\n", path);
+		return -1;
+	}
+
+	len = tcmu_read_config(fd, buf, TCMU_MAX_CFG_FILE_SIZE);
+	if (len < 0) {
+		tcmu_err("Failed to read file '%s'\n", path);
+		return -1;
+	}
+
+	close(fd);
+
+	buf[len] = '\0';
+
+	tcmu_parse_options(cfg, buf, len);
+
+	return 0;
+}

--- a/libtcmu_config.h
+++ b/libtcmu_config.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016, China Mobile, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __TCMU_CONFIG_H
+# define __TCMU_CONFIG_H
+
+#include <stdbool.h>
+
+struct tcmu_config {
+	int log_level;
+};
+
+/*
+ * There are 4 logging levels supported in tcmu.conf:
+ *    1: ERROR
+ *    2: WARNING
+ *    3: INFO
+ *    4: DEBUG
+ */
+#define TCMU_CONF_LOG_LEVEL_MIN 1
+#define TCMU_CONF_LOG_LEVEL_MAX 4
+#define TCMU_CONF_LOG_ERROR 1
+#define TCMU_CONF_LOG_WARN 2
+#define TCMU_CONF_LOG_INFO 3
+#define TCMU_CONF_LOG_DEBUG 4
+
+typedef enum {
+	TCMU_OPT_NONE = 0,
+	TCMU_OPT_INT, /* type int */
+	TCMU_OPT_STR, /* type string */
+	TCMU_OPT_BOOL, /* type boolean */
+	TCMU_OPT_MAX,
+} tcmu_option_type;
+
+struct tcmu_conf_option {
+	char *key;
+	tcmu_option_type type;
+	union {
+		int opt_int;
+		bool opt_bool;
+		char *opt_str;
+	};
+};
+
+int tcmu_load_config(struct tcmu_config *cfg, const char *path);
+void tcmu_config_destroy(struct tcmu_config *cfg);
+struct tcmu_config * tcmu_config_new(void);
+#endif /* __TCMU_CONFIG_H */

--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016, China Mobile, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define _GNU_SOURCE
+#include "libtcmu_log.h"
+
+void tcmu_log_open_syslog(const char *ident, int option, int facility)
+{
+	const char *id = TCMU_IDENT;
+
+	if (ident)
+		id = ident;
+
+	openlog(id, option, facility);
+}
+
+void tcmu_log_close_syslog(void)
+{
+	closelog();
+}
+
+static inline void tcmu_log_output_to_syslog(int pri, const char *fmt, va_list args)
+{
+	char logbuf[TCMU_LOG_BUF_SIZE];
+
+	vsnprintf(logbuf, TCMU_LOG_BUF_SIZE - 1, fmt, args);
+	syslog(pri, "%s", logbuf);
+}
+
+void tcmu_err(const char *fmt, ...)
+{
+	va_list args;
+
+	if (!fmt)
+		return;
+
+	va_start(args, fmt);
+	tcmu_log_output_to_syslog(TCMU_LOG_ERR, fmt, args);
+	va_end(args);
+}
+
+void tcmu_warn(const char *fmt, ...)
+{
+	va_list args;
+
+	if (!fmt)
+		return;
+
+	va_start(args, fmt);
+	tcmu_log_output_to_syslog(TCMU_LOG_WARN, fmt, args);
+	va_end(args);
+}
+
+void tcmu_info(const char *fmt, ...)
+{
+	va_list args;
+
+	if (!fmt)
+		return;
+
+	va_start(args, fmt);
+	tcmu_log_output_to_syslog(TCMU_LOG_INFO, fmt, args);
+	va_end(args);
+}
+
+void tcmu_dbg(const char *fmt, ...)
+{
+	va_list args;
+
+	if (!fmt)
+		return;
+
+	va_start(args, fmt);
+	tcmu_log_output_to_syslog(TCMU_LOG_DEBUG, fmt, args);
+	va_end(args);
+}

--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -16,6 +16,36 @@
 
 #define _GNU_SOURCE
 #include "libtcmu_log.h"
+#include "libtcmu_config.h"
+
+#define TCMU_LOG_ERROR	LOG_ERR		/* error conditions */
+#define TCMU_LOG_WARN	LOG_WARNING	/* warning conditions */
+#define TCMU_LOG_INFO	LOG_INFO	/* informational */
+#define TCMU_LOG_DEBUG	LOG_DEBUG	/* debug-level messages */
+
+static int tcmu_log_level = TCMU_LOG_WARN;
+
+static inline int tcmu_log_level_conf_to_syslog(int level)
+{
+	switch (level) {
+		case TCMU_CONF_LOG_ERROR:
+			return TCMU_LOG_ERROR;
+		case TCMU_CONF_LOG_WARN:
+			return TCMU_LOG_WARN;
+		case TCMU_CONF_LOG_INFO:
+			return TCMU_LOG_INFO;
+		case TCMU_CONF_LOG_DEBUG:
+			return TCMU_LOG_DEBUG;
+		default:
+			return -1;
+	}
+}
+
+/* covert log level from tcmu config to syslog */
+void tcmu_set_log_level(int level)
+{
+	tcmu_log_level = tcmu_log_level_conf_to_syslog(level);
+}
 
 void tcmu_log_open_syslog(const char *ident, int option, int facility)
 {
@@ -36,6 +66,9 @@ static inline void tcmu_log_output_to_syslog(int pri, const char *fmt, va_list a
 {
 	char logbuf[TCMU_LOG_BUF_SIZE];
 
+	if (pri > tcmu_log_level)
+		return;
+
 	vsnprintf(logbuf, TCMU_LOG_BUF_SIZE - 1, fmt, args);
 	syslog(pri, "%s", logbuf);
 }
@@ -48,7 +81,7 @@ void tcmu_err(const char *fmt, ...)
 		return;
 
 	va_start(args, fmt);
-	tcmu_log_output_to_syslog(TCMU_LOG_ERR, fmt, args);
+	tcmu_log_output_to_syslog(TCMU_LOG_ERROR, fmt, args);
 	va_end(args);
 }
 

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016, China Mobile, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __TCMU_LOG_H
+#define __TCMU_LOG_H
+#include <syslog.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#define TCMU_IDENT "tcmu"
+#define TCMU_RUNNER "tcmu-runner"
+#define TCMU_CONSUMER "tcmu-consumer"
+#define TCMU_SYNC "tcmu-synthesizer"
+#define TCMU_LOG_BUF_SIZE 1024
+
+#define TCMU_LOG_ERR	LOG_ERR		/* error conditions */
+#define TCMU_LOG_WARN	LOG_WARNING	/* warning conditions */
+#define TCMU_LOG_INFO	LOG_INFO	/* informational */
+#define TCMU_LOG_DEBUG	LOG_DEBUG	/* debug-level messages */
+
+void tcmu_log_open_syslog(const char *ident, int option, int facility);
+void tcmu_log_close_syslog(void);
+
+void tcmu_set_log_level(int level);
+void tcmu_err(const char *fmt, ...);
+void tcmu_warn(const char *fmt, ...);
+void tcmu_info(const char *fmt, ...);
+void tcmu_dbg(const char *fmt, ...);
+#endif /* __TCMU_LOG_H */

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -29,10 +29,15 @@
 
 void tcmu_log_open_syslog(const char *ident, int option, int facility);
 void tcmu_log_close_syslog(void);
-
 void tcmu_set_log_level(int level);
-void tcmu_err(const char *fmt, ...);
-void tcmu_warn(const char *fmt, ...);
-void tcmu_info(const char *fmt, ...);
-void tcmu_dbg(const char *fmt, ...);
+
+void tcmu_err_message(const char *funcname, int linenr, const char *fmt, ...);
+void tcmu_warn_message(const char *funcname, int linenr, const char *fmt, ...);
+void tcmu_info_message(const char *funcname, int linenr, const char *fmt, ...);
+void tcmu_dbg_message(const char *funcname, int linenr, const char *fmt, ...);
+
+#define tcmu_err(...)  {tcmu_err_message(__func__, __LINE__, __VA_ARGS__);}
+#define tcmu_warn(...) {tcmu_warn_message(__func__, __LINE__, __VA_ARGS__);}
+#define tcmu_info(...) {tcmu_info_message(__func__, __LINE__, __VA_ARGS__);}
+#define tcmu_dbg(...)  {tcmu_dbg_message(__func__, __LINE__, __VA_ARGS__);}
 #endif /* __TCMU_LOG_H */

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -27,11 +27,6 @@
 #define TCMU_SYNC "tcmu-synthesizer"
 #define TCMU_LOG_BUF_SIZE 1024
 
-#define TCMU_LOG_ERR	LOG_ERR		/* error conditions */
-#define TCMU_LOG_WARN	LOG_WARNING	/* warning conditions */
-#define TCMU_LOG_INFO	LOG_INFO	/* informational */
-#define TCMU_LOG_DEBUG	LOG_DEBUG	/* debug-level messages */
-
 void tcmu_log_open_syslog(const char *ident, int option, int facility);
 void tcmu_log_close_syslog(void);
 

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -41,14 +41,10 @@ struct tcmulib_context {
 
 	struct nl_sock *nl_sock;
 
-	void (*err_print)(const char *fmt, ...);
-
 	unsigned reg_count_down;
 
 	GDBusConnection *connection;
 };
-
-#define tcmu_errp(ctx, fmt, ...) if ((ctx)->err_print) { (ctx)->err_print((fmt),##__VA_ARGS__);}
 
 struct tcmu_device {
 	int fd;

--- a/main.c
+++ b/main.c
@@ -45,11 +45,18 @@
 #include "libtcmu.h"
 #include "tcmuhandler-generated.h"
 #include "version.h"
+#include "libtcmu_log.h"
 
 #define ARRAY_SIZE(X) (sizeof(X) / sizeof((X)[0]))
 
 static char *handler_path = DEFAULT_HANDLER_PATH;
-static bool debug = false;
+
+static void tcmu_debug_none(const char *fmt, ...)
+{
+	/* Nothing to do */
+}
+
+static void (*tcmu_debug)(const char *fmt, ...);
 
 darray(struct tcmur_handler *) g_runner_handlers = darray_new();
 
@@ -59,28 +66,6 @@ struct tcmu_thread {
 };
 
 static darray(struct tcmu_thread) g_threads = darray_new();
-
-/*
- * Debug API implementation
- */
-void dbgp(const char *fmt, ...)
-{
-	if (debug) {
-		va_list va;
-		va_start(va, fmt);
-		vprintf(fmt, va);
-		va_end(va);
-	}
-}
-
-void errp(const char *fmt, ...)
-{
-	va_list va;
-
-	va_start(va, fmt);
-	vfprintf(stderr, fmt, va);
-	va_end(va);
-}
 
 static struct tcmur_handler *find_handler_by_subtype(gchar *subtype)
 {
@@ -97,7 +82,7 @@ int tcmur_register_handler(struct tcmur_handler *handler)
 {
 	if (handler->handle_cmd &&
 	    (handler->read || handler->write || handler->flush)) {
-		errp("Skip bad handler: %s\n", handler->name);
+		tcmu_err("Skip bad handler: %s\n", handler->name);
 		return -1;
 	}
 
@@ -145,20 +130,20 @@ static int open_handlers(void)
 
 		ret = asprintf(&path, "%s/%s", handler_path, dirent_list[i]->d_name);
 		if (ret == -1) {
-			errp("ENOMEM\n");
+			tcmu_err("ENOMEM\n");
 			continue;
 		}
 
 		handle = dlopen(path, RTLD_NOW|RTLD_LOCAL);
 		if (!handle) {
-			errp("Could not open handler at %s: %s\n", path, dlerror());
+			tcmu_err("Could not open handler at %s: %s\n", path, dlerror());
 			free(path);
 			continue;
 		}
 
 		handler_init = dlsym(handle, "handler_init");
 		if (!handler_init) {
-			errp("dlsym failure on %s\n", path);
+			tcmu_err("dlsym failure on %s\n", path);
 			free(path);
 			continue;
 		}
@@ -246,7 +231,7 @@ static int generic_handle_cmd(struct tcmu_device *dev,
 	case READ_16:
 		ret = store->read(dev, iovec, iov_cnt, offset);
 		if (ret != l) {
-			errp("Error on read %x, %x\n", ret, l);
+			tcmu_err("Error on read %x, %x\n", ret, l);
 			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
 						   ASC_READ_ERROR, NULL);
 		} else
@@ -257,7 +242,7 @@ static int generic_handle_cmd(struct tcmu_device *dev,
 	case WRITE_16:
 		ret = store->write(dev, iovec, iov_cnt, offset);
 		if (ret != l) {
-			errp("Error on write %x, %x\n", ret, l);
+			tcmu_err("Error on write %x, %x\n", ret, l);
 			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
 						   ASC_READ_ERROR, NULL);
 		} else
@@ -266,7 +251,7 @@ static int generic_handle_cmd(struct tcmu_device *dev,
 	case SYNCHRONIZE_CACHE_16:
 		ret = store->flush(dev);
 		if (ret < 0) {
-			errp("Error on flush %x\n", ret);
+			tcmu_err("Error on flush %x\n", ret);
 			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
 						   ASC_READ_ERROR, NULL);
 		} else
@@ -274,14 +259,14 @@ static int generic_handle_cmd(struct tcmu_device *dev,
 	case COMPARE_AND_WRITE:
 		iov.iov_base = malloc(half);
 		if (!iov.iov_base) {
-			errp("out of memory\n");
+			tcmu_err("out of memory\n");
 			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
 						   ASC_READ_ERROR, NULL);
 		}
 		iov.iov_len = half;
 		ret = store->read(dev, &iov, 1, offset);
 		if (ret != l) {
-			errp("Error on read %x, %x\n", ret, l);
+			tcmu_err("Error on read %x, %x\n", ret, l);
 			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
 						   ASC_READ_ERROR, NULL);
 		}
@@ -296,13 +281,13 @@ static int generic_handle_cmd(struct tcmu_device *dev,
 		tcmu_seek_in_iovec(iovec, half);
 		ret = store->write(dev, iovec, iov_cnt, offset);
 		if (ret != half) {
-			errp("Error on write %x, %x\n", ret, half);
+			tcmu_err("Error on write %x, %x\n", ret, half);
 			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
 						   ASC_READ_ERROR, NULL);
 		} else
 			return SAM_STAT_GOOD;
 	default:
-		errp("unknown command %x\n", cdb[0]);
+		tcmu_err("unknown command %x\n", cdb[0]);
 		return TCMU_NOT_HANDLED;
 	}
 }
@@ -328,9 +313,9 @@ static void *thread_start(void *arg)
 			bool short_cdb = cmd->cdb[0] <= 0x1f;
 
 			for (i = 0; i < (short_cdb ? 6 : 10); i++) {
-				dbgp("%x ", cmd->cdb[i]);
+				tcmu_debug("%x ", cmd->cdb[i]);
 			}
-			dbgp("\n");
+			tcmu_debug("\n");
 
 			if (r_handler->handle_cmd)
 				ret = r_handler->handle_cmd(dev, cmd);
@@ -352,12 +337,12 @@ static void *thread_start(void *arg)
 		poll(&pfd, 1, -1);
 
 		if (pfd.revents != POLLIN) {
-			errp("poll received unexpected revent: 0x%x\n", pfd.revents);
+			tcmu_err("poll received unexpected revent: 0x%x\n", pfd.revents);
 			break;
 		}
 	}
 
-	errp("thread terminating, should never happen\n");
+	tcmu_err("thread terminating, should never happen\n");
 
 	pthread_cleanup_pop(1);
 
@@ -371,25 +356,25 @@ static void cancel_thread(pthread_t thread)
 
 	ret = pthread_cancel(thread);
 	if (ret) {
-		errp("pthread_cancel failed with value %d\n", ret);
+		tcmu_err("pthread_cancel failed with value %d\n", ret);
 		return;
 	}
 
 	ret = pthread_join(thread, &join_retval);
 	if (ret) {
-		errp("pthread_join failed with value %d\n", ret);
+		tcmu_err("pthread_join failed with value %d\n", ret);
 		return;
 	}
 
 	if (join_retval != PTHREAD_CANCELED)
-		errp("unexpected join retval: %p\n", join_retval);
+		tcmu_err("unexpected join retval: %p\n", join_retval);
 }
 
 static void sighandler(int signal)
 {
 	struct tcmu_thread *thread;
 
-	errp("signal %d received!\n", signal);
+	tcmu_err("signal %d received!\n", signal);
 
 	darray_foreach(thread, g_threads) {
 		cancel_thread(thread->thread_id);
@@ -652,7 +637,7 @@ void dbus_handler_manager1_init(GDBusConnection *connection)
 			 G_CALLBACK (on_unregister_handler),
 			 NULL);
 	if (!ret)
-		errp("Handler manager export failed: %s\n",
+		tcmu_err("Handler manager export failed: %s\n",
 		     error ? error->message : "unknown error");
 	if (error)
 		g_error_free(error);
@@ -664,7 +649,7 @@ static void dbus_bus_acquired(GDBusConnection *connection,
 {
 	struct tcmur_handler **handler;
 
-	dbgp("bus %s acquired\n", name);
+	tcmu_debug("bus %s acquired\n", name);
 
 	manager = g_dbus_object_manager_server_new("/org/kernel/TCMUService1");
 
@@ -680,14 +665,14 @@ static void dbus_name_acquired(GDBusConnection *connection,
 			      const gchar *name,
 			      gpointer user_data)
 {
-	dbgp("name %s acquired\n", name);
+	tcmu_debug("name %s acquired\n", name);
 }
 
 static void dbus_name_lost(GDBusConnection *connection,
 			   const gchar *name,
 			   gpointer user_data)
 {
-	dbgp("name lost\n");
+	tcmu_debug("name lost\n");
 }
 
 int load_our_module(void) {
@@ -697,7 +682,7 @@ int load_our_module(void) {
 
 	ctx = kmod_new(NULL, NULL);
 	if (!ctx) {
-		errp("kmod_new() failed\n");
+		tcmu_err("kmod_new() failed\n");
 		return -1;
 	}
 
@@ -712,12 +697,12 @@ int load_our_module(void) {
 			mod, KMOD_PROBE_APPLY_BLACKLIST, 0, 0, 0, 0);
 
 		if (err != 0) {
-			errp("kmod_module_probe_insert_module() for %s failed\n",
+			tcmu_err("kmod_module_probe_insert_module() for %s failed\n",
 			    kmod_module_get_name(mod));
 			return -1;
 		}
 
-		dbgp("Module %s inserted (or already loaded)\n", kmod_module_get_name(mod));
+		tcmu_debug("Module %s inserted (or already loaded)\n", kmod_module_get_name(mod));
 
 		kmod_module_unref(mod);
 	}
@@ -765,7 +750,7 @@ static void dev_removed(struct tcmu_device *dev)
 	}
 
 	if (!found) {
-		errp("could not remove a device: not found\n");
+		tcmu_err("could not remove a device: not found\n");
 		return;
 	}
 
@@ -805,6 +790,11 @@ int main(int argc, char **argv)
 	darray(struct tcmulib_handler) handlers = darray_new();
 	struct tcmur_handler **tmp_r_handler;
 
+	tcmu_log_open_syslog(TCMU_SYNC, 0, 0);
+	tcmu_debug = tcmu_debug_none;
+
+	tcmu_log_open_syslog(TCMU_RUNNER, 0, 0);
+
 	while (1) {
 		int option_index = 0;
 
@@ -819,7 +809,7 @@ int main(int argc, char **argv)
 				handler_path = strdup(optarg);
 			break;
 		case 'd':
-			debug = true;
+			tcmu_debug = tcmu_dbg;
 			break;
 		case 'V':
 			printf("tcmu-runner %d.%d.%d\n",
@@ -834,20 +824,20 @@ int main(int argc, char **argv)
 		}
 	}
 
-	dbgp("handler path: %s\n", handler_path);
+	tcmu_debug("handler path: %s\n", handler_path);
 
 	ret = load_our_module();
 	if (ret < 0) {
-		errp("couldn't load module\n");
+		tcmu_err("couldn't load module\n");
 		exit(1);
 	}
 
 	ret = open_handlers();
 	if (ret < 0) {
-		errp("couldn't open handlers\n");
+		tcmu_err("couldn't open handlers\n");
 		exit(1);
 	}
-	dbgp("%d runner handlers found\n", ret);
+	tcmu_debug("%d runner handlers found\n", ret);
 
 	/*
 	 * Convert from tcmu-runner's handler struct to libtcmu's
@@ -873,16 +863,15 @@ int main(int argc, char **argv)
 		darray_append(handlers, tmp_handler);
 	}
 
-
-	tcmulib_context = tcmulib_initialize(handlers.item, handlers.size, errp);
+	tcmulib_context = tcmulib_initialize(handlers.item, handlers.size);
 	if (!tcmulib_context) {
-		errp("tcmulib_initialize failed\n");
+		tcmu_err("tcmulib_initialize failed\n");
 		exit(1);
 	}
 
 	ret = sigaction(SIGINT, &tcmu_sigaction, NULL);
 	if (ret) {
-		errp("couldn't set sigaction\n");
+		tcmu_err("couldn't set sigaction\n");
 		exit(1);
 	}
 
@@ -904,9 +893,10 @@ int main(int argc, char **argv)
 	loop = g_main_loop_new(NULL, FALSE);
 	g_main_loop_run(loop);
 
-	dbgp("Exiting...\n");
+	tcmu_debug("Exiting...\n");
 	g_bus_unown_name(reg_id);
 	g_main_loop_unref(loop);
+	tcmu_log_close_syslog();
 
 	return 0;
 }

--- a/qcow.c
+++ b/qcow.c
@@ -128,14 +128,14 @@ static int bdev_open(struct bdev *bdev, int dirfd, const char *pathname, int fla
 	for (ops = &bdev_ops[0]; *ops != NULL; ops++) {
 		if ((*ops)->probe(bdev, dirfd, pathname) == 0) {
 			if ((*ops)->open(bdev, dirfd, pathname, flags) == -1) {
-				errp("image open failed: %s\n", pathname);
+				tcmu_err("image open failed: %s\n", pathname);
 				goto err;
 			}
 			bdev->ops = *ops;
 			return 0;
 		}
 	}
-	errp("image format not recognized: %s\n", pathname);
+	tcmu_err("image format not recognized: %s\n", pathname);
 err:
 	return -1;
 }
@@ -276,7 +276,7 @@ static int qcow_probe(struct bdev *bdev, int dirfd, const char *pathname)
 	    uint32_t version;
 	} head;
 
-	dbgp("%s\n", __func__);
+	tcmu_dbg("%s\n", __func__);
 
 	if (faccessat(dirfd, pathname, R_OK|W_OK, AT_EACCESS) == -1)
 		return -1;
@@ -303,7 +303,7 @@ static int qcow2_probe(struct bdev *bdev, int dirfd, const char *pathname)
 	    uint32_t version;
 	} head;
 
-	dbgp("%s\n", __func__);
+	tcmu_dbg("%s\n", __func__);
 
 	if (faccessat(dirfd, pathname, R_OK|W_OK, AT_EACCESS) == -1) {
 		perror("no file access");
@@ -322,7 +322,7 @@ static int qcow2_probe(struct bdev *bdev, int dirfd, const char *pathname)
 		goto err;
 	}
 	if (be32toh(head.version) < 2) {
-		errp("version = %d\n", head.version);
+		tcmu_err("version = %d\n", head.version);
 		goto err;
 	}
 	close(fd);
@@ -335,30 +335,30 @@ err:
 static int qcow_validate_header(struct qcow_header *header)
 {
 	if (header->magic != QCOW_MAGIC) {
-		errp("header is not QCOW\n");
+		tcmu_err("header is not QCOW\n");
 		 return -1;
 	}
 	if (header->version != 1) {
-		errp("version is %d, expected 1\n", header->version);
+		tcmu_err("version is %d, expected 1\n", header->version);
 		 return -1;
 	}
 	if (header->cluster_bits < 9 || header->cluster_bits > 16) {
-		errp("bad cluster_bits = %d\n", header->cluster_bits);
+		tcmu_err("bad cluster_bits = %d\n", header->cluster_bits);
 		 return -1;
 	}
 	if (header->l2_bits < (9 - 3) || header->l2_bits > (16 - 3)) {
-		errp("bad l2_bits = %d\n", header->l2_bits);
+		tcmu_err("bad l2_bits = %d\n", header->l2_bits);
 		 return -1;
 	}
 	switch (header->crypt_method) {
 		case QCOW_CRYPT_NONE:
 			break;
 		case QCOW_CRYPT_AES:
-			errp("QCOW AES-CBC encryption has been deprecated\n");
-			errp("Convert to unencrypted image using qemu-img\n");
+			tcmu_err("QCOW AES-CBC encryption has been deprecated\n");
+			tcmu_err("Convert to unencrypted image using qemu-img\n");
 			 return -1;
 		default:
-			errp("Invalid encryption value %d\n", header->crypt_method);
+			tcmu_err("Invalid encryption value %d\n", header->crypt_method);
 			 return -1;
 	}
 	return 0;
@@ -368,26 +368,26 @@ static int qcow2_validate_header(struct qcow2_header *header)
 {
 	/* TODO check other stuff ... L1, refcount, snapshots */
 	if (header->magic != QCOW_MAGIC) {
-		errp("header is not QCOW\n");
+		tcmu_err("header is not QCOW\n");
 		 return -1;
 	}
 	if (header->version < 2) {
-		errp("version is %d, expected 2 or 3\n", header->version);
+		tcmu_err("version is %d, expected 2 or 3\n", header->version);
 		 return -1;
 	}
 	if (header->cluster_bits < 9 || header->cluster_bits > 16) {
-		errp("bad cluster_bits = %d\n", header->cluster_bits);
+		tcmu_err("bad cluster_bits = %d\n", header->cluster_bits);
 		 return -1;
 	}
 	switch (header->crypt_method) {
 		case QCOW2_CRYPT_NONE:
 			break;
 		case QCOW2_CRYPT_AES:
-			errp("QCOW AES-CBC encryption has been deprecated\n");
-			errp("Convert to unencrypted image using qemu-img\n");
+			tcmu_err("QCOW AES-CBC encryption has been deprecated\n");
+			tcmu_err("Convert to unencrypted image using qemu-img\n");
 			 return -1;
 		default:
-			errp("Invalid encryption value %d\n", header->crypt_method);
+			tcmu_err("Invalid encryption value %d\n", header->crypt_method);
 			 return -1;
 	}
 	return 0;
@@ -409,14 +409,14 @@ static int qcow_setup_backing_file(struct bdev *bdev, struct qcow_header *header
 		return 0;
 
 	if (len >= PATH_MAX) {
-		errp("Backing file name too long\n");
+		tcmu_err("Backing file name too long\n");
 		return -1;
 	}
 
 	backing_file = alloca(len + 1);
 
 	if (pread(bdev->fd, backing_file, len, header->backing_file_offset) != len) {
-		errp("Error reading backing file name\n");
+		tcmu_err("Error reading backing file name\n");
 		return -1;
 	}
 	backing_file[len] = '\0';
@@ -469,12 +469,12 @@ static int qcow_image_open(struct bdev *bdev, int dirfd, const char *pathname, i
 	bdev->fd = openat(dirfd, pathname, flags);
 	s->fd = bdev->fd;
 	if (bdev->fd == -1) {
-		errp("Failed to open file: %s\n", pathname);
+		tcmu_err("Failed to open file: %s\n", pathname);
 		goto fail_nofd;
 	}
 
 	if (pread(bdev->fd, &buf, sizeof(buf), 0) != sizeof(buf)) {
-		errp("Failed to read file: &s\n", pathname);
+		tcmu_err("Failed to read file: &s\n", pathname);
 		goto fail;
 	}
 
@@ -483,14 +483,14 @@ static int qcow_image_open(struct bdev *bdev, int dirfd, const char *pathname, i
 		goto fail;
 
 	if (bdev->size != header.size) {
-		errp("size misconfigured, TCMU says %" PRId64
+		tcmu_err("size misconfigured, TCMU says %" PRId64
 				" but image says %" PRId64 "\n",
 				bdev->size, header.size);
 		goto fail;
 	}
 	s->size = bdev->size;
 	if (bdev->block_size != 512) {
-		errp("block_size misconfigured, TCMU says %" PRId32
+		tcmu_err("block_size misconfigured, TCMU says %" PRId32
 				" but qcow only supports 512\n",
 				bdev->block_size);
 		goto fail;
@@ -505,12 +505,12 @@ static int qcow_image_open(struct bdev *bdev, int dirfd, const char *pathname, i
 
 	shift = s->cluster_bits + s->l2_bits;
 	if (header.size > UINT64_MAX - (1LL << shift)) {
-		errp("Image size too big\n");
+		tcmu_err("Image size too big\n");
 		goto fail;
 	}
 	l1_size = (header.size + (1LL << shift) - 1) >> shift;
 	if (l1_size > INT_MAX / sizeof(uint64_t)) {
-		errp("Image size too big\n");
+		tcmu_err("Image size too big\n");
 		goto fail;
 	}
 	s->l1_size = l1_size;
@@ -518,18 +518,18 @@ static int qcow_image_open(struct bdev *bdev, int dirfd, const char *pathname, i
 
 	s->l1_table = calloc(s->l1_size, sizeof(uint64_t));
 	if (!s->l1_table) {
-		errp("Failed to allocate L1 table\n");
+		tcmu_err("Failed to allocate L1 table\n");
 		goto fail;
 	}
 	read = pread(bdev->fd, s->l1_table, s->l1_size * sizeof(uint64_t), s->l1_table_offset);
 	if (read != s->l1_size * sizeof(uint64_t)) {
-		errp("Failed to read L1 table\n");
+		tcmu_err("Failed to read L1 table\n");
 		goto fail;
 	}
 
 	s->l2_cache = calloc(L2_CACHE_SIZE, s->l2_size * sizeof(uint64_t));
 	if (s->l2_cache == NULL) {
-		errp("Failed to allocate L2 cache\n");
+		tcmu_err("Failed to allocate L2 cache\n");
 		goto fail;
 	}
 
@@ -538,7 +538,7 @@ static int qcow_image_open(struct bdev *bdev, int dirfd, const char *pathname, i
 	s->cluster_data = calloc(1, s->cluster_size);
 	s->cluster_cache_offset = -1;
 	if (!s->cluster_cache || !s->cluster_data) {
-		errp("Failed to allocate cluster decompression space\n");
+		tcmu_err("Failed to allocate cluster decompression space\n");
 		goto fail;
 	}
 
@@ -550,7 +550,7 @@ static int qcow_image_open(struct bdev *bdev, int dirfd, const char *pathname, i
 
 	s->block_alloc = qcow_block_alloc;
 	s->set_refcount = qcow_no_refcount;
-	dbgp("%d: %s\n", bdev->fd, pathname);
+	tcmu_dbg("%d: %s\n", bdev->fd, pathname);
 	return 0;
 fail:
 	close(bdev->fd);
@@ -580,12 +580,12 @@ static int qcow2_image_open(struct bdev *bdev, int dirfd, const char *pathname, 
 	bdev->fd = openat(dirfd, pathname, flags);
 	s->fd = bdev->fd;
 	if (bdev->fd == -1) {
-		errp("Failed to open file: %s\n", pathname);
+		tcmu_err("Failed to open file: %s\n", pathname);
 		goto fail_nofd;
 	}
 
 	if (pread(bdev->fd, &buf, sizeof(buf), 0) != sizeof(buf)) {
-		errp("Failed to read file: %s\n", pathname);
+		tcmu_err("Failed to read file: %s\n", pathname);
 		goto fail;
 	}
 
@@ -594,14 +594,14 @@ static int qcow2_image_open(struct bdev *bdev, int dirfd, const char *pathname, 
 		goto fail;
 
 	if (bdev->size != header.size) {
-		errp("size misconfigured, TCMU says %" PRId64
+		tcmu_err("size misconfigured, TCMU says %" PRId64
 				" but image says %" PRId64 "\n",
 				bdev->size, header.size);
 		goto fail;
 	}
 	s->size = bdev->size;
 	if (bdev->block_size != 512) {
-		errp("block_size misconfigured, TCMU says %" PRId32
+		tcmu_err("block_size misconfigured, TCMU says %" PRId32
 				" but qcow only supports 512\n",
 				bdev->block_size);
 		goto fail;
@@ -616,49 +616,49 @@ static int qcow2_image_open(struct bdev *bdev, int dirfd, const char *pathname, 
 
 	shift = s->cluster_bits + s->l2_bits;
 	if (header.size > UINT64_MAX - (1LL << shift)) {
-		errp("Image size too big\n");
+		tcmu_err("Image size too big\n");
 		goto fail;
 	}
 	l1_size = (header.size + (1LL << shift) - 1) >> shift;
 	if (l1_size > INT_MAX / sizeof(uint64_t)) {
-		errp("Image size too big\n");
+		tcmu_err("Image size too big\n");
 		goto fail;
 	}
 	s->l1_size = l1_size;
 	// why did they add this to qcow2 ?
 	if (header.l1_size != s->l1_size) {
-		errp("L1 size is incorrect\n");
+		tcmu_err("L1 size is incorrect\n");
 		goto fail;
 	}
 	s->l1_table_offset = header.l1_table_offset;
 
 	s->l1_table = calloc(s->l1_size, sizeof(uint64_t));
 	if (!s->l1_table) {
-		errp("Failed to allocate L1 table\n");
+		tcmu_err("Failed to allocate L1 table\n");
 		goto fail;
 	}
 	read = pread(bdev->fd, s->l1_table, s->l1_size * sizeof(uint64_t), s->l1_table_offset);
 	if (read != s->l1_size * sizeof(uint64_t)) {
-		errp("Failed to read L1 table\n");
+		tcmu_err("Failed to read L1 table\n");
 		goto fail;
 	}
 
 	s->l2_cache = calloc(L2_CACHE_SIZE, s->l2_size * sizeof(uint64_t));
 	if (s->l2_cache == NULL) {
-		errp("Failed to allocate L2 cache\n");
+		tcmu_err("Failed to allocate L2 cache\n");
 		goto fail;
 	}
-	dbgp("s->l2_cache = %p\n", s->l2_cache);
+	tcmu_dbg("s->l2_cache = %p\n", s->l2_cache);
 
 	/* cluster decompression cache */
 	s->cluster_cache = calloc(1, s->cluster_size);
 	s->cluster_data = calloc(1, s->cluster_size);
 	s->cluster_cache_offset = -1;
 	if (!s->cluster_cache || !s->cluster_data) {
-		errp("Failed to allocate cluster decompression space\n");
+		tcmu_err("Failed to allocate cluster decompression space\n");
 		goto fail;
 	}
-	dbgp("s->cluster_cache = %p\n", s->cluster_cache);
+	tcmu_dbg("s->cluster_cache = %p\n", s->cluster_cache);
 
 	/* refcount table */
 	s->refcount_table_offset = header.refcount_table_offset;
@@ -666,22 +666,22 @@ static int qcow2_image_open(struct bdev *bdev, int dirfd, const char *pathname, 
 
 	s->refcount_table = calloc(s->refcount_table_size, sizeof(uint64_t));
 	if (!s->refcount_table) {
-		errp("Failed to allocate refcount table\n");
+		tcmu_err("Failed to allocate refcount table\n");
 		goto fail;
 	}
 	read = pread(bdev->fd, s->refcount_table, s->refcount_table_size * sizeof(uint64_t), s->refcount_table_offset);
 	if (read != s->refcount_table_size * sizeof(uint64_t)) {
-		errp("Failed to read refcount table\n");
+		tcmu_err("Failed to read refcount table\n");
 		goto fail;
 	}
 
 	s->refcount_order = header.refcount_order;
 	s->rc_cache = calloc(RC_CACHE_SIZE, s->cluster_size);
 	if (s->rc_cache == NULL) {
-		errp("Failed to allocate refcount cache\n");
+		tcmu_err("Failed to allocate refcount cache\n");
 		goto fail;
 	}
-	dbgp("s->rc_cache = %p\n", s->rc_cache);
+	tcmu_dbg("s->rc_cache = %p\n", s->rc_cache);
 
 	if (qcow2_setup_backing_file(bdev, &header) == -1)
 		goto fail;
@@ -692,7 +692,7 @@ static int qcow2_image_open(struct bdev *bdev, int dirfd, const char *pathname, 
 
 	s->block_alloc = qcow2_block_alloc;
 	s->set_refcount = qcow2_set_refcount;
-	dbgp("%d: %s\n", bdev->fd, pathname);
+	tcmu_dbg("%d: %s\n", bdev->fd, pathname);
 	return 0;
 fail:
 	close(bdev->fd);
@@ -742,7 +742,7 @@ static uint64_t *l2_cache_lookup(struct qcow_state *s, uint64_t l2_offset)
 				}
 			}
 			l2_table = s->l2_cache + (i << s->l2_bits);
-			dbgp("%s: l2 hit %llx at index %d\n", __func__, l2_table, i);
+			tcmu_dbg("%s: l2 hit %llx at index %d\n", __func__, l2_table, i);
 			return l2_table;
 		}
 	}
@@ -765,7 +765,7 @@ static uint64_t *l2_cache_lookup(struct qcow_state *s, uint64_t l2_offset)
 
 static uint64_t qcow_cluster_alloc(struct qcow_state *s)
 {
-	dbgp("%s\n", __func__);
+	tcmu_dbg("%s\n", __func__);
 	return s->block_alloc(s, s->cluster_size);
 }
 
@@ -786,7 +786,7 @@ static uint64_t qcow_block_alloc(struct qcow_state *s, size_t size)
 
 static uint64_t l2_table_alloc(struct qcow_state *s)
 {
-	dbgp("%s\n", __func__);
+	tcmu_dbg("%s\n", __func__);
 	return s->block_alloc(s, s->l2_size * sizeof(uint64_t));
 }
 
@@ -794,7 +794,7 @@ static int l1_table_update(struct qcow_state *s, unsigned int l1_index, uint64_t
 {
 	ssize_t ret;
 
-	dbgp("%s: setting L1[%d] to %llx\n", __func__, l1_index, l2_offset);
+	tcmu_dbg("%s: setting L1[%d] to %llx\n", __func__, l1_index, l2_offset);
 	s->l1_table[l1_index] = htobe64(l2_offset);
 
 	ret = pwrite(s->fd,
@@ -803,7 +803,7 @@ static int l1_table_update(struct qcow_state *s, unsigned int l1_index, uint64_t
 		s->l1_table_offset + (l1_index * sizeof(uint64_t)));
 
 	if (ret != sizeof(uint64_t))
-		errp("%s: error, L1 writeback failed (%zd)\n", __func__, ret);
+		tcmu_err("%s: error, L1 writeback failed (%zd)\n", __func__, ret);
 
 	fdatasync(s->fd);
 	return ret;
@@ -934,7 +934,7 @@ static int rc_table_update(struct qcow_state *s, unsigned int rc_index, uint64_t
 {
 	ssize_t ret;
 
-	dbgp("%s: setting RC[%d] to %llx\n", __func__, rc_index, refblock_offset);
+	tcmu_dbg("%s: setting RC[%d] to %llx\n", __func__, rc_index, refblock_offset);
 	s->refcount_table[rc_index] = htobe64(refblock_offset);
 
 	ret = pwrite(s->fd,
@@ -943,7 +943,7 @@ static int rc_table_update(struct qcow_state *s, unsigned int rc_index, uint64_t
 		s->refcount_table_offset + (rc_index * sizeof(uint64_t)));
 
 	if (ret != sizeof(uint64_t))
-		errp("%s: error, RC writeback failed (%zd)\n", __func__, ret);
+		tcmu_err("%s: error, RC writeback failed (%zd)\n", __func__, ret);
 
 	fdatasync(s->fd);
 	return ret;
@@ -963,11 +963,11 @@ static int qcow2_set_refcount(struct qcow_state *s, uint64_t cluster_offset, uin
 	refblock_offset = be64toh(s->refcount_table[rc_index]);
 	refblock_index = (cluster_offset >> s->cluster_bits) & ((1 << refcount_bits) - 1);
 
-	dbgp("%s: rc[%d][%d] = %llx[%d] = %d\n", __func__, rc_index, refblock_index, refblock_offset, refblock_index, value);
+	tcmu_dbg("%s: rc[%d][%d] = %llx[%d] = %d\n", __func__, rc_index, refblock_index, refblock_offset, refblock_index, value);
 
 	if (!refblock_offset) {
 		if (!(refblock_offset = qcow_cluster_alloc(s))) {
-			errp("refblock allocation failure\n");
+			tcmu_err("refblock allocation failure\n");
 			return -1;
 		}
 		rc_table_update(s, rc_index, refblock_offset | s->cluster_copied);
@@ -976,7 +976,7 @@ static int qcow2_set_refcount(struct qcow_state *s, uint64_t cluster_offset, uin
 
 	refblock = rc_cache_lookup(s, refblock_offset);
 	if (!refblock) {
-		errp("refblock cache failure\n");
+		tcmu_err("refblock cache failure\n");
 		return -1;
 	}
 
@@ -985,7 +985,7 @@ static int qcow2_set_refcount(struct qcow_state *s, uint64_t cluster_offset, uin
 	/* for now this writes back the entire block */
 	ret = pwrite(s->fd, refblock, s->cluster_size, refblock_offset);
 	if (ret != s->cluster_size)
-		errp("%s: error, refblock writeback failed (%zd)\n", __func__, ret);
+		tcmu_err("%s: error, refblock writeback failed (%zd)\n", __func__, ret);
 	fdatasync(s->fd);
 	return ret;
 }
@@ -997,7 +997,7 @@ static uint64_t qcow2_block_alloc(struct qcow_state *s, size_t size)
 	uint64_t count;
 	int ret;
 
-	dbgp("  %s %zx\n", __func__, size);
+	tcmu_dbg("  %s %zx\n", __func__, size);
 
 	/* all allocations for qcow2 should be of the same size */
 	assert(size == s->cluster_size);
@@ -1007,17 +1007,17 @@ static uint64_t qcow2_block_alloc(struct qcow_state *s, size_t size)
 		if (count == 0) {
 			ret = fallocate(s->fd, FALLOC_FL_ZERO_RANGE, cluster, s->cluster_size);
 			if (ret) {
-				errp("fallocate failed: %m\n");
+				tcmu_err("fallocate failed: %m\n");
 				return 0;
 			}
 			s->first_free_cluster = cluster + s->cluster_size;
 			// this causes a nasty loop
 			// qcow2_set_refcount(s, cluster, 1);
-			dbgp("  allocating cluster %d\n", cluster / s->cluster_size);
+			tcmu_dbg("  allocating cluster %d\n", cluster / s->cluster_size);
 			return cluster;
 		}
 	}
-	errp("no more free clusters in image file\n");
+	tcmu_err("no more free clusters in image file\n");
 	return 0;
 }
 
@@ -1027,7 +1027,7 @@ static int l2_table_update(struct qcow_state *s,
 {
 	ssize_t ret;
 
-	dbgp("%s: setting %llx[%d] to %llx\n", __func__, l2_table_offset, l2_index, cluster_offset);
+	tcmu_dbg("%s: setting %llx[%d] to %llx\n", __func__, l2_table_offset, l2_index, cluster_offset);
 	l2_table[l2_index] = htobe64(cluster_offset);
 
 	ret = pwrite(s->fd,
@@ -1036,7 +1036,7 @@ static int l2_table_update(struct qcow_state *s,
 		l2_table_offset + (l2_index * sizeof(uint64_t)));
 
 	if (ret != sizeof(uint64_t))
-		errp("%s: error, L2 writeback failed (%zd)\n", __func__, ret);
+		tcmu_err("%s: error, L2 writeback failed (%zd)\n", __func__, ret);
 
 	fdatasync(s->fd);
 	return ret;
@@ -1105,15 +1105,15 @@ static uint64_t get_cluster_offset(struct qcow_state *s, const uint64_t offset, 
 	uint64_t *l2_table;
 	uint64_t cluster_offset;
 
-	dbgp("%s: %"PRIx64" %s\n", __func__, offset, allocate ? "write" : "read");
+	tcmu_dbg("%s: %"PRIx64" %s\n", __func__, offset, allocate ? "write" : "read");
 
 	l1_index = offset >> (s->l2_bits + s->cluster_bits);
 	l2_offset = be64toh(s->l1_table[l1_index]) & s->cluster_mask;
 	l2_index = (offset >> s->cluster_bits) & (s->l2_size - 1);
 	// TODO, check refcount on L2 table and handle CoW for metadata updates
-	dbgp("  l1_index = %d\n", l1_index);
-	dbgp("  l2_offset = %"PRIx64"\n", l2_offset);
-	dbgp("  l2_index = %d\n", l2_index);
+	tcmu_dbg("  l1_index = %d\n", l1_index);
+	tcmu_dbg("  l2_offset = %"PRIx64"\n", l2_offset);
+	tcmu_dbg("  l2_index = %d\n", l2_index);
 
 	if (!l2_offset) {
 		if (!allocate || !(l2_offset = l2_table_alloc(s)))
@@ -1127,8 +1127,8 @@ static uint64_t get_cluster_offset(struct qcow_state *s, const uint64_t offset, 
 		return 0;
 
 	cluster_offset = be64toh(l2_table[l2_index]); // & s->cluster_mask;
-	dbgp("  l2_table @ %p\n", l2_table);
-	dbgp("  cluster offset = %" PRIx64 "\n", cluster_offset);
+	tcmu_dbg("  l2_table @ %p\n", l2_table);
+	tcmu_dbg("  cluster offset = %" PRIx64 "\n", cluster_offset);
 
 	if (!cluster_offset) {
 		/* sector not allocated in image file */
@@ -1137,7 +1137,7 @@ static uint64_t get_cluster_offset(struct qcow_state *s, const uint64_t offset, 
 		l2_table_update(s, l2_table, l2_offset, l2_index, cluster_offset | s->cluster_copied);
 		s->set_refcount(s, cluster_offset, 1);
 	} else if ((cluster_offset & s->cluster_compressed) && allocate) {
-		errp("re-allocating compressed cluster for writing\n");
+		tcmu_err("re-allocating compressed cluster for writing\n");
 		/* reallocate a compressed cluster for writing */
 		if (decompress_cluster(s, cluster_offset) < 0)
 			return 0;
@@ -1148,7 +1148,7 @@ static uint64_t get_cluster_offset(struct qcow_state *s, const uint64_t offset, 
 		l2_table_update(s, l2_table, l2_offset, l2_index, cluster_offset | s->cluster_copied);
 		s->set_refcount(s, cluster_offset, 1);
 	} else if (!(cluster_offset & s->cluster_copied) && allocate) {
-		errp("re-allocating shared cluster for writing\n");
+		tcmu_err("re-allocating shared cluster for writing\n");
 		/* refcount > 1 (the copied bit means refcount == 1)
 		 * need to make a new copy if this is for a write */
 		uint64_t old_offset = cluster_offset & s->cluster_mask;
@@ -1168,7 +1168,7 @@ static uint64_t get_cluster_offset(struct qcow_state *s, const uint64_t offset, 
 		// TODO drop refcount on old cluster
 		goto out;
 	fail:
-		errp("CoW failed\n");
+		tcmu_err("CoW failed\n");
 		free(cow_buffer);
 		return 0;
 	}
@@ -1260,7 +1260,7 @@ static ssize_t qcow_preadv(struct bdev *bdev, struct iovec *iov, int iovcnt, off
 			iovec_memset(_iov, _cnt, 0, 512 * n);
 		} else if (cluster_offset & s->cluster_compressed) {
 			if (decompress_cluster(s, cluster_offset) < 0) {
-				errp("decompression failure\n");
+				tcmu_err("decompression failure\n");
 				return -1;
 			}
 			tcmu_memcpy_into_iovec(_iov, _cnt, s->cluster_cache + sector_index * 512, 512 * n);
@@ -1304,12 +1304,12 @@ static ssize_t qcow_pwritev(struct bdev *bdev, struct iovec *iov, int iovcnt, of
 
 		cluster_offset = get_cluster_offset(s, sector_num << 9, true);
 		if (!cluster_offset) {
-			errp("cluster not allocated for writes\n");
+			tcmu_err("cluster not allocated for writes\n");
 			return -1;
 		} else if (cluster_offset & QCOW_OFLAG_COMPRESSED) {
 			/* compressed clusters should be copied and inflated in
 			 * get_cluster_offset() with alloc=true */
-			errp("cluster decompression CoW failure\n");
+			tcmu_err("cluster decompression CoW failure\n");
 			return -1;
 		} else {
 			written = pwritev(bdev->fd, _iov, _cnt, cluster_offset + (sector_index * 512));
@@ -1345,7 +1345,7 @@ static int raw_probe(struct bdev *bdev, int dirfd, const char *pathname)
 {
 	struct stat st;
 
-	dbgp("%s\n", __func__);
+	tcmu_dbg("%s\n", __func__);
 
 	if (faccessat(dirfd, pathname, R_OK, AT_EACCESS) == -1)
 		return -1;
@@ -1360,7 +1360,7 @@ static int raw_probe(struct bdev *bdev, int dirfd, const char *pathname)
 static int raw_image_open(struct bdev *bdev, int dirfd, const char *pathname, int flags)
 {
 	bdev->fd = openat(dirfd, pathname, flags);
-	dbgp("%d: %s\n", bdev->fd, pathname);
+	tcmu_dbg("%d: %s\n", bdev->fd, pathname);
 	return bdev->fd;
 }
 
@@ -1423,13 +1423,13 @@ static int qcow_open(struct tcmu_device *dev)
 
 	bdev->block_size = tcmu_get_attribute(dev, "hw_block_size");
 	if (bdev->block_size < 0) {
-		errp("Could not get device block size\n");
+		tcmu_err("Could not get device block size\n");
 		goto err;
 	}
 
 	bdev->size = tcmu_get_device_size(dev);
 	if (bdev->size < 0) {
-		errp("Could not get device size\n");
+		tcmu_err("Could not get device size\n");
 		goto err;
 	}
 
@@ -1437,13 +1437,13 @@ static int qcow_open(struct tcmu_device *dev)
 
 	config = strchr(tcmu_get_dev_cfgstring(dev), '/');
 	if (!config) {
-		errp("no configuration found in cfgstring\n");
+		tcmu_err("no configuration found in cfgstring\n");
 		goto err;
 	}
 	config += 1; /* get past '/' */
 
-	dbgp("%s\n", tcmu_get_dev_cfgstring(dev));
-	dbgp("%s\n", config);
+	tcmu_dbg("%s\n", tcmu_get_dev_cfgstring(dev));
+	tcmu_dbg("%s\n", config);
 
 	if (bdev_open(bdev, AT_FDCWD, config, O_RDWR) == -1)
 		goto err;
@@ -1531,7 +1531,7 @@ static int qcow_handle_cmd(
 		while (remaining) {
 			ret = bdev->ops->preadv(bdev, iovec, iov_cnt, offset);
 			if (ret < 0) {
-				errp("read failed: %m\n");
+				tcmu_err("read failed: %m\n");
 				return set_medium_error(sense);
 			}
 			tcmu_seek_in_iovec(iovec, ret);
@@ -1552,7 +1552,7 @@ static int qcow_handle_cmd(
 		while (remaining) {
 			ret = bdev->ops->pwritev(bdev, iovec, iov_cnt, offset);
 			if (ret < 0) {
-				errp("writefailed: %m\n");
+				tcmu_err("writefailed: %m\n");
 				return set_medium_error(sense);
 			}
 			tcmu_seek_in_iovec(iovec, ret);
@@ -1562,7 +1562,7 @@ static int qcow_handle_cmd(
 	}
 	break;
 	default:
-		errp("unknown command %x\n", cdb[0]);
+		tcmu_err("unknown command %x\n", cdb[0]);
 		return TCMU_NOT_HANDLED;
 	}
 }

--- a/qcow.h
+++ b/qcow.h
@@ -2,6 +2,7 @@
 #define _QCOW_H_
 
 #include <stdint.h>
+#include "libtcmu_log.h"
 
 #define QCOW_MAGIC (('Q' << 24) | ('F' << 16) | ('I' << 8) | 0xfb)
 #define QCOW_VERSION 1

--- a/qcow2.h
+++ b/qcow2.h
@@ -44,6 +44,8 @@
 #ifndef BLOCK_QCOW2_H
 #define BLOCK_QCOW2_H
 
+#include "libtcmu_log.h"
+
 #define BDRV_SECTOR_BITS 9
 
 // until we remove

--- a/rbd.c
+++ b/rbd.c
@@ -57,10 +57,10 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 	tcmu_set_dev_private(dev, state);
 
 	config = strchr(tcmu_get_dev_cfgstring(dev), '/');
-	dbgp("tcmu_rbd_open config %s\n", config);
+	tcmu_dbg("tcmu_rbd_open config %s\n", config);
 
 	if (!config) {
-		errp("no configuration found in cfgstring\n");
+		tcmu_err("no configuration found in cfgstring\n");
 		ret = -EINVAL;
 		goto free_state;
 	}
@@ -68,7 +68,7 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 
 	block_size = tcmu_get_attribute(dev, "hw_block_size");
 	if (block_size < 0) {
-		errp("Could not get hw_block_size\n");
+		tcmu_err("Could not get hw_block_size\n");
 		ret = -EINVAL;
 		goto free_state;
 	}
@@ -76,7 +76,7 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 
 	size = tcmu_get_device_size(dev);
 	if (size < 0) {
-		errp("Could not get device size\n");
+		tcmu_err("Could not get device size\n");
 		goto free_state;
 	}
 	tcmu_set_dev_num_lbas(dev, size / block_size);
@@ -94,7 +94,7 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 
 	ret = rados_create(&state->cluster, NULL);
 	if (ret < 0) {
-		errp("error initializing\n");
+		tcmu_err("error initializing\n");
 		goto free_state;
 	}
 
@@ -104,31 +104,31 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 
 	ret = rados_connect(state->cluster);
 	if (ret < 0) {
-		errp("error connecting\n");
+		tcmu_err("error connecting\n");
 		goto rados_shutdown;
 	}
 
 	ret = rados_ioctx_create(state->cluster, pool, &state->io_ctx);
 	if (ret < 0) {
-		errp("error opening pool %s\n", pool);
+		tcmu_err("error opening pool %s\n", pool);
 		goto rados_destroy;
 	}
 
 	ret = rbd_open(state->io_ctx, name, &state->image, NULL);
 	if (ret < 0) {
-		errp("error reading header from %s\n", name);
+		tcmu_err("error reading header from %s\n", name);
 		goto rados_destroy;
 	}
 
 	ret = rbd_get_size(state->image, &rbd_size);
 	if(ret < 0) {
-		errp("error get rbd_size %s\n", name);
+		tcmu_err("error get rbd_size %s\n", name);
 		goto rados_destroy;
 	}
-	dbgp("rbd size %lld\n", rbd_size);
+	tcmu_dbg("rbd size %lld\n", rbd_size);
 
 	if(size != rbd_size) {
-		errp("device size and backing size disagree: "
+		tcmu_err("device size and backing size disagree: "
 		     "device %lld backing %lld\n",
 		     size,
 		     rbd_size);

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -30,6 +30,7 @@ extern "C" {
 #include <stdint.h>
 #include <sys/uio.h>
 #include "scsi_defs.h"
+#include "libtcmu_log.h"
 
 #include "libtcmu_common.h"
 

--- a/tcmu-synthesizer.c
+++ b/tcmu-synthesizer.c
@@ -29,27 +29,21 @@
 #include "libtcmu.h"
 #include "version.h"
 
-static int debug = false;
-
-static void syn_debug(const char *fmt, ...)
-{
-	if (debug) {
-		va_list va;
-
-		va_start(va, fmt);
-		vprintf(fmt, va);
-		va_end(va);
-	}
-}
-
 typedef struct {
 	GIOChannel *gio;
 	int watcher_id;
 } syn_dev_t;
 
+static void tcmu_debug_none(const char *fmt, ...)
+{
+	/* Nothing to do */
+}
+
+static void (*tcmu_debug)(const char *fmt, ...);
+
 static bool syn_check_config(const char *cfgstring, char **reason)
 {
-	syn_debug("syn check config\n");
+	tcmu_debug("syn check config\n");
 	if (strcmp(cfgstring, "syn/null")) {
 		asprintf(reason, "invalid option");
 		return false;
@@ -64,7 +58,7 @@ static int syn_handle_cmd(struct tcmu_device *dev, uint8_t *cdb,
 	uint8_t cmd;
 
 	cmd = cdb[0];
-	syn_debug("syn handle cmd %d\n", cmd);
+	tcmu_debug("syn handle cmd %d\n", cmd);
 
 	switch (cmd) {
 	case INQUIRY:
@@ -103,7 +97,7 @@ static int syn_handle_cmd(struct tcmu_device *dev, uint8_t *cdb,
 		return SAM_STAT_GOOD;
 
 	default:
-		syn_debug("unknown command %x\n", cdb[0]);
+		tcmu_debug("unknown command %x\n", cdb[0]);
 		return TCMU_NOT_HANDLED;
 	}
 }
@@ -116,7 +110,7 @@ static gboolean syn_dev_callback(GIOChannel *source,
 	struct tcmu_device *dev = data;
 	struct tcmulib_cmd *cmd;
 
-	syn_debug("dev fd cb\n");
+	tcmu_debug("dev fd cb\n");
 	tcmulib_processing_start(dev);
 
 	while ((cmd = tcmulib_get_next_command(dev)) != NULL) {
@@ -136,7 +130,7 @@ static int syn_added(struct tcmu_device *dev)
 {
 	syn_dev_t *s = g_new0(syn_dev_t, 1);
 
-	syn_debug("added %s\n", tcmu_get_dev_cfgstring(dev));
+	tcmu_debug("added %s\n", tcmu_get_dev_cfgstring(dev));
 	tcmu_set_dev_private(dev, s);
 	s->gio = g_io_channel_unix_new(tcmu_get_dev_fd(dev));
 	s->watcher_id = g_io_add_watch(s->gio, G_IO_IN,
@@ -147,7 +141,7 @@ static int syn_added(struct tcmu_device *dev)
 static void syn_removed(struct tcmu_device *dev)
 {
 	syn_dev_t *s = tcmu_get_dev_private(dev);
-	syn_debug("removed %s\n", tcmu_get_dev_cfgstring(dev));
+	tcmu_debug("removed %s\n", tcmu_get_dev_cfgstring(dev));
 	g_source_remove(s->watcher_id);
 	g_io_channel_unref(s->gio);
 	g_free(s);
@@ -170,19 +164,10 @@ gboolean tcmulib_callback(GIOChannel *source,
 {
 	struct tcmulib_context *ctx = data;
 
-	syn_debug("master fd ready\n");
+	tcmu_debug("master fd ready\n");
 	tcmulib_master_fd_ready(ctx);
 
 	return TRUE;
-}
-
-void syn_err(const char *fmt, ...)
-{
-	va_list va;
-
-	va_start(va, fmt);
-	vfprintf(stderr, fmt, va);
-	va_end(va);
 }
 
 static void usage(void) {
@@ -208,6 +193,9 @@ int main(int argc, char **argv)
 	GIOChannel *libtcmu_gio;
 	struct tcmulib_context *ctx;
 
+	tcmu_log_open_syslog(TCMU_SYNC, 0, 0);
+	tcmu_debug = tcmu_debug_none;
+
 	while (1) {
 		int c;
 		int option_index = 0;
@@ -219,7 +207,7 @@ int main(int argc, char **argv)
 
 		switch (c) {
 		case 'd':
-			debug = true;
+			tcmu_debug = tcmu_dbg;
 			break;
 		case 'V':
 			printf("tcmu-synthesizer %d.%d.%d\n",
@@ -234,9 +222,9 @@ int main(int argc, char **argv)
 		}
 	}
 
-	ctx = tcmulib_initialize(&syn_handler, 1, syn_err);
+	ctx = tcmulib_initialize(&syn_handler, 1);
 	if (!ctx) {
-		fprintf(stderr, "tcmulib_initialize failed\n");
+		tcmu_err("tcmulib_initialize failed\n");
 		exit(1);
 	}
 	tcmulib_register(ctx);
@@ -246,5 +234,6 @@ int main(int argc, char **argv)
 	loop = g_main_loop_new(NULL, FALSE);
 	g_main_loop_run(loop);
 	g_main_loop_unref(loop);
+	tcmu_log_close_syslog();
 	return 0;
 }

--- a/tcmu.conf
+++ b/tcmu.conf
@@ -1,0 +1,11 @@
+# Master TCMU configuration file
+
+# Logging Controls
+# There are 4 logging levels supported:
+#    1: ERROR
+#    2: WARNING
+#    3: INFO
+#    4: DEBUG
+# And the default logging level is 2, if you want to change the
+# default level, uncomment it and set your level number:
+#log_level = 2


### PR DESCRIPTION
This patch series add logger and system config support.

The logger feature:
For now the log messages will output to system logger. And the non-block feature will be supported in the later series.

The system config feature:
For now it will support 3 type options: int, string and boolean. If the options has been changed in config file, the tcmu-runner, consumer and tcmu-synthesizer daemons should be restarted.
And the dynamic reloading feature will be added later.

Thanks.
BRs

