### PR TITLE
user:file/user:qcow - Add resize capability

### DIFF
--- a/file_example.c
+++ b/file_example.c
@@ -386,14 +386,23 @@ static int file_handle_cmd(
 	int remaining;
 	size_t ret;
 	uint32_t block_size = tcmu_get_dev_block_size(dev);
-	uint64_t num_lbas = tcmu_get_dev_num_lbas(dev);
+	uint64_t num_lbas;
 	bool do_verify = false;
 	uint64_t offset;
 	int length = 0;
 	uint64_t cur_lba = 0;
 	int rc;
+	int64_t size;
 
 	cmd = cdb[0];
+
+	size = tcmu_get_device_size(dev);
+	if (size < 0) {
+		tcmu_err("Could not get device size\n");
+		return TCMU_NOT_HANDLED;
+	}
+	tcmu_set_dev_num_lbas(dev, size / block_size);
+	num_lbas = tcmu_get_dev_num_lbas(dev);
 
 	switch (cmd) {
 	case INQUIRY:

--- a/qcow.c
+++ b/qcow.c
@@ -1498,8 +1498,17 @@ static int qcow_handle_cmd(
 	uint8_t cmd;
 	ssize_t ret;
 	uint64_t offset = bdev->block_size * tcmu_get_lba(cdb);
+	uint64_t size;
+	uint64_t num_lbas;
 
 	cmd = cdb[0];
+
+	size = tcmu_get_device_size(dev);
+	if (size < 0) {
+		tcmu_err("Could not get device size\n");
+		return TCMU_NOT_HANDLED;
+	}
+	num_lbas = size / bdev->block_size;
 
 	switch (cmd) {
 	case INQUIRY:
@@ -1510,7 +1519,7 @@ static int qcow_handle_cmd(
 		break;
 	case SERVICE_ACTION_IN_16:
 		if (cdb[1] == READ_CAPACITY_16)
-			return tcmu_emulate_read_capacity_16(bdev->num_lbas,
+			return tcmu_emulate_read_capacity_16(num_lbas,
 							     bdev->block_size,
 							     cdb, iovec,
 							     iov_cnt, sense);
@@ -1524,7 +1533,7 @@ static int qcow_handle_cmd(
 						   ASC_INVALID_FIELD_IN_CDB,
 						   NULL);
 		else
-			return tcmu_emulate_read_capacity_10(bdev->num_lbas,
+			return tcmu_emulate_read_capacity_10(num_lbas,
 							     bdev->block_size,
 							     cdb, iovec,
 							     iov_cnt, sense);


### PR DESCRIPTION
This patch allows for one to use qemu-img resize or truncate
to resize raw file types.

Signed-off-by: Bryant G. Ly <bryantly@linux.vnet.ibm.com>