### PR TITLE
Add nonblock logger support

### DIFF
--- a/consumer.c
+++ b/consumer.c
@@ -150,8 +150,6 @@ int main(int argc, char **argv)
 	int i;
 	int ret;
 
-	tcmu_log_open_syslog(TCMU_CONSUMER, 0, 0);
-
 	/* If any TCMU devices that exist that match subtype,
 	   handler->added() will now be called from within
 	   tcmulib_initialize(). */
@@ -210,8 +208,6 @@ int main(int argc, char **argv)
 			}
 		}
 	}
-
-	tcmu_log_close_syslog();
 
 	return 0;
 }

--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -15,12 +15,46 @@
  */
 
 #define _GNU_SOURCE
+#include <stdint.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
 #include "libtcmu_log.h"
 #include "libtcmu_config.h"
 
-static int tcmu_log_level = TCMU_LOG_WARN;
+/* tcmu ring buffer for log */
+#define LOG_ENTRY_LEN 256 /* rb[0] is reserved for pri */
+#define LOG_MSG_LEN (LOG_ENTRY_LEN - 1) /* the length of the log message */
+#define LOG_ENTRYS (1024 * 32)
 
-static inline int tcmu_log_level_conf_to_syslog(int level)
+pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+struct log_buf {
+	pthread_cond_t cond;
+	pthread_mutex_t lock;
+
+	bool thread_active;
+	int init_state;
+	bool finish_initialize;
+
+	unsigned int head;
+	unsigned int tail;
+	char buf[LOG_ENTRYS][LOG_ENTRY_LEN];
+	pthread_t thread_id;
+};
+
+static int tcmu_log_level = TCMU_LOG_WARN;
+static struct log_buf *tcmu_log_initialize(void);
+
+static struct log_buf *logbuf = NULL;
+static int initialized = false;
+
+/* covert log level from tcmu config to syslog */
+static inline int to_syslog_level(int level)
 {
 	switch (level) {
 		case TCMU_CONF_LOG_ERROR:
@@ -42,40 +76,91 @@ unsigned int tcmu_get_log_level(void)
 	return tcmu_log_level;
 }
 
-/* covert log level from tcmu config to syslog */
 void tcmu_set_log_level(int level)
 {
-	tcmu_log_level = tcmu_log_level_conf_to_syslog(level);
+	tcmu_log_level = to_syslog_level(level);
 }
 
-void tcmu_log_open_syslog(const char *ident, int option, int facility)
+static void open_syslog(const char *ident, int option, int facility)
 {
-	const char *id = TCMU_IDENT;
+#define ID_MAX_LEN 16
+	char id[ID_MAX_LEN + 1] = {0}, path[128];
+	int fd, len = -1;
 
-	if (ident)
-		id = ident;
+	if (!ident) {
+		sprintf(path, "/proc/%d/comm", getpid());
+		fd = open(path, O_RDONLY);
+			if (fd < 0)
+				return;
+		len = read(fd, id, ID_MAX_LEN);
+		if (len < 0) {
+			close(fd);
+			return;
+		}
+		close(fd);
+	} else {
+		strncpy(id, ident, ID_MAX_LEN);
+	}
 
 	openlog(id, option, facility);
 }
 
-void tcmu_log_close_syslog(void)
+static void close_syslog(void)
 {
 	closelog();
 }
 
-static inline void tcmu_log_to_syslog(int pri, const char *logbuf)
+static inline void log_to_syslog(int pri, const char *logbuf)
 {
 	syslog(pri, "%s", logbuf);
 }
 
-static void
-tcmu_log_internal(int pri,
-		  const char *funcname,
-		  int linenr,
-		  const char *fmt,
-		  va_list args)
+static inline uint8_t rb_get_pri(struct log_buf *logbuf, unsigned int cur)
 {
-	char logbuf[TCMU_LOG_BUF_SIZE];
+	return logbuf->buf[cur][0];
+}
+
+static inline void rb_set_pri(struct log_buf *logbuf, unsigned int cur, uint8_t pri)
+{
+	logbuf->buf[cur][0] = (char)pri;
+}
+
+static inline char *rb_get_msg(struct log_buf *logbuf, unsigned int cur)
+{
+	return logbuf->buf[cur] + 1;
+}
+
+static inline bool rb_is_empty(struct log_buf *logbuf)
+{
+	return logbuf->tail == logbuf->head;
+}
+
+static inline bool rb_is_full(struct log_buf *logbuf)
+{
+	return logbuf->tail == (logbuf->head + 1) % LOG_ENTRYS;
+}
+
+static inline void rb_update_tail(struct log_buf *logbuf)
+{
+	logbuf->tail = (logbuf->tail + 1) % LOG_ENTRYS;
+}
+
+static inline void rb_update_head(struct log_buf *logbuf)
+{
+	/* when the ring buffer is full, the oldest log will be dropped */
+	if (rb_is_full(logbuf))
+		rb_update_tail(logbuf);
+
+	logbuf->head = (logbuf->head + 1) % LOG_ENTRYS;
+}
+
+static void
+log_internal(int pri,const char *funcname,
+		int linenr,const char *fmt,
+		va_list args)
+{
+	unsigned int head;
+	char *msg;
 	int n;
 
 	if (pri > tcmu_log_level)
@@ -84,10 +169,23 @@ tcmu_log_internal(int pri,
 	if (!fmt)
 		return;
 
-	n = sprintf(logbuf, "%s:%d : ", funcname, linenr);
-	vsnprintf(logbuf + n, TCMU_LOG_BUF_SIZE - n - 1, fmt, args);
+	if (!initialized && !(logbuf = tcmu_log_initialize()))
+		return;
 
-	tcmu_log_to_syslog(pri, logbuf);
+	pthread_mutex_lock(&logbuf->lock);
+
+	head = logbuf->head;
+	rb_set_pri(logbuf, head, pri);
+	msg = rb_get_msg(logbuf, head);
+	n = sprintf(msg, "%s:%d : ", funcname, linenr);
+	vsnprintf(msg + n, LOG_MSG_LEN - n, fmt, args);
+
+	rb_update_head(logbuf);
+
+	if (logbuf->thread_active == false)
+		pthread_cond_signal(&logbuf->cond);
+
+	pthread_mutex_unlock(&logbuf->lock);
 }
 
 void tcmu_err_message(const char *funcname, int linenr, const char *fmt, ...)
@@ -95,7 +193,7 @@ void tcmu_err_message(const char *funcname, int linenr, const char *fmt, ...)
 	va_list args;
 
 	va_start(args, fmt);
-	tcmu_log_internal(TCMU_LOG_ERROR, funcname, linenr, fmt, args);
+	log_internal(TCMU_LOG_ERROR, funcname, linenr, fmt, args);
 	va_end(args);
 }
 
@@ -104,7 +202,7 @@ void tcmu_warn_message(const char *funcname, int linenr, const char *fmt, ...)
 	va_list args;
 
 	va_start(args, fmt);
-	tcmu_log_internal(TCMU_LOG_WARN, funcname, linenr, fmt, args);
+	log_internal(TCMU_LOG_WARN, funcname, linenr, fmt, args);
 	va_end(args);
 }
 
