### PR TITLE
logger: add tcmu_dbg_cdb() helper support

### DIFF
--- a/libtcmu.c
+++ b/libtcmu.c
@@ -405,7 +405,7 @@ static void tcmu_cdb_debug_info(const struct tcmulib_cmd *cmd)
 	}
 	sprintf(buf + n, "\n");
 
-	tcmu_dbg(buf);
+	tcmu_dbg_scsi_cmd(buf);
 
 	if (bytes > CDB_FIX_SIZE)
 		free(buf);
@@ -668,7 +668,7 @@ static void *tcmu_cmdproc_thread(void *arg)
 		tcmulib_processing_start(dev);
 
 		while ((cmd = tcmulib_get_next_command(dev)) != NULL) {
-			if (tcmu_get_log_level() == TCMU_LOG_DEBUG)
+			if (tcmu_get_log_level() == TCMU_LOG_DEBUG_SCSI_CMD)
 				tcmu_cdb_debug_info(cmd);
 
 			/* call async command */

--- a/libtcmu_config.h
+++ b/libtcmu_config.h
@@ -24,18 +24,23 @@ struct tcmu_config {
 };
 
 /*
- * There are 4 logging levels supported in tcmu.conf:
+ * There are 5 logging levels supported in tcmu.conf:
  *    1: ERROR
  *    2: WARNING
  *    3: INFO
  *    4: DEBUG
+ *    5: DEBUG SCSI CMD
  */
-#define TCMU_CONF_LOG_LEVEL_MIN 1
-#define TCMU_CONF_LOG_LEVEL_MAX 4
-#define TCMU_CONF_LOG_ERROR 1
-#define TCMU_CONF_LOG_WARN 2
-#define TCMU_CONF_LOG_INFO 3
-#define TCMU_CONF_LOG_DEBUG 4
+
+enum {
+	TCMU_CONF_LOG_LEVEL_MIN = 1,
+	TCMU_CONF_LOG_ERROR = 1,
+	TCMU_CONF_LOG_WARN,
+	TCMU_CONF_LOG_INFO,
+	TCMU_CONF_LOG_DEBUG,
+	TCMU_CONF_LOG_DEBUG_SCSI_CMD,
+	TCMU_CONF_LOG_LEVEL_MAX = TCMU_CONF_LOG_DEBUG_SCSI_CMD,
+};
 
 typedef enum {
 	TCMU_OPT_NONE = 0,

--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -234,11 +234,11 @@ static void log_output(int pri, const char *msg)
 }
 
 static bool log_buf_not_empty_output(struct log_buf *logbuf)
-{	
+{
 	unsigned int tail;
 	uint8_t pri;
 	char *msg, buf[LOG_MSG_LEN];
-	
+
 	if (!logbuf) {
 		return false;
 	}
@@ -257,12 +257,12 @@ static bool log_buf_not_empty_output(struct log_buf *logbuf)
 	pthread_mutex_unlock(&logbuf->lock);
 
 	/*
- 	 * This may block due to rsyslog and syslog-ng, etc.
- 	 * And the log productors could still insert their log
- 	 * messages into the ring buffer without blocking. But
- 	 * the ring buffer may lose some old log rbs if the
- 	 * ring buffer is full.
- 	 */
+	 * This may block due to rsyslog and syslog-ng, etc.
+	 * And the log productors could still insert their log
+	 * messages into the ring buffer without blocking. But
+	 * the ring buffer may lose some old log rbs if the
+	 * ring buffer is full.
+	 */
 	log_output(pri, buf);
 
 	return true;
@@ -355,8 +355,8 @@ static struct log_buf *tcmu_log_initialize(void)
 		pthread_mutex_unlock(&g_mutex);
 		return NULL;
 	}
-	
-	pthread_mutex_lock(&logbuf->lock);	
+
+	pthread_mutex_lock(&logbuf->lock);
 	while (!logbuf->finish_initialize)
 		pthread_cond_wait(&logbuf->cond, &logbuf->lock);
 	pthread_mutex_unlock(&logbuf->lock);

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -31,6 +31,7 @@
 #define TCMU_LOG_WARN	LOG_WARNING	/* warning conditions */
 #define TCMU_LOG_INFO	LOG_INFO	/* informational */
 #define TCMU_LOG_DEBUG	LOG_DEBUG	/* debug-level messages */
+#define TCMU_LOG_DEBUG_SCSI_CMD	(LOG_DEBUG + 1)	/* scsi cmd debug-level messages */
 
 void tcmu_set_log_level(int level);
 unsigned int tcmu_get_log_level(void);
@@ -40,9 +41,11 @@ void tcmu_err_message(const char *funcname, int linenr, const char *fmt, ...);
 void tcmu_warn_message(const char *funcname, int linenr, const char *fmt, ...);
 void tcmu_info_message(const char *funcname, int linenr, const char *fmt, ...);
 void tcmu_dbg_message(const char *funcname, int linenr, const char *fmt, ...);
+void tcmu_dbg_scsi_cmd_message(const char *funcname, int linenr, const char *fmt, ...);
 
 #define tcmu_err(...)  {tcmu_err_message(__func__, __LINE__, __VA_ARGS__);}
 #define tcmu_warn(...) {tcmu_warn_message(__func__, __LINE__, __VA_ARGS__);}
 #define tcmu_info(...) {tcmu_info_message(__func__, __LINE__, __VA_ARGS__);}
 #define tcmu_dbg(...)  {tcmu_dbg_message(__func__, __LINE__, __VA_ARGS__);}
+#define tcmu_dbg_scsi_cmd(...)  {tcmu_dbg_scsi_cmd_message(__func__, __LINE__, __VA_ARGS__);}
 #endif /* __TCMU_LOG_H */

--- a/main.c
+++ b/main.c
@@ -552,7 +552,7 @@ int main(int argc, char **argv)
 				handler_path = strdup(optarg);
 			break;
 		case 'd':
-			tcmu_set_log_level(TCMU_CONF_LOG_DEBUG);
+			tcmu_set_log_level(TCMU_CONF_LOG_DEBUG_SCSI_CMD);
 			break;
 		case 'V':
 			printf("tcmu-runner %s\n", TCMUR_VERSION);

--- a/tcmu.conf
+++ b/tcmu.conf
@@ -1,11 +1,12 @@
 # Master TCMU configuration file
 
 # Logging Controls
-# There are 4 logging levels supported:
+# There are 5 logging levels supported:
 #    1: ERROR
 #    2: WARNING
 #    3: INFO
 #    4: DEBUG
+#    5: DEBUG SCSI CMD
 # And the default logging level is 2, if you want to change the
 # default level, uncomment it and set your level number:
-#log_level = 2
+# log_level = 2


### PR DESCRIPTION
For the CDB debug messages, they will fill the logger buffer
full very quickly and will overwrite all the other err/warn/debug
messages.

Here just output the CDB debuginfo output to the stderr.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>