### PR TITLE
Restart tcmu-runner on failure

### DIFF
--- a/tcmu-runner.service
+++ b/tcmu-runner.service
@@ -5,3 +5,4 @@ Description=LIO Userspace-passthrough daemon
 Type=dbus
 BusName=org.kernel.TCMUService1
 ExecStart=/usr/bin/tcmu-runner
+Restart=on-failure


### PR DESCRIPTION
If tcmu-runner fails for any reason, systemd should restart it.

Signed-off-by: Steven Royer <seroyer@us.ibm.com>