### PR TITLE
tcmu-runner: write verify fix

### DIFF
--- a/qcow.c
+++ b/qcow.c
@@ -1426,6 +1426,7 @@ static int qcow_open(struct tcmu_device *dev)
 		tcmu_err("Could not get device block size\n");
 		goto err;
 	}
+	tcmu_set_dev_block_size(dev, bdev->block_size);
 
 	bdev->size = tcmu_get_device_size(dev);
 	if (bdev->size < 0) {


### PR DESCRIPTION
This patch addresses tcmu_write_verify not working properly.
The caller needs to pass the length as a parm, otherwise the function doesnt
work properly, and the length will be 0. Thus the code does not run.

Signed-off-by: Bryant G. Ly <bryantly@linux.vnet.ibm.com>