@@ -113,14 +211,157 @@ void tcmu_info_message(const char *funcname, int linenr, const char *fmt, ...)
 	va_list args;
 
 	va_start(args, fmt);
-	tcmu_log_internal(TCMU_LOG_INFO, funcname, linenr, fmt, args);
+	log_internal(TCMU_LOG_INFO, funcname, linenr, fmt, args);
 	va_end(args);
 }
+
 void tcmu_dbg_message(const char *funcname, int linenr, const char *fmt, ...)
 {
 	va_list args;
 
 	va_start(args, fmt);
-	tcmu_log_internal(TCMU_LOG_DEBUG, funcname, linenr, fmt, args);
+	log_internal(TCMU_LOG_DEBUG, funcname, linenr, fmt, args);
 	va_end(args);
+}
+
+static void log_output(int pri, const char *msg)
+{
+	log_to_syslog(pri, msg);
+	/* log to stdout if tcmu_log_level is DEBUG */
+	if (pri <= TCMU_LOG_DEBUG && tcmu_log_level == TCMU_LOG_DEBUG) {
+		fprintf(stdout, "%s", msg);
+	}
+}
+
+static bool log_buf_not_empty_output(struct log_buf *logbuf)
+{	
+	unsigned int tail;
+	uint8_t pri;
+	char *msg, buf[LOG_MSG_LEN];
+	
+	if (!logbuf) {
+		return false;
+	}
+
+	pthread_mutex_lock(&logbuf->lock);
+	if (rb_is_empty(logbuf)) {
+		pthread_mutex_unlock(&logbuf->lock);
+		return false;
+	}
+
+	tail = logbuf->tail;
+	pri = rb_get_pri(logbuf, tail);
+	msg = rb_get_msg(logbuf, tail);
+	memcpy(buf, msg, LOG_MSG_LEN);
+	rb_update_tail(logbuf);
+	pthread_mutex_unlock(&logbuf->lock);
+
+	/*
+ 	 * This may block due to rsyslog and syslog-ng, etc.
+ 	 * And the log productors could still insert their log
+ 	 * messages into the ring buffer without blocking. But
+ 	 * the ring buffer may lose some old log rbs if the
+ 	 * ring buffer is full.
+ 	 */
+	log_output(pri, buf);
+
+	return true;
+}
+
+static void cancel_log_thread(pthread_t thread)
+{
+	void *join_retval;
+	int ret;
+
+	ret = pthread_cancel(thread);
+	if (ret) {
+		return;
+	}
+
+	pthread_join(thread, &join_retval);
+}
+
+void tcmu_cancel_log_thread(void)
+{
+	cancel_log_thread(logbuf->thread_id);
+}
+
+static void log_thread_cleanup(void *arg)
+{
+	struct log_buf *logbuf = arg;
+
+	pthread_cond_destroy(&logbuf->cond);
+	pthread_mutex_destroy(&logbuf->lock);
+	free(logbuf);
+
+	close_syslog();
+}
+
+static void *log_thread_start(void *arg)
+{
+	struct log_buf *logbuf = arg;
+
+	pthread_cleanup_push(log_thread_cleanup, arg);
+
+	open_syslog(NULL, 0, 0);
+
+	pthread_mutex_lock(&logbuf->lock);
+	if(!logbuf->finish_initialize){
+		logbuf->finish_initialize = true;
+		pthread_cond_signal(&logbuf->cond);
+	}
+	pthread_mutex_unlock(&logbuf->lock);
+
+	while (1) {
+		pthread_mutex_lock(&logbuf->lock);
+		logbuf->thread_active = false;
+		pthread_cond_wait(&logbuf->cond, &logbuf->lock);
+		logbuf->thread_active = true;
+		pthread_mutex_unlock(&logbuf->lock);
+
+		while (log_buf_not_empty_output(logbuf));
+	}
+
+	pthread_cleanup_pop(1);
+	return NULL;
+}
+
+static struct log_buf *tcmu_log_initialize(void)
+{
+	int ret;
+	pthread_mutex_lock(&g_mutex);
+
+	if (initialized && logbuf != NULL) {
+		pthread_mutex_unlock(&g_mutex);
+		return logbuf;
+	}
+
+	logbuf = malloc(sizeof(struct log_buf));
+	if (!logbuf) {
+		pthread_mutex_unlock(&g_mutex);
+		return NULL;
+	}
+
+	logbuf->thread_active = false;
+	logbuf->finish_initialize = false;
+	logbuf->head = 0;
+	logbuf->tail = 0;
+	pthread_cond_init(&logbuf->cond, NULL);
+	pthread_mutex_init(&logbuf->lock, NULL);
+
+	ret = pthread_create(&logbuf->thread_id, NULL, log_thread_start, logbuf);
+	if (ret) {
+		free(logbuf);
+		pthread_mutex_unlock(&g_mutex);
+		return NULL;
+	}
+	
+	pthread_mutex_lock(&logbuf->lock);	
+	while (!logbuf->finish_initialize)
+		pthread_cond_wait(&logbuf->cond, &logbuf->lock);
+	pthread_mutex_unlock(&logbuf->lock);
+
+	initialized = true;
+	pthread_mutex_unlock(&g_mutex);
+	return logbuf;
 }

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -32,10 +32,9 @@
 #define TCMU_LOG_INFO	LOG_INFO	/* informational */
 #define TCMU_LOG_DEBUG	LOG_DEBUG	/* debug-level messages */
 
