### PR TITLE
runner: add command passthrough support for generic_handle_cmd

### DIFF
--- a/main.c
+++ b/main.c
@@ -67,12 +67,6 @@ static struct tcmur_handler *find_handler_by_subtype(gchar *subtype)
 
 int tcmur_register_handler(struct tcmur_handler *handler)
 {
-	if (handler->handle_cmd &&
-	    (handler->read || handler->write || handler->flush)) {
-		tcmu_err("Skip bad handler: %s\n", handler->name);
-		return -1;
-	}
-
 	darray_append(g_runner_handlers, handler);
 	return 0;
 }


### PR DESCRIPTION
COMPARE_AND_WRITE in rbd.c is just an example (which will be overloaded once
ceph part is ready) about how we can pass down chose command to the specific
store.

Signed-off-by: Liu Yuan <liuyuan@cmss.chinamobile.com>