### PR TITLE
Support CMake 2.8 instead of CMake 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required (VERSION 3.0 FATAL_ERROR)
-project (tcmu-runner VERSION 1.1.3 LANGUAGES C)
-
+cmake_minimum_required (VERSION 2.8 FATAL_ERROR)
+project (tcmu-runner C)
+set(VERSION 1.1.3)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=c99")
 
 include(GNUInstallDirs)

--- a/main.c
+++ b/main.c
@@ -822,10 +822,7 @@ int main(int argc, char **argv)
 			debug = true;
 			break;
 		case 'V':
-			printf("tcmu-runner %d.%d.%d\n",
-			       TCMUR_VERSION_MAJOR,
-			       TCMUR_VERSION_MINOR,
-			       TCMUR_VERSION_PATCHLEVEL);
+			printf("tcmu-runner %s\n", TCMUR_VERSION);
 			exit(1);
 		default:
 		case 'h':

--- a/tcmu-synthesizer.c
+++ b/tcmu-synthesizer.c
@@ -222,10 +222,7 @@ int main(int argc, char **argv)
 			debug = true;
 			break;
 		case 'V':
-			printf("tcmu-synthesizer %d.%d.%d\n",
-			       TCMUR_VERSION_MAJOR,
-			       TCMUR_VERSION_MINOR,
-			       TCMUR_VERSION_PATCHLEVEL);
+			printf("tcmu-synthesizer %s\n", TCMUR_VERSION);
 			exit(1);
 		default:
 		case 'h':

--- a/version.h.in
+++ b/version.h.in
@@ -1,6 +1,4 @@
 
-#define TCMUR_VERSION_MAJOR @tcmu-runner_VERSION_MAJOR@
-#define TCMUR_VERSION_MINOR @tcmu-runner_VERSION_MINOR@
-#define TCMUR_VERSION_PATCHLEVEL @tcmu-runner_VERSION_PATCH@
+#define TCMUR_VERSION "@VERSION@"
 
 #define DEFAULT_HANDLER_PATH "@tcmu-runner_HANDLER_PATH@"


### PR DESCRIPTION
RHEL 7 only supports CMake 2.8, so ensure tcmu-runner can
be built within a RHEL 7 build environment.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>