-void tcmu_log_open_syslog(const char *ident, int option, int facility);
-void tcmu_log_close_syslog(void);
 void tcmu_set_log_level(int level);
 unsigned int tcmu_get_log_level(void);
+void tcmu_cancel_log_thread(void);
 
 void tcmu_err_message(const char *funcname, int linenr, const char *fmt, ...);
 void tcmu_warn_message(const char *funcname, int linenr, const char *fmt, ...);

--- a/main.c
+++ b/main.c
@@ -384,6 +384,8 @@ static void sighandler(int signal)
 		cancel_thread(thread->thread_id);
 	}
 
+	tcmu_cancel_log_thread();
+
 	exit(1);
 }
 
@@ -799,8 +801,6 @@ int main(int argc, char **argv)
 	tcmu_load_config(cfg, NULL);
 	tcmu_set_log_level(cfg->log_level);
 
-	tcmu_log_open_syslog(TCMU_RUNNER, 0, 0);
-
 	while (1) {
 		int option_index = 0;
 
@@ -899,7 +899,6 @@ int main(int argc, char **argv)
 	tcmu_dbg("Exiting...\n");
 	g_bus_unown_name(reg_id);
 	g_main_loop_unref(loop);
-	tcmu_log_close_syslog();
 	tcmu_config_destroy(cfg);
 
 	return 0;

--- a/tcmu-synthesizer.c
+++ b/tcmu-synthesizer.c
@@ -187,8 +187,6 @@ int main(int argc, char **argv)
 	GIOChannel *libtcmu_gio;
 	struct tcmulib_context *ctx;
 
-	tcmu_log_open_syslog(TCMU_SYNC, 0, 0);
-
 	while (1) {
 		int c;
 		int option_index = 0;
@@ -224,6 +222,5 @@ int main(int argc, char **argv)
 	loop = g_main_loop_new(NULL, FALSE);
 	g_main_loop_run(loop);
 	g_main_loop_unref(loop);
-	tcmu_log_close_syslog();
 	return 0;
 }


### PR DESCRIPTION
Add nonblock logger by using ring buffer. Log request is inserted into the rb as an array element firstly.A handler thread will fetch logs from the rb to output to syslog.
Output to stdout while log level is DEBUG is temporarily added in this patch.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>
Signed-off-by: Jianfei Hu <hujianfei@cmss.chinamobile.com>