### PR TITLE
asynchronous rbd handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(tcmu
   tcmuhandler-generated.c
   libtcmu_log.c
   libtcmu_config.c
+  libtcmu_store.c
   )
 set_target_properties(tcmu
   PROPERTIES
@@ -67,6 +68,7 @@ add_library(tcmu_static
   tcmuhandler-generated.c
   libtcmu_log.c
   libtcmu_config.c
+  libtcmu_store.c
   )
 target_include_directories(tcmu_static
   PUBLIC ${LIBNL_INCLUDE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(tcmu
   libtcmu_log.c
   libtcmu_config.c
   libtcmu_store.c
+  libtcmu_aio.c
   )
 set_target_properties(tcmu
   PROPERTIES
@@ -69,6 +70,7 @@ add_library(tcmu_static
   libtcmu_log.c
   libtcmu_config.c
   libtcmu_store.c
+  libtcmu_aio.c
   )
 target_include_directories(tcmu_static
   PUBLIC ${LIBNL_INCLUDE_DIR}

--- a/api.c
+++ b/api.c
@@ -908,13 +908,8 @@ int tcmu_emulate_start_stop(struct tcmu_device *dev, uint8_t *cdb,
 
 int tcmu_emulate_write_verify(struct tcmu_device *dev,
 			      struct tcmulib_cmd *tcmulib_cmd,
-			      ssize_t (*read)(struct tcmu_device *,
-					      struct iovec *, size_t, off_t),
-			      ssize_t (*write)(struct tcmu_device *,
-					       struct iovec *, size_t, off_t),
-			      struct iovec *iovec,
-			      size_t iov_cnt,
-			      off_t offset)
+			      store_rw_t read, store_rw_t write,
+			      struct iovec *iovec, size_t iov_cnt, off_t offset)
 {
 	struct iovec iov;
 	uint32_t cmp_offset;

--- a/api.c
+++ b/api.c
@@ -921,7 +921,7 @@ int tcmu_emulate_write_verify(struct tcmu_device *dev,
 	int ret;
 
 	while (remaining) {
-		ret = write(dev, iovec, iov_cnt, offset);
+		ret = write(dev, tcmulib_cmd, iovec, iov_cnt, offset);
 		if (ret < 0) {
 			tcmu_err("write failed\n");
 			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
@@ -938,7 +938,7 @@ int tcmu_emulate_write_verify(struct tcmu_device *dev,
 
 		iov.iov_len = len;
 
-		ret = read(dev, &iov, iov_cnt, offset);
+		ret = read(dev, tcmulib_cmd, &iov, iov_cnt, offset);
 		if (ret != len) {
 			tcmu_err("read failed\n");
 			free(iov.iov_base);

--- a/glfs.c
+++ b/glfs.c
@@ -539,23 +539,26 @@ static void tcmu_glfs_close(struct tcmu_device *dev)
 	free(gfsp);
 }
 
-static ssize_t tcmu_glfs_read(struct tcmu_device *dev, struct iovec *iov,
-			      size_t iov_cnt, off_t offset)
+static ssize_t tcmu_glfs_read(struct tcmu_device *dev,
+			      struct tcmulib_cmd *tcmulib_cmd,
+			      struct iovec *iov, size_t iov_cnt, off_t offset)
 {
         struct glfs_state *state = tcmu_get_dev_private(dev);
 
         return glfs_preadv(state->gfd, iov, iov_cnt, offset, SEEK_SET);
 }
 
-static ssize_t tcmu_glfs_write(struct tcmu_device *dev, struct iovec *iov,
-			       size_t iov_cnt, off_t offset)
+static ssize_t tcmu_glfs_write(struct tcmu_device *dev,
+			       struct tcmulib_cmd *tcmulib_cmd,
+			       struct iovec *iov, size_t iov_cnt, off_t offset)
 {
 	struct glfs_state *state = tcmu_get_dev_private(dev);
 
         return glfs_pwritev(state->gfd, iov, iov_cnt, offset, ALLOWED_BSOFLAGS);
 }
 
-static int tcmu_glfs_flush(struct tcmu_device *dev)
+static int tcmu_glfs_flush(struct tcmu_device *dev,
+			   struct tcmulib_cmd *tcmulib_cmd)
 {
 	struct glfs_state *state = tcmu_get_dev_private(dev);
 

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -35,6 +35,7 @@
 #include <libnl3/netlink/genl/ctrl.h>
 
 #include "libtcmu.h"
+#include "libtcmu_aio.h"
 #include "libtcmu_log.h"
 #include "libtcmu_priv.h"
 #include "libtcmu_store.h"
@@ -159,27 +160,6 @@ static void teardown_netlink(struct nl_sock *sock)
 	nl_socket_free(sock);
 }
 
-static void cancel_thread(pthread_t thread)
-{
-	void *join_retval;
-	int ret;
-
-	ret = pthread_cancel(thread);
-	if (ret) {
-		tcmu_err("pthread_cancel failed with value %d\n", ret);
-		return;
-	}
-
-	ret = pthread_join(thread, &join_retval);
-	if (ret) {
-		tcmu_err("pthread_join failed with value %d\n", ret);
-		return;
-	}
-
-	if (join_retval != PTHREAD_CANCELED)
-		tcmu_err("unexpected join retval: %p\n", join_retval);
-}
-
 static struct tcmulib_handler *find_handler(struct tcmulib_context *ctx,
 					    char *cfgstring)
 {
@@ -198,23 +178,7 @@ static struct tcmulib_handler *find_handler(struct tcmulib_context *ctx,
 	return NULL;
 }
 
-/*
- * convert errno to closest possible SAM status code.
- * (add more conversions as required)
- */
-static int errno_to_sam_status(int rc, uint8_t *sense)
-{
-	if (rc == -ENOMEM) {
-		return SAM_STAT_TASK_SET_FULL;
-	} else if (rc == -EIO) {
-		return tcmu_set_sense_data(sense, MEDIUM_ERROR,
-					   ASC_READ_ERROR, NULL);
-	} else if (rc < 0) {
-		return TCMU_NOT_HANDLED;
-	} else {
-		return SAM_STAT_GOOD;
-	}
-}
+
 
 static void cmdproc_thread_cleanup(void *arg)
 {
@@ -294,18 +258,6 @@ static bool command_is_store_call(uint8_t cmd)
 	}
 }
 
-static int generic_handle_cmd(struct tcmu_device *dev,
-			      struct tcmulib_cmd *tcmulib_cmd)
-{
-
-	uint8_t cmd = (tcmulib_cmd->cdb)[0];
-
-	if (command_is_store_call(cmd))
-		return call_store(dev, tcmulib_cmd, cmd);
-	else
-		return generic_cmd(dev, tcmulib_cmd, cmd);
-}
-
 #define CDB_TO_BUF_SIZE(bytes) ((bytes) * 3 + 1)
 #define CDB_FIX_BYTES 64 /* 64 bytes for default */
 #define CDB_FIX_SIZE CDB_TO_BUF_SIZE(CDB_FIX_BYTES)
@@ -363,258 +315,30 @@ static void tcmu_cdb_debug_info(const struct tcmulib_cmd *cmd)
 		free(buf);
 }
 
-static void _cleanup_mutex_lock(void *arg)
+int generic_handle_cmd(struct tcmu_device *dev,
+		       struct tcmulib_cmd *tcmulib_cmd)
 {
-	pthread_mutex_unlock(arg);
-}
 
-static void _cleanup_spin_lock(void *arg)
-{
-	pthread_spin_unlock(arg);
-}
+	uint8_t cmd = (tcmulib_cmd->cdb)[0];
 
-static void tcmulib_track_aio_request_start(struct tcmu_device *dev)
-{
-	struct tcmu_track_aio *aio_track = &dev->track_queue;
-
-	pthread_cleanup_push(_cleanup_spin_lock, (void *)&aio_track->track_lock);
-	pthread_spin_lock(&aio_track->track_lock);
-
-	++aio_track->tracked_aio_ops;
-
-	pthread_spin_unlock(&aio_track->track_lock);
-	pthread_cleanup_pop(0);
-}
-
-static void tcmulib_track_aio_request_finish(struct tcmu_device *dev, int *is_idle)
-{
-	struct tcmu_track_aio *aio_track = &dev->track_queue;
-
-	pthread_cleanup_push(_cleanup_spin_lock, (void *)&aio_track->track_lock);
-	pthread_spin_lock(&aio_track->track_lock);
-
-	assert(aio_track->tracked_aio_ops > 0);
-
-	--aio_track->tracked_aio_ops;
-	if (is_idle) {
-		*is_idle = (aio_track->tracked_aio_ops == 0) ? 1 : 0;
-	}
-
-	pthread_spin_unlock(&aio_track->track_lock);
-	pthread_cleanup_pop(0);
-
-}
-
-static void _untrack_in_flight_io(void *arg)
-{
-	int wakeup;
-	tcmulib_track_aio_request_finish(arg, &wakeup);
-	if (wakeup) {
-		tcmulib_processing_complete(arg);
-	}
-}
-
-static int invokecmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
-{
-	struct tcmulib_handler *handler = tcmu_get_dev_handler(dev);
-	struct tcmur_handler *r_handler = handler->hm_private;
-
-	int (*func)(struct tcmu_device *, struct tcmulib_cmd *) =
-		(r_handler->write || r_handler->read || r_handler->flush) ?
-		generic_handle_cmd : r_handler->handle_cmd;
-	return func(dev, cmd);
-}
-
-static void *io_work_queue(void *arg)
-{
-	struct tcmu_device *dev = arg;
-	struct tcmu_io_queue *io_wq = &dev->work_queue;
-
-	while (1) {
-		int ret;
-		struct tcmu_io_entry *io_entry;
-
-		pthread_cleanup_push(_cleanup_mutex_lock, &io_wq->io_lock);
-		pthread_mutex_lock(&io_wq->io_lock);
-
-		while (list_empty(&io_wq->io_queue)) {
-			pthread_cond_wait(&io_wq->io_cond,
-					  &io_wq->io_lock);
-		}
-
-		io_entry = list_first_entry(&io_wq->io_queue,
-					    struct tcmu_io_entry, entry);
-		list_del(&io_entry->entry);
-
-		pthread_mutex_unlock(&io_wq->io_lock);
-		pthread_cleanup_pop(0);
-
-		/* kick start I/O request */
-		pthread_cleanup_push(_untrack_in_flight_io, dev);
-		tcmulib_track_aio_request_start(dev);
-
-		ret = invokecmd(dev, io_entry->cmd);
-		tcmulib_command_complete(dev, io_entry->cmd, ret);
-
-		pthread_cleanup_pop(1); /* untrack aio */
-		free(io_entry);
-	}
-
-	return NULL;
-}
-
-static int aio_schedule(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
-{
-	struct tcmu_io_entry *io_entry;
-	uint8_t *sense = cmd->sense_buf;
-	struct tcmu_io_queue *io_wq = &dev->work_queue;
-
-	io_entry = malloc(sizeof(*io_entry));
-	if (!io_entry) {
-		return errno_to_sam_status(-ENOMEM, sense);
-	}
-
-	io_entry->cmd = cmd;
-	list_node_init(&io_entry->entry);
-
-	/* cleanup push/pop not _really_ required here atm */
-	pthread_cleanup_push(_cleanup_mutex_lock, &io_wq->io_lock);
-	pthread_mutex_lock(&io_wq->io_lock);
-
-	list_add_tail(&io_wq->io_queue, &io_entry->entry);
-	pthread_cond_signal(&io_wq->io_cond); // TODO: conditional
-
-	pthread_mutex_unlock(&io_wq->io_lock);
-	pthread_cleanup_pop(0);
-
-	return TCMU_ASYNC_HANDLED;
-}
-
-static int setup_io_work_queue(struct tcmu_device *dev)
-{
-	int ret;
-	struct tcmu_io_queue *io_wq = &dev->work_queue;
-
-	list_head_init(&io_wq->io_queue);
-
-	ret = pthread_mutex_init(&io_wq->io_lock, NULL);
-	if (ret < 0) {
-		goto out;
-	}
-	ret = pthread_cond_init(&io_wq->io_cond, NULL);
-	if (ret < 0) {
-		goto cleanup_lock;
-	}
-
-	// TODO: >1 worker threads (per device via config)
-	ret = pthread_create(&io_wq->io_wq_thread, NULL, io_work_queue, dev);
-	if (ret < 0) {
-		goto cleanup_cond;
-	}
-
-	return 0;
-
-cleanup_cond:
-	pthread_cond_destroy(&io_wq->io_cond);
-cleanup_lock:
-	pthread_mutex_destroy(&io_wq->io_lock);
-out:
-	return ret;
-}
-
-static void cleanup_io_work_queue(struct tcmu_device *dev,
-				  bool cancel)
-{
-	int ret;
-	struct tcmu_io_queue *io_wq = &dev->work_queue;
-
-	if (cancel) {
-		cancel_thread(io_wq->io_wq_thread);
-	}
-
-	/*
-	 * Note that there's no need to drain ->io_queue at this point
-	 * as it _should_ be empty (target layer would call this path
-	 * when no commands are running - thanks Mike).
-	 *
-	 * Out of tree handlers which do not use the aio code are not
-	 * supported in this path.
-	 */
-
-	ret = pthread_mutex_destroy(&io_wq->io_lock);
-	if (ret != 0) {
-		tcmu_err("failed to destroy io workqueue lock\n");
-	}
-
-	ret = pthread_cond_destroy(&io_wq->io_cond);
-	if (ret != 0) {
-		tcmu_err("failed to destroy io workqueue cond\n");
-	}
-}
-
-static int setup_aio_tracking(struct tcmu_device *dev)
-{
-	int ret;
-	struct tcmu_track_aio *aio_track = &dev->track_queue;
-
-	aio_track->tracked_aio_ops = 0;
-	ret = pthread_spin_init(&aio_track->track_lock, 0);
-	if (ret < 0) {
-		return ret;
-	}
-
-	return 0;
-}
-
-static void cleanup_aio_tracking(struct tcmu_device *dev)
-{
-	int ret;
-	struct tcmu_track_aio *aio_track = &dev->track_queue;
-
-	assert(aio_track->tracked_aio_ops == 0);
-
-	ret = pthread_spin_destroy(&aio_track->track_lock);
-	if (ret < 0) {
-		tcmu_err("failes to destroy track lock\n");
-	}
-}
-
-static void async_call_command(struct tcmu_device *dev,
-			       struct tcmulib_cmd *cmd)
-{
-	int ret;
-	struct tcmulib_handler *handler = tcmu_get_dev_handler(dev);
-	struct tcmur_handler *r_handler = handler->hm_private;
-
-	if (r_handler->aio_supported) {
-		ret = invokecmd(dev, cmd);
-	} else {
-		ret = aio_schedule(dev, cmd);
-	}
-
-	/*
-	 * command (processing) completion is done when one of the
-	 * following scenario occurs:
-	 *  - synchronous handler:
-	 *	only if aio_schedule() returns an error
-	 *  - asynchronous handler:
-	 *	on an error or if the command was not asynchronously
-	 *	handled (see generic_handle_cmd(), non store callouts)
-	 */
-	if (ret != TCMU_ASYNC_HANDLED) {
-		tcmulib_command_complete(dev, cmd, ret);
-		tcmulib_processing_complete(dev);
-	}
+	if (command_is_store_call(cmd))
+		return call_store(dev, tcmulib_cmd, cmd);
+	else
+		return generic_cmd(dev, tcmulib_cmd, cmd);
 }
 
 static void *tcmu_cmdproc_thread(void *arg)
 {
+        int ret;
 	struct tcmu_device *dev = arg;
+	struct tcmulib_handler *handler = tcmu_get_dev_handler(dev);
+	struct tcmur_handler *r_handler = handler->hm_private;
 	struct pollfd pfd;
 
 	pthread_cleanup_push(cmdproc_thread_cleanup, dev);
 
 	while (1) {
+                int completed = 0;
 		struct tcmulib_cmd *cmd;
 
 		tcmulib_processing_start(dev);
@@ -623,9 +347,26 @@ static void *tcmu_cmdproc_thread(void *arg)
 			if (tcmu_get_log_level() == TCMU_LOG_DEBUG)
 				tcmu_cdb_debug_info(cmd);
 
-			/* call async command */
-			async_call_command(dev, cmd);
+			int (*func)(struct tcmu_device *, struct tcmulib_cmd *) =
+				(r_handler->write || r_handler->read || r_handler->flush) ?
+				generic_handle_cmd : r_handler->handle_cmd;
+			ret = func(dev, cmd);
+
+			/*
+			 * command (processing) completion is called in the following
+			 * scenarios:
+			 *   - handle_cmd: synchronous handlers
+			 *   - generic_handle_cmd: non-store calls (see generic_cmd())
+			 *			   and on errors when calling store.
+			 */
+			if (ret != TCMU_ASYNC_HANDLED) {
+				completed = 1;
+				tcmulib_command_complete(dev, cmd, ret);
+			}
 		}
+
+		if (completed)
+			tcmulib_processing_complete(dev);
 
 		pfd.fd = tcmu_get_dev_fd(dev);
 		pfd.events = POLLIN;
@@ -765,9 +506,15 @@ static int add_device(struct tcmulib_context *ctx,
 		goto err_munmap;
 	}
 
+	ret = pthread_mutex_init(&dev->caw_lock, NULL);
+	if (ret < 0) {
+		tcmu_err("failed to initialize caw lock\n");
+		goto cleanup_lock;
+	}
+
 	ret = setup_io_work_queue(dev);
 	if (ret < 0) {
-		goto cleanup_lock;
+		goto cleanup_caw_lock;
 	}
 
 	ret = setup_aio_tracking(dev);
@@ -793,6 +540,8 @@ cleanup_aio_tracking:
 	cleanup_aio_tracking(dev);
 cleanup_io_work_queue:
 	cleanup_io_work_queue(dev, true);
+cleanup_caw_lock:
+	pthread_mutex_destroy(&dev->caw_lock);
 cleanup_lock:
 	pthread_spin_destroy(&dev->lock);
 err_munmap:
@@ -871,6 +620,11 @@ static void remove_device(struct tcmulib_context *ctx,
 	if (ret < 0) {
 		tcmu_err("could not cleanup mailbox lock %s: %d\n", dev_name, errno);
 	}
+
+	ret = pthread_mutex_destroy(&dev->caw_lock);
+	if (ret < 0)
+		tcmu_err("could not cleanup caw lock %s: %d\n", dev_name, errno);
+
 	free(dev);
 }
 
@@ -1233,6 +987,37 @@ int tcmulib_start_cmdproc_thread(struct tcmu_device *dev)
 	return 0;
 }
 
+void _cleanup_mutex_lock(void *arg)
+{
+	pthread_mutex_unlock(arg);
+}
+
+void _cleanup_spin_lock(void *arg)
+{
+	pthread_spin_unlock(arg);
+}
+
+void cancel_thread(pthread_t thread)
+{
+	void *join_retval;
+	int ret;
+
+	ret = pthread_cancel(thread);
+	if (ret) {
+		tcmu_err("pthread_cancel failed with value %d\n", ret);
+		return;
+	}
+
+	ret = pthread_join(thread, &join_retval);
+	if (ret) {
+		tcmu_err("pthread_join failed with value %d\n", ret);
+		return;
+	}
+
+	if (join_retval != PTHREAD_CANCELED)
+		tcmu_err("unexpected join retval: %p\n", join_retval);
+}
+
 void tcmulib_cleanup_cmdproc_thread(struct tcmu_device *dev)
 {
 	struct tcmu_thread *thread;
@@ -1262,5 +1047,23 @@ void tcmulib_cleanup_all_cmdproc_threads()
 	struct tcmu_thread *thread;
 	darray_foreach(thread, g_threads) {
 		cancel_thread(thread->thread_id);
+	}
+}
+
+/*
+ * convert errno to closest possible SAM status code.
+ * (add more conversions as required)
+ */
+int errno_to_sam_status(int rc, uint8_t *sense)
+{
+	if (rc == -ENOMEM) {
+		return SAM_STAT_TASK_SET_FULL;
+	} else if (rc == -EIO) {
+		return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+					   ASC_READ_ERROR, NULL);
+	} else if (rc < 0) {
+		return TCMU_NOT_HANDLED;
+	} else {
+		return SAM_STAT_GOOD;
 	}
 }

--- a/libtcmu_aio.c
+++ b/libtcmu_aio.c
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2017, Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <assert.h>
+#include <stdint.h>
+#include <pthread.h>
+
+#include "libtcmu.h"
+#include "libtcmu_priv.h"
+#include "libtcmu_aio.h"
+#include "tcmu-runner.h"
+
+void track_aio_request_start(struct tcmu_device *dev)
+{
+	struct tcmu_track_aio *aio_track = &dev->track_queue;
+
+	pthread_cleanup_push(_cleanup_spin_lock, (void *)&aio_track->track_lock);
+	pthread_spin_lock(&aio_track->track_lock);
+
+	++aio_track->tracked_aio_ops;
+
+	pthread_spin_unlock(&aio_track->track_lock);
+	pthread_cleanup_pop(0);
+}
+
+void track_aio_request_finish(struct tcmu_device *dev, int *is_idle)
+{
+	struct tcmu_track_aio *aio_track = &dev->track_queue;
+
+	pthread_cleanup_push(_cleanup_spin_lock, (void *)&aio_track->track_lock);
+	pthread_spin_lock(&aio_track->track_lock);
+
+	assert(aio_track->tracked_aio_ops > 0);
+
+	--aio_track->tracked_aio_ops;
+	if (is_idle) {
+		*is_idle = (aio_track->tracked_aio_ops == 0) ? 1 : 0;
+	}
+
+	pthread_spin_unlock(&aio_track->track_lock);
+	pthread_cleanup_pop(0);
+}
+
+static void tcmu_callout_finished(struct tcmu_device *dev,
+				  struct tcmulib_cmd *cmd, int ret)
+{
+	cmd->callout_cbk(dev, cmd, ret);
+}
+
+/*
+ * This deals with return values from sync and async store handlers.
+ * Possible return values:
+ *
+ * 0: success from sync store handler
+ * -errno: failure from [a]sync store handler
+ * TCMU_ASYNC_HANDLED: command async handled
+ * TCMU_NOT_HANDLED: unhandled command (from command passthru)
+ */
+static int call_stub_exec(struct tcmu_device *dev,
+			  struct tcmulib_cmd *cmd,
+			  struct tcmu_call_stub *stub, bool is_async)
+{
+	ssize_t ret;
+	ssize_t requested;
+	int err = SAM_STAT_GOOD;
+	uint8_t *sense_buf = cmd->sense_buf;
+
+	switch(stub->sop) {
+	case TCMU_STORE_OP_READ:
+	case TCMU_STORE_OP_WRITE:
+		requested = tcmu_iovec_length(stub->u.rw.iov, stub->u.rw.iov_cnt);
+		ret  = stub->u.rw.exec(dev, stub->u.rw.iov,
+				       stub->u.rw.iov_cnt, stub->u.rw.off);
+		if (!is_async) {
+			if (ret != requested)
+				ret = -EIO;
+			else
+				ret = 0;
+		}
+
+		break;
+	case TCMU_STORE_OP_FLUSH:
+		ret = (ssize_t) stub->u.flush.exec(dev);
+		break;
+	case TCMU_STORE_OP_HANDLE_CMD:
+		ret = (ssize_t) stub->u.handle_cmd.exec(dev, cmd);
+		break;
+	default:
+		tcmu_err("unhandled store operation\n");
+		assert(0 == "unhandled store operation");
+	}
+
+	if (ret < 0) {
+		if (ret == TCMU_ASYNC_HANDLED || ret == TCMU_NOT_HANDLED)
+			err = ret;
+		else
+			err = errno_to_sam_status(ret, sense_buf);
+	}
+
+	if (!is_async)
+		tcmu_callout_finished(dev, cmd, err);
+	return err;
+}
+
+static void _cleanup_io_work(void *arg)
+{
+	free(arg);
+}
+
+static void *io_work_queue(void *arg)
+{
+	struct tcmu_device *dev = arg;
+	struct tcmu_io_queue *io_wq = &dev->work_queue;
+
+	while (1) {
+		struct tcmu_io_entry *io_entry;
+		struct tcmulib_cmd *cmd;
+
+		pthread_cleanup_push(_cleanup_mutex_lock, &io_wq->io_lock);
+		pthread_mutex_lock(&io_wq->io_lock);
+
+		while (list_empty(&io_wq->io_queue)) {
+			pthread_cond_wait(&io_wq->io_cond,
+					  &io_wq->io_lock);
+		}
+
+		io_entry = list_first_entry(&io_wq->io_queue,
+					    struct tcmu_io_entry, entry);
+		list_del(&io_entry->entry);
+
+		pthread_mutex_unlock(&io_wq->io_lock);
+		pthread_cleanup_pop(0);
+
+		/* kick start I/O request */
+		cmd = io_entry->cmd;
+		pthread_cleanup_push(_cleanup_io_work, io_entry);
+
+		(void) call_stub_exec(io_entry->dev, cmd, &io_entry->stub,
+				      false);
+		pthread_cleanup_pop(1); /* cleanup io_entry */
+	}
+
+	return NULL;
+}
+
+static int aio_schedule(struct tcmu_device *dev,
+			struct tcmulib_cmd *cmd,
+			struct tcmu_call_stub *stub)
+{
+	struct tcmu_io_entry *io_entry;
+	uint8_t *sense = cmd->sense_buf;
+	struct tcmu_io_queue *io_wq = &dev->work_queue;
+
+	io_entry = malloc(sizeof(*io_entry));
+	if (!io_entry) {
+		return errno_to_sam_status(-ENOMEM, sense);
+	}
+
+	io_entry->dev = dev;
+	io_entry->cmd = cmd;
+	memcpy(&io_entry->stub, stub, sizeof(*stub));
+	list_node_init(&io_entry->entry);
+
+	/* cleanup push/pop not _really_ required here atm */
+	pthread_cleanup_push(_cleanup_mutex_lock, &io_wq->io_lock);
+	pthread_mutex_lock(&io_wq->io_lock);
+
+	list_add_tail(&io_wq->io_queue, &io_entry->entry);
+	pthread_cond_signal(&io_wq->io_cond); // TODO: conditional
+
+	pthread_mutex_unlock(&io_wq->io_lock);
+	pthread_cleanup_pop(0);
+
+	return TCMU_ASYNC_HANDLED;
+}
+
+/* execute a given call stub asynchronously */
+int async_call_command(struct tcmu_device *dev,
+		       struct tcmulib_cmd *cmd,
+		       struct tcmu_call_stub *stub)
+{
+	int ret;
+	struct tcmulib_handler *handler = tcmu_get_dev_handler(dev);
+	struct tcmur_handler *r_handler = handler->hm_private;
+
+	cmd->callout_cbk = stub->callout_cbk;
+
+	if (r_handler->aio_supported) {
+		ret = call_stub_exec(dev, cmd, stub, true);
+	} else {
+		ret = aio_schedule(dev, cmd, stub);
+	}
+
+	return ret;
+}
+
+int setup_aio_tracking(struct tcmu_device *dev)
+{
+	int ret;
+	struct tcmu_track_aio *aio_track = &dev->track_queue;
+
+	aio_track->tracked_aio_ops = 0;
+	ret = pthread_spin_init(&aio_track->track_lock, 0);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+void cleanup_aio_tracking(struct tcmu_device *dev)
+{
+	int ret;
+	struct tcmu_track_aio *aio_track = &dev->track_queue;
+
+	assert(aio_track->tracked_aio_ops == 0);
+
+	ret = pthread_spin_destroy(&aio_track->track_lock);
+	if (ret < 0) {
+		tcmu_err("failed to destroy track lock\n");
+	}
+}
+
+int setup_io_work_queue(struct tcmu_device *dev)
+{
+	int ret;
+	struct tcmu_io_queue *io_wq = &dev->work_queue;
+
+	list_head_init(&io_wq->io_queue);
+
+	ret = pthread_mutex_init(&io_wq->io_lock, NULL);
+	if (ret < 0) {
+		goto out;
+	}
+	ret = pthread_cond_init(&io_wq->io_cond, NULL);
+	if (ret < 0) {
+		goto cleanup_lock;
+	}
+
+	// TODO: >1 worker threads (per device via config)
+	ret = pthread_create(&io_wq->io_wq_thread, NULL, io_work_queue, dev);
+	if (ret < 0) {
+		goto cleanup_cond;
+	}
+
+	return 0;
+
+cleanup_cond:
+	pthread_cond_destroy(&io_wq->io_cond);
+cleanup_lock:
+	pthread_mutex_destroy(&io_wq->io_lock);
+out:
+	return ret;
+}
+
+void cleanup_io_work_queue(struct tcmu_device *dev, bool cancel)
+{
+	int ret;
+	struct tcmu_io_queue *io_wq = &dev->work_queue;
+
+	if (cancel) {
+		cancel_thread(io_wq->io_wq_thread);
+	}
+
+	/*
+	 * Note that there's no need to drain ->io_queue at this point
+	 * as it _should_ be empty (target layer would call this path
+	 * when no commands are running - thanks Mike).
+	 *
+	 * Out of tree handlers which do not use the aio code are not
+	 * supported in this path.
+	 */
+
+	ret = pthread_mutex_destroy(&io_wq->io_lock);
+	if (ret != 0) {
+		tcmu_err("failed to destroy io workqueue lock\n");
+	}
+
+	ret = pthread_cond_destroy(&io_wq->io_cond);
+	if (ret != 0) {
+		tcmu_err("failed to destroy io workqueue cond\n");
+	}
+}

--- a/libtcmu_aio.c
+++ b/libtcmu_aio.c
@@ -56,8 +56,8 @@ void track_aio_request_finish(struct tcmu_device *dev, int *is_idle)
 	pthread_cleanup_pop(0);
 }
 
-static void tcmu_callout_finished(struct tcmu_device *dev,
-				  struct tcmulib_cmd *cmd, int ret)
+void tcmu_callout_finished(struct tcmu_device *dev,
+			   struct tcmulib_cmd *cmd, int ret)
 {
 	cmd->callout_cbk(dev, cmd, ret);
 }

--- a/libtcmu_aio.c
+++ b/libtcmu_aio.c
@@ -84,7 +84,7 @@ static int call_stub_exec(struct tcmu_device *dev,
 	case TCMU_STORE_OP_READ:
 	case TCMU_STORE_OP_WRITE:
 		requested = tcmu_iovec_length(stub->u.rw.iov, stub->u.rw.iov_cnt);
-		ret  = stub->u.rw.exec(dev, stub->u.rw.iov,
+		ret  = stub->u.rw.exec(dev, cmd, stub->u.rw.iov,
 				       stub->u.rw.iov_cnt, stub->u.rw.off);
 		if (!is_async) {
 			if (ret != requested)
@@ -95,7 +95,7 @@ static int call_stub_exec(struct tcmu_device *dev,
 
 		break;
 	case TCMU_STORE_OP_FLUSH:
-		ret = (ssize_t) stub->u.flush.exec(dev);
+		ret = (ssize_t) stub->u.flush.exec(dev, cmd);
 		break;
 	case TCMU_STORE_OP_HANDLE_CMD:
 		ret = (ssize_t) stub->u.handle_cmd.exec(dev, cmd);

--- a/libtcmu_aio.h
+++ b/libtcmu_aio.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017, Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __LIBTCMU_AIO_H
+#define __LIBTCMU_AIO_H
+
+struct tcmu_device;
+struct tcmulib_cmd;
+struct tcmu_call_stub;
+
+int setup_io_work_queue(struct tcmu_device *);
+void cleanup_io_work_queue(struct tcmu_device *, bool);
+
+int setup_aio_tracking(struct tcmu_device *);
+void cleanup_aio_tracking(struct tcmu_device *);
+
+int async_call_command(struct tcmu_device *,
+		       struct tcmulib_cmd *,
+		       struct tcmu_call_stub *);
+
+#endif /* __LIBTCMU_AIO_H */

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -35,8 +35,10 @@ struct tcmulib_cmd;
 
 #define SENSE_BUFFERSIZE 96
 
-typedef ssize_t (*store_rw_t)(struct tcmu_device *, struct iovec *, size_t, off_t);
-typedef int (*store_flush_t)(struct tcmu_device *);
+typedef ssize_t (*store_rw_t)(struct tcmu_device *,
+			      struct tcmulib_cmd *,
+			      struct iovec *, size_t, off_t);
+typedef int (*store_flush_t)(struct tcmu_device *, struct tcmulib_cmd *);
 typedef int (*store_handle_cmd_t)(struct tcmu_device *, struct tcmulib_cmd *);
 
 typedef void (*callout_cbk_t)(struct tcmu_device *, struct tcmulib_cmd *, int);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -98,6 +98,9 @@ int tcmu_emulate_write_verify(struct tcmu_device *, struct tcmulib_cmd *,
 			      store_rw_t read, store_rw_t write,
 			      struct iovec *, size_t, off_t);
 
+void tcmu_callout_finished(struct tcmu_device *dev,
+			   struct tcmulib_cmd *cmd, int ret);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -34,6 +34,9 @@ struct tcmu_device;
 
 #define SENSE_BUFFERSIZE 96
 
+typedef ssize_t (*store_rw_t)(struct tcmu_device *, struct iovec *, size_t, off_t);
+typedef int (*store_flush_t)(struct tcmu_device *);
+
 struct tcmulib_cmd {
 	uint16_t cmd_id;
 	uint8_t *cdb;
@@ -77,10 +80,7 @@ int tcmu_emulate_read_capacity_16(uint64_t num_lbas, uint32_t block_size, uint8_
 int tcmu_emulate_mode_sense(uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
 int tcmu_emulate_mode_select(uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
 int tcmu_emulate_write_verify(struct tcmu_device *, struct tcmulib_cmd *,
-			      ssize_t (*read)(struct tcmu_device *,
-					      struct iovec *, size_t, off_t),
-			      ssize_t (*write)(struct tcmu_device *,
-					       struct iovec *, size_t, off_t),
+			      store_rw_t read, store_rw_t write,
 			      struct iovec *, size_t, off_t);
 
 #ifdef __cplusplus

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 struct tcmu_device;
+struct tcmulib_cmd;
 
 #define TCMU_NOT_HANDLED -1
 #define TCMU_ASYNC_HANDLED -2
@@ -36,6 +37,9 @@ struct tcmu_device;
 
 typedef ssize_t (*store_rw_t)(struct tcmu_device *, struct iovec *, size_t, off_t);
 typedef int (*store_flush_t)(struct tcmu_device *);
+typedef int (*store_handle_cmd_t)(struct tcmu_device *, struct tcmulib_cmd *);
+
+typedef void (*callout_cbk_t)(struct tcmu_device *, struct tcmulib_cmd *, int);
 
 struct tcmulib_cmd {
 	uint16_t cmd_id;
@@ -43,6 +47,15 @@ struct tcmulib_cmd {
 	struct iovec *iovec;
 	size_t iov_cnt;
 	uint8_t sense_buf[SENSE_BUFFERSIZE];
+
+	/*
+	 * this is mostly used by compound operations as such operations
+	 * need to carry some state around for multiple commands.
+	 */
+	void *cmdstate;
+
+	/* callback to finish/continue command processing */
+	callout_cbk_t callout_cbk;
 };
 
 /* Set/Get methods for the opaque tcmu_device */

--- a/libtcmu_store.c
+++ b/libtcmu_store.c
@@ -19,101 +19,639 @@
 #include <errno.h>
 
 #include "libtcmu.h"
+#include "libtcmu_aio.h"
 #include "libtcmu_log.h"
+#include "libtcmu_priv.h"
 #include "libtcmu_store.h"
 #include "tcmu-runner.h"
 
-int call_store(struct tcmu_device *dev,
-	       struct tcmulib_cmd *tcmulib_cmd, uint8_t cmd)
+static void aio_command_start(struct tcmu_device *dev)
 {
-	int ret = TCMU_NOT_HANDLED;
+	track_aio_request_start(dev);
+}
+
+static void aio_command_finish(struct tcmu_device *dev,
+			       struct tcmulib_cmd *tcmulib_cmd,
+			       int rc, bool complete)
+{
+	int wakeup;
+
+	track_aio_request_finish(dev, &wakeup);
+	if (complete) {
+		tcmulib_command_complete(dev, tcmulib_cmd, rc);
+		if (wakeup)
+			tcmulib_processing_complete(dev);
+	}
+}
+
+static struct iovec *
+alloc_and_assign_single_iovec(struct tcmulib_cmd *tcmulib_cmd, size_t length)
+{
+	struct iovec *iov;
+
+	assert(!tcmulib_cmd->iovec);
+
+	iov = calloc(1, sizeof(*iov));
+	if (!iov)
+		goto out;
+	iov->iov_base = calloc(1, length);
+	if (!iov->iov_base)
+		goto free_iov;
+	iov->iov_len = length;
+
+	tcmulib_cmd->iovec = iov;
+	tcmulib_cmd->iov_cnt = 1;
+	return iov;
+
+free_iov:
+	free(iov);
+out:
+	return NULL;
+}
+
+static void free_single_iovec(struct tcmulib_cmd *tcmulib_cmd)
+{
+	assert(tcmulib_cmd->iovec);
+	assert(tcmulib_cmd->iovec->iov_base);
+
+	free(tcmulib_cmd->iovec->iov_base);
+	free(tcmulib_cmd->iovec);
+
+	tcmulib_cmd->iov_cnt = 0;
+	tcmulib_cmd->iovec = NULL;
+}
+
+/* async write verify */
+
+struct tcmu_write_verify_state {
+	off_t off;
+	size_t requested;
+	struct iovec *w_iovec;
+	size_t w_iov_cnt;
+	struct tcmulib_cmd *readcmd;
+};
+
+/*
+ * read command state just points to the original command which
+ * itself is the write command. no special state maintainance
+ * is required here as we retrigger the write after a successful
+ * verification in read.
+ */
+static struct tcmulib_cmd *
+write_verify_init_readcmd(struct tcmulib_cmd *origcmd)
+{
+	struct tcmulib_cmd *readcmd;
+
+	readcmd = calloc(1, sizeof(*readcmd));
+	if (!readcmd)
+		goto out;
+
+	readcmd->iov_cnt = 0;
+	readcmd->iovec = NULL;
+	readcmd->cmdstate = origcmd;
+	return readcmd;
+
+out:
+	return NULL;
+}
+
+static void write_verify_free_readcmd(struct tcmulib_cmd *readcmd)
+{
+	/* no state is allocated - just deallocate cmd */
+	free(readcmd);
+}
+
+static struct tcmulib_cmd *
+write_verify_init_writecmd(struct tcmulib_cmd *origcmd,
+			   struct tcmulib_cmd *readcmd,
+			   off_t off, size_t length)
+{
+	size_t count = 0;
+	struct tcmu_write_verify_state *state;
+
+	state = calloc(1, sizeof(*state));
+	if (!state)
+		goto out;
+
+	/* use @origcmd as writecmd */
+	state->off = off;
+	state->requested = length;
+	state->readcmd = readcmd;
+
+	state->w_iovec = calloc(origcmd->iov_cnt, sizeof(struct iovec));
+	if (!state->w_iovec)
+		goto free_state;
+
+	state->w_iov_cnt = origcmd->iov_cnt;
+	for (; count < origcmd->iov_cnt; ++count) {
+		state->w_iovec[count].iov_base = origcmd->iovec[count].iov_base;
+		state->w_iovec[count].iov_len = origcmd->iovec[count].iov_len;
+	}
+
+	origcmd->cmdstate = state;
+	return origcmd;
+
+free_state:
+	free(state);
+out:
+	return NULL;
+}
+
+static void write_verify_free_writecmd(struct tcmulib_cmd *writecmd)
+{
+	struct tcmu_write_verify_state *state = writecmd->cmdstate;
+
+	/* writecmd is original cmd - just deallocate its state */
+	free(state->w_iovec);
+	free(state);
+}
+
+static void call_store_write_verify_read_cbk(struct tcmu_device *dev,
+					     struct tcmulib_cmd *readcmd, int ret)
+{
+	uint32_t cmp_offset;
+	struct tcmulib_cmd *writecmd = readcmd->cmdstate;
+	struct tcmu_write_verify_state *state = writecmd->cmdstate;
+	uint8_t *sense = writecmd->sense_buf;
+	size_t count = 0;
+
+	/* failed read - bail out */
+	if (ret != SAM_STAT_GOOD)
+		goto done;
+
+	readcmd->iovec->iov_base -= state->requested;
+
+	for(; count < state->w_iov_cnt; ++count) {
+		if (writecmd->iovec[count].iov_len != state->w_iovec[count].iov_len) {
+			writecmd->iovec[count].iov_base = state->w_iovec[count].iov_base;
+			writecmd->iovec[count].iov_len = state->w_iovec[count].iov_len -
+				writecmd->iovec[count].iov_len;
+		}
+	}
+
+	/* verify failed - bail out */
+	ret = SAM_STAT_GOOD;
+	cmp_offset = tcmu_compare_with_iovec(readcmd->iovec->iov_base,
+					     writecmd->iovec, state->requested);
+	if (cmp_offset != -1) {
+		tcmu_err("Verify failed at offset %lu\n", cmp_offset);
+		ret =  tcmu_set_sense_data(sense, MISCOMPARE,
+					   ASC_MISCOMPARE_DURING_VERIFY_OPERATION,
+					   &cmp_offset);
+	}
+
+done:
+	free_single_iovec(readcmd);
+	write_verify_free_readcmd(readcmd);
+	write_verify_free_writecmd(writecmd);
+	aio_command_finish(dev, writecmd, ret, true);
+}
+
+static int write_verify_do_read(struct tcmu_device *dev,
+				struct tcmulib_cmd *readcmd,
+				off_t off, size_t length)
+{
+	int ret;
+	struct iovec *iov;
+	struct tcmu_call_stub stub;
+	struct tcmulib_cmd *writecmd = readcmd->cmdstate;
+	uint8_t *sense = writecmd->sense_buf;
 	struct tcmulib_handler *handler = tcmu_get_dev_handler(dev);
 	struct tcmur_handler *store = handler->hm_private;
+
+	ret = errno_to_sam_status(-ENOMEM, sense);
+
+	/* do realloc() ? */
+	iov = alloc_and_assign_single_iovec(readcmd, length);
+	if (!iov)
+		goto out;
+
+	stub.sop = TCMU_STORE_OP_READ;
+	stub.callout_cbk = call_store_write_verify_read_cbk;
+
+	stub.u.rw.exec = store->read;
+	stub.u.rw.iov = iov;
+	stub.u.rw.iov_cnt = 1;
+	stub.u.rw.off = off;
+
+	ret = async_call_command(dev, readcmd, &stub);
+	if (ret != TCMU_ASYNC_HANDLED)
+		goto free_iov;
+	return TCMU_ASYNC_HANDLED;
+
+free_iov:
+	free_single_iovec(readcmd);
+out:
+	return ret;
+}
+
+static void call_store_write_verify_write_cbk(struct tcmu_device *dev,
+					      struct tcmulib_cmd *writecmd, int ret)
+{
+	struct tcmu_write_verify_state *state = writecmd->cmdstate;
+
+	/* write error - bail out */
+	if (ret != SAM_STAT_GOOD)
+		goto finish_err;
+
+	/* perform read for verification */
+	ret = write_verify_do_read(dev, state->readcmd, state->off, state->requested);
+	if (ret != TCMU_ASYNC_HANDLED)
+		goto finish_err;
+	return;
+
+finish_err:
+	write_verify_free_readcmd(state->readcmd);
+	write_verify_free_writecmd(writecmd);
+	aio_command_finish(dev, writecmd, ret, true);
+}
+
+static int write_verify_do_write(struct tcmu_device *dev,
+				 struct tcmulib_cmd *writecmd,
+				 struct iovec *iovec, size_t iov_cnt, off_t off)
+{
+	struct tcmu_call_stub stub;
+	struct tcmulib_handler *handler = tcmu_get_dev_handler(dev);
+	struct tcmur_handler *store = handler->hm_private;
+
+	stub.sop = TCMU_STORE_OP_WRITE;
+	stub.callout_cbk = call_store_write_verify_write_cbk;
+
+	stub.u.rw.exec = store->write;
+	stub.u.rw.iov = iovec;
+	stub.u.rw.iov_cnt = iov_cnt;
+	stub.u.rw.off = off;
+
+	return async_call_command(dev, writecmd, &stub);
+}
+
+static int call_store_write_verify(struct tcmu_device *dev,
+				   struct tcmulib_cmd *tcmulib_cmd, off_t off)
+{
+	int ret;
+	uint8_t *cdb = tcmulib_cmd->cdb;
+	struct tcmulib_cmd *readcmd, *writecmd;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
+	size_t length = tcmu_get_xfer_length(cdb) * tcmu_get_dev_block_size(dev);
+
+	ret = errno_to_sam_status(-ENOMEM, sense);
+
+	readcmd = write_verify_init_readcmd(tcmulib_cmd);
+	if (!readcmd)
+		goto out;
+	writecmd = write_verify_init_writecmd(tcmulib_cmd, readcmd, off, length);
+	if (!writecmd)
+		goto free_readcmd;
+
+	aio_command_start(dev);
+	ret = write_verify_do_write(dev, writecmd,
+				    writecmd->iovec, writecmd->iov_cnt, off);
+	if (ret != TCMU_ASYNC_HANDLED) {
+		aio_command_finish(dev, writecmd, ret, false);
+		goto free_writecmd;
+	}
+
+	return TCMU_ASYNC_HANDLED;
+
+free_writecmd:
+	write_verify_free_writecmd(writecmd);
+free_readcmd:
+	write_verify_free_readcmd(readcmd);
+out:
+	return ret;
+}
+
+/* async compare_and_write */
+
+struct tcmu_caw_state {
+	off_t off;
+	ssize_t requested;
+	struct tcmulib_cmd *origcmd;
+};
+
+static struct tcmulib_cmd *
+caw_init_readcmd(struct tcmulib_cmd *origcmd, off_t off, ssize_t length)
+{
+	struct iovec *iov;
+	struct tcmulib_cmd *readcmd;
+	struct tcmu_caw_state *state;
+
+	state = calloc(1, sizeof(*state));
+	if (!state)
+		goto out;
+	readcmd = calloc(1, sizeof(*readcmd));
+	if (!readcmd)
+		goto free_state;
+
+	readcmd->iov_cnt = 0;
+	readcmd->iovec = NULL;
+	iov = alloc_and_assign_single_iovec(readcmd, length);
+	if (!iov)
+		goto free_cmd;
+
+	/* multi-op state maintainance */
+	state->off = off;
+	state->requested = length;
+	state->origcmd = origcmd;
+
+	readcmd->cmdstate = state;
+	return readcmd;
+
+free_cmd:
+	free(readcmd);
+free_state:
+	free(state);
+out:
+	return NULL;
+}
+
+static void caw_free_readcmd(struct tcmulib_cmd *readcmd)
+{
+	struct tcmu_caw_state *state = readcmd->cmdstate;
+
+	free_single_iovec(readcmd);
+	free(state);
+	free(readcmd);
+}
+
+static void call_store_caw_write_cbk(struct tcmu_device *dev,
+				     struct tcmulib_cmd *tcmulib_cmd, int ret)
+{
+	pthread_mutex_unlock(&dev->caw_lock);
+	aio_command_finish(dev, tcmulib_cmd, ret, true);
+}
+
+static void call_store_caw_read_cbk(struct tcmu_device *dev,
+				    struct tcmulib_cmd *readcmd, int ret)
+{
+	uint32_t cmp_offset;
+	struct tcmu_call_stub stub;
+	struct tcmu_caw_state *state = readcmd->cmdstate;
+	struct tcmulib_cmd *origcmd = state->origcmd;
+	uint8_t *sense = origcmd->sense_buf;
+	struct tcmulib_handler *handler = tcmu_get_dev_handler(dev);
+	struct tcmur_handler *store = handler->hm_private;
+
+	/* read failed - bail out */
+	if (ret != SAM_STAT_GOOD)
+		goto finish_err;
+
+	readcmd->iovec->iov_base -= state->requested;
+
+	/* verify failed - bail out */
+	cmp_offset = tcmu_compare_with_iovec(readcmd->iovec->iov_base,
+					     origcmd->iovec, state->requested);
+	if (cmp_offset != -1) {
+		ret = tcmu_set_sense_data(sense, MISCOMPARE,
+					  ASC_MISCOMPARE_DURING_VERIFY_OPERATION,
+					  &cmp_offset);
+		goto finish_err;
+	}
+
+	/* perform write */
+	tcmu_seek_in_iovec(origcmd->iovec, state->requested);
+	stub.sop = TCMU_STORE_OP_WRITE;
+	stub.callout_cbk = call_store_caw_write_cbk;
+
+	stub.u.rw.exec = store->write;
+	stub.u.rw.iov = origcmd->iovec;
+	stub.u.rw.iov_cnt = origcmd->iov_cnt;
+	stub.u.rw.off = state->off;
+
+	ret = async_call_command(dev, origcmd, &stub);
+	if (ret != TCMU_ASYNC_HANDLED)
+		goto finish_err;
+
+	caw_free_readcmd(readcmd);
+	return;
+
+finish_err:
+	pthread_mutex_unlock(&dev->caw_lock);
+	aio_command_finish(dev, origcmd, ret, true);
+	caw_free_readcmd(readcmd);
+}
+
+static int call_store_caw(struct tcmu_device *dev,
+			  struct tcmur_handler *store,
+			  struct tcmulib_cmd *tcmulib_cmd,
+			  struct iovec *iovec, size_t iov_cnt, off_t off)
+{
+	int ret;
+	struct tcmu_call_stub stub;
+	struct tcmulib_cmd *readcmd;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
+	ssize_t half = (tcmu_iovec_length(iovec, iov_cnt)) / 2;
+
+	ret = errno_to_sam_status(-ENOMEM, sense);
+
+	readcmd = caw_init_readcmd(tcmulib_cmd, off, half);
+	if (!readcmd)
+		goto out;
+
+	stub.sop = TCMU_STORE_OP_READ;
+	stub.callout_cbk = call_store_caw_read_cbk;
+
+	stub.u.rw.exec = store->read;
+	stub.u.rw.iov = readcmd->iovec;
+	stub.u.rw.iov_cnt = readcmd->iov_cnt;
+	stub.u.rw.off = off;
+
+	aio_command_start(dev);
+	pthread_mutex_lock(&dev->caw_lock);
+
+	ret = async_call_command(dev, readcmd, &stub);
+	if (ret == TCMU_ASYNC_HANDLED)
+		return TCMU_ASYNC_HANDLED;
+
+	pthread_mutex_unlock(&dev->caw_lock);
+	aio_command_finish(dev, tcmulib_cmd, ret, false);
+
+	caw_free_readcmd(readcmd);
+out:
+	return ret;
+}
+
+/* async flush */
+static void call_store_flush_cbk(struct tcmu_device *dev,
+				 struct tcmulib_cmd *tcmulib_cmd, int ret)
+{
+	aio_command_finish(dev, tcmulib_cmd, ret, true);
+}
+
+static int call_store_flush(struct tcmu_device *dev,
+			    struct tcmur_handler *store,
+			    struct tcmulib_cmd *tcmulib_cmd)
+{
+	int ret;
+	struct tcmu_call_stub stub;
+
+	stub.sop = TCMU_STORE_OP_FLUSH;
+	stub.callout_cbk = call_store_flush_cbk;
+	stub.u.flush.exec = store->flush;
+
+	aio_command_start(dev);
+	ret = async_call_command(dev, tcmulib_cmd, &stub);
+	if (ret != TCMU_ASYNC_HANDLED)
+		aio_command_finish(dev, tcmulib_cmd, ret, false);
+	return ret;
+}
+
+/* async write */
+static void call_store_write_cbk(struct tcmu_device *dev,
+				 struct tcmulib_cmd *tcmulib_cmd, int ret)
+{
+	aio_command_finish(dev, tcmulib_cmd, ret, true);
+}
+
+static int call_store_write(struct tcmu_device *dev,
+			    struct tcmur_handler *store,
+			    struct tcmulib_cmd *tcmulib_cmd,
+			    struct iovec *iovec, size_t iov_cnt, off_t off)
+{
+	int ret;
+	struct tcmu_call_stub stub;
+
+	stub.sop = TCMU_STORE_OP_WRITE;
+	stub.callout_cbk = call_store_write_cbk;
+
+	stub.u.rw.exec = store->write;
+	stub.u.rw.iov = iovec;
+	stub.u.rw.iov_cnt = iov_cnt;
+	stub.u.rw.off = off;
+
+	aio_command_start(dev);
+	ret = async_call_command(dev, tcmulib_cmd, &stub);
+	if (ret != TCMU_ASYNC_HANDLED)
+		aio_command_finish(dev, tcmulib_cmd, ret, false);
+	return ret;
+}
+
+/* async read */
+static void call_store_read_cbk(struct tcmu_device *dev,
+				struct tcmulib_cmd *tcmulib_cmd, int ret)
+{
+	aio_command_finish(dev, tcmulib_cmd, ret, true);
+}
+
+static int call_store_read(struct tcmu_device *dev,
+			   struct tcmur_handler *store,
+			   struct tcmulib_cmd *tcmulib_cmd,
+			   struct iovec *iovec, size_t iov_cnt, off_t off)
+{
+	int ret;
+	struct tcmu_call_stub stub;
+
+	stub.sop = TCMU_STORE_OP_READ;
+	stub.callout_cbk = call_store_read_cbk;
+
+	stub.u.rw.exec = store->read;
+	stub.u.rw.iov = iovec;
+	stub.u.rw.iov_cnt = iov_cnt;
+	stub.u.rw.off = off;
+
+	aio_command_start(dev);
+	ret = async_call_command(dev, tcmulib_cmd, &stub);
+	if (ret != TCMU_ASYNC_HANDLED)
+		aio_command_finish(dev, tcmulib_cmd, ret, false);
+	return ret;
+}
+
+int call_store_handler(struct tcmu_device *dev,
+		       struct tcmur_handler *store,
+		       struct tcmulib_cmd *tcmulib_cmd, int cmd)
+{
 	uint8_t *cdb = tcmulib_cmd->cdb;
 	struct iovec *iovec = tcmulib_cmd->iovec;
 	size_t iov_cnt = tcmulib_cmd->iov_cnt;
-	uint8_t *sense = tcmulib_cmd->sense_buf;
 	uint32_t block_size = tcmu_get_dev_block_size(dev);
-	ssize_t ret, l = tcmu_iovec_length(iovec, iov_cnt);
 	off_t offset = block_size * tcmu_get_lba(cdb);
-	struct iovec iov;
-	size_t half = l / 2;
-	uint32_t cmp_offset;
-
-	if (store->handle_cmd)
-		ret = store->handle_cmd(dev, tcmulib_cmd);
-	if (ret != TCMU_NOT_HANDLED)
-		return ret;
 
 	switch(cmd) {
 	case READ_6:
 	case READ_10:
 	case READ_12:
 	case READ_16:
-		ret = store->read(dev, iovec, iov_cnt, offset);
-		if (ret != l) {
-			tcmu_err("Error on read %x, %x\n", ret, l);
-			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
-						   ASC_READ_ERROR, NULL);
-		} else
-			return SAM_STAT_GOOD;
+		return call_store_read(dev, store,
+				       tcmulib_cmd, iovec, iov_cnt, offset);
 	case WRITE_6:
 	case WRITE_10:
 	case WRITE_12:
 	case WRITE_16:
-		ret = store->write(dev, iovec, iov_cnt, offset);
-		if (ret != l) {
-			tcmu_err("Error on write %x, %x\n", ret, l);
-			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
-						   ASC_READ_ERROR, NULL);
-		} else
-			return SAM_STAT_GOOD;
+		return call_store_write(dev, store,
+					tcmulib_cmd, iovec, iov_cnt, offset);
 	case SYNCHRONIZE_CACHE:
 	case SYNCHRONIZE_CACHE_16:
-		ret = store->flush(dev);
-		if (ret < 0) {
-			tcmu_err("Error on flush %x\n", ret);
-			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
-						   ASC_READ_ERROR, NULL);
-		} else
-			return SAM_STAT_GOOD;
+		return call_store_flush(dev, store, tcmulib_cmd);
 	case COMPARE_AND_WRITE:
-		iov.iov_base = malloc(half);
-		if (!iov.iov_base) {
-			tcmu_err("out of memory\n");
-			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
-						   ASC_READ_ERROR, NULL);
-		}
-		iov.iov_len = half;
-		ret = store->read(dev, &iov, 1, offset);
-		if (ret != l) {
-			tcmu_err("Error on read %x, %x\n", ret, l);
-			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
-						   ASC_READ_ERROR, NULL);
-		}
-		cmp_offset = tcmu_compare_with_iovec(iov.iov_base, iovec, half);
-		if (cmp_offset != -1) {
-			return tcmu_set_sense_data(sense, MISCOMPARE,
-					ASC_MISCOMPARE_DURING_VERIFY_OPERATION,
-					&cmp_offset);
-		}
-		free(iov.iov_base);
-
-		tcmu_seek_in_iovec(iovec, half);
-		ret = store->write(dev, iovec, iov_cnt, offset);
-		if (ret != half) {
-			tcmu_err("Error on write %x, %x\n", ret, half);
-			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
-						   ASC_READ_ERROR, NULL);
-		} else
-			return SAM_STAT_GOOD;
+		return call_store_caw(dev, store,
+				      tcmulib_cmd, iovec, iov_cnt, offset);
 	case WRITE_VERIFY:
-		return tcmu_emulate_write_verify(dev, tcmulib_cmd,
-						 store->read,
-						 store->write,
-						 iovec, iov_cnt, offset);
+		return call_store_write_verify(dev, tcmulib_cmd, offset);
 	default:
 		tcmu_err("unknown command %x\n", cdb[0]);
 		return TCMU_NOT_HANDLED;
 	}
+}
+
+/* command passthrough */
+static void
+call_store_passthrough_cbk(struct tcmu_device *dev,
+			   struct tcmulib_cmd *tcmulib_cmd, int ret)
+{
+	uint8_t cmd = (tcmulib_cmd->cdb)[0];
+	struct tcmulib_handler *handler = tcmu_get_dev_handler(dev);
+	struct tcmur_handler *store = handler->hm_private;
+
+	if (ret != TCMU_NOT_HANDLED) {
+		aio_command_finish(dev, tcmulib_cmd, ret, true);
+		return;
+	}
+
+	/* passthrough command was not handled - fallback to generic handling */
+	ret = call_store_handler(dev, store, tcmulib_cmd, cmd);
+	aio_command_finish(dev, tcmulib_cmd, ret,
+			    (ret != TCMU_ASYNC_HANDLED) ? true : false);
+}
+
+static int call_store_passthrough(struct tcmu_device *dev,
+				  struct tcmur_handler *store,
+				  struct tcmulib_cmd *tcmulib_cmd)
+{
+	int ret;
+	struct tcmu_call_stub stub;
+
+	stub.sop = TCMU_STORE_OP_HANDLE_CMD;
+	stub.callout_cbk = call_store_passthrough_cbk;
+	stub.u.handle_cmd.exec = store->handle_cmd;
+
+	aio_command_start(dev);
+	ret = async_call_command(dev, tcmulib_cmd, &stub);
+	if (ret != TCMU_ASYNC_HANDLED)
+		aio_command_finish(dev, tcmulib_cmd, ret, false);
+	return ret;
+}
+
+/*
+ * try to passthrough the command if handler supports command passthrough.
+ * note that TCMU_NOT_HANDLED is returned when a store handler does not
+ * handle a passthrough command, but since we call ->handle_cmd via
+ * async_call_command(), ->handle_cmd can finish in the callers context
+ * (asynchronous handler) or work queue context (synchronous handlers),
+ * thus we'd need to check if ->handle_cmd handled the passthough command
+ * here as well as in call_store_passthrough_cbk().
+ */
+int call_store(struct tcmu_device *dev,
+	       struct tcmulib_cmd *tcmulib_cmd, uint8_t cmd)
+{
+	int ret;
+	struct tcmulib_handler *handler = tcmu_get_dev_handler(dev);
+	struct tcmur_handler *store = handler->hm_private;
+
+	if (store->handle_cmd) {
+		ret = call_store_passthrough(dev, store, tcmulib_cmd);
+		if ((ret == TCMU_ASYNC_HANDLED) || (ret != TCMU_NOT_HANDLED))
+			return ret;
+	}
+
+	return call_store_handler(dev, store, tcmulib_cmd, cmd);
 }

--- a/libtcmu_store.c
+++ b/libtcmu_store.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017, Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define _GNU_SOURCE
+#include <scsi/scsi.h>
+#include <errno.h>
+
+#include "libtcmu.h"
+#include "libtcmu_log.h"
+#include "libtcmu_store.h"
+#include "tcmu-runner.h"
+
+int call_store(struct tcmu_device *dev,
+	       struct tcmulib_cmd *tcmulib_cmd, uint8_t cmd)
+{
+	int ret = TCMU_NOT_HANDLED;
+	struct tcmulib_handler *handler = tcmu_get_dev_handler(dev);
+	struct tcmur_handler *store = handler->hm_private;
+	uint8_t *cdb = tcmulib_cmd->cdb;
+	struct iovec *iovec = tcmulib_cmd->iovec;
+	size_t iov_cnt = tcmulib_cmd->iov_cnt;
+	uint8_t *sense = tcmulib_cmd->sense_buf;
+	uint32_t block_size = tcmu_get_dev_block_size(dev);
+	ssize_t ret, l = tcmu_iovec_length(iovec, iov_cnt);
+	off_t offset = block_size * tcmu_get_lba(cdb);
+	struct iovec iov;
+	size_t half = l / 2;
+	uint32_t cmp_offset;
+
+	if (store->handle_cmd)
+		ret = store->handle_cmd(dev, tcmulib_cmd);
+	if (ret != TCMU_NOT_HANDLED)
+		return ret;
+
+	switch(cmd) {
+	case READ_6:
+	case READ_10:
+	case READ_12:
+	case READ_16:
+		ret = store->read(dev, iovec, iov_cnt, offset);
+		if (ret != l) {
+			tcmu_err("Error on read %x, %x\n", ret, l);
+			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+						   ASC_READ_ERROR, NULL);
+		} else
+			return SAM_STAT_GOOD;
+	case WRITE_6:
+	case WRITE_10:
+	case WRITE_12:
+	case WRITE_16:
+		ret = store->write(dev, iovec, iov_cnt, offset);
+		if (ret != l) {
+			tcmu_err("Error on write %x, %x\n", ret, l);
+			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+						   ASC_READ_ERROR, NULL);
+		} else
+			return SAM_STAT_GOOD;
+	case SYNCHRONIZE_CACHE:
+	case SYNCHRONIZE_CACHE_16:
+		ret = store->flush(dev);
+		if (ret < 0) {
+			tcmu_err("Error on flush %x\n", ret);
+			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+						   ASC_READ_ERROR, NULL);
+		} else
+			return SAM_STAT_GOOD;
+	case COMPARE_AND_WRITE:
+		iov.iov_base = malloc(half);
+		if (!iov.iov_base) {
+			tcmu_err("out of memory\n");
+			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+						   ASC_READ_ERROR, NULL);
+		}
+		iov.iov_len = half;
+		ret = store->read(dev, &iov, 1, offset);
+		if (ret != l) {
+			tcmu_err("Error on read %x, %x\n", ret, l);
+			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+						   ASC_READ_ERROR, NULL);
+		}
+		cmp_offset = tcmu_compare_with_iovec(iov.iov_base, iovec, half);
+		if (cmp_offset != -1) {
+			return tcmu_set_sense_data(sense, MISCOMPARE,
+					ASC_MISCOMPARE_DURING_VERIFY_OPERATION,
+					&cmp_offset);
+		}
+		free(iov.iov_base);
+
+		tcmu_seek_in_iovec(iovec, half);
+		ret = store->write(dev, iovec, iov_cnt, offset);
+		if (ret != half) {
+			tcmu_err("Error on write %x, %x\n", ret, half);
+			return tcmu_set_sense_data(sense, MEDIUM_ERROR,
+						   ASC_READ_ERROR, NULL);
+		} else
+			return SAM_STAT_GOOD;
+	case WRITE_VERIFY:
+		return tcmu_emulate_write_verify(dev, tcmulib_cmd,
+						 store->read,
+						 store->write,
+						 iovec, iov_cnt, offset);
+	default:
+		tcmu_err("unknown command %x\n", cdb[0]);
+		return TCMU_NOT_HANDLED;
+	}
+}

--- a/libtcmu_store.h
+++ b/libtcmu_store.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017, Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+*/
+
+#ifndef __LIBTCMU_STORE_H
+#define __LIBTCMU_STORE_H
+
+#include <stdint.h>
+
+struct tcmu_device;
+struct tcmulib_cmd;
+
+int call_store(struct tcmu_device *dev,
+	       struct tcmulib_cmd *tcmulib_cmd, uint8_t cmd);
+
+#endif /* __LIBTCMU_STORE_H */

--- a/qcow.c
+++ b/qcow.c
@@ -1468,6 +1468,7 @@ static int set_medium_error(uint8_t *sense)
 }
 
 static ssize_t _tcmu_qcow_read(struct tcmu_device *dev,
+			       struct tcmulib_cmd *tcmulib_cmd,
 			       struct iovec *iov, size_t iov_cnt,
 			       off_t offset)
 {
@@ -1476,6 +1477,7 @@ static ssize_t _tcmu_qcow_read(struct tcmu_device *dev,
 }
 
 static ssize_t _tcmu_qcow_write(struct tcmu_device *dev,
+				struct tcmulib_cmd *tcmulib_cmd,
 				struct iovec *iov, size_t iov_cnt,
 				off_t offset)
 {

--- a/rbd.c
+++ b/rbd.c
@@ -159,8 +159,9 @@ static void tcmu_rbd_close(struct tcmu_device *dev)
 	free(state);
 }
 
-static ssize_t tcmu_rbd_read(struct tcmu_device *dev, struct iovec *iov,
-			     size_t iov_cnt, off_t offset)
+static ssize_t tcmu_rbd_read(struct tcmu_device *dev,
+			     struct tcmulib_cmd *tcmulib_cmd,
+			     struct iovec *iov, size_t iov_cnt, off_t offset)
 {
 	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
 	size_t length = tcmu_iovec_length(iov, iov_cnt);
@@ -179,8 +180,9 @@ out:
 	return ret;
 }
 
-static ssize_t tcmu_rbd_write(struct tcmu_device *dev, struct iovec *iov,
-			      size_t iov_cnt, off_t offset)
+static ssize_t tcmu_rbd_write(struct tcmu_device *dev,
+			      struct tcmulib_cmd *tcmulib_cmd,
+			      struct iovec *iov, size_t iov_cnt, off_t offset)
 {
 	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
 	size_t length = tcmu_iovec_length(iov, iov_cnt);
@@ -196,7 +198,8 @@ out:
 	return ret;
 }
 
-static int tcmu_rbd_flush(struct tcmu_device *dev)
+static int tcmu_rbd_flush(struct tcmu_device *dev,
+			  struct tcmulib_cmd *tcmulib_cmd)
 {
 	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
 

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -33,6 +33,13 @@ extern "C" {
 #include "libtcmu_log.h"
 #include "libtcmu_common.h"
 
+enum tcmu_store_op {
+	TCMU_STORE_OP_READ = 0,
+	TCMU_STORE_OP_WRITE,
+	TCMU_STORE_OP_FLUSH,
+	TCMU_STORE_OP_HANDLE_CMD,
+};
+
 struct tcmur_handler {
 	const char *name;	/* Human-friendly name */
 	const char *subtype;	/* Name for cfgstring matching */

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -31,7 +31,6 @@ extern "C" {
 #include <sys/uio.h>
 #include "scsi_defs.h"
 #include "libtcmu_log.h"
-
 #include "libtcmu_common.h"
 
 struct tcmur_handler {
@@ -72,9 +71,9 @@ struct tcmur_handler {
 	int (*handle_cmd)(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
 
 	/* Below callbacks are only exected called by generic_handle_cmd */
-	ssize_t (*write)(struct tcmu_device *, struct iovec *, size_t, off_t);
-	ssize_t (*read)(struct tcmu_device *, struct iovec *, size_t, off_t);
-	int (*flush)(struct tcmu_device *);
+	store_rw_t    write;
+	store_rw_t    read;
+	store_flush_t flush;
 };
 
 /*


### PR DESCRIPTION
These set of changes aims to conver RBD handlers read/write/flush operation asynchronous by making use of asynchronous librbd APIs. This involves changes to `generic_handle_cmd()` to handle `TCMU_ASYNC_HANDLED` return value by store callout methods. Furthermore, `compare_and_write` has been added as a store callout method though keeping the implementation same (read + write as of now, but rbd would make use of `cmpext` OSD op when ready).