### PR TITLE
Add multi-output support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(tcmu
   tcmuhandler-generated.c
   libtcmu_log.c
   libtcmu_config.c
+  libtcmu_time.c
   )
 set_target_properties(tcmu
   PROPERTIES

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, China Mobile, Inc.
+ * Copyright 2016,2017 China Mobile, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -32,6 +32,15 @@
 #define TCMU_LOG_INFO	LOG_INFO	/* informational */
 #define TCMU_LOG_DEBUG	LOG_DEBUG	/* debug-level messages */
 #define TCMU_LOG_DEBUG_SCSI_CMD	(LOG_DEBUG + 1)	/* scsi cmd debug-level messages */
+
+typedef enum {
+        TCMU_LOG_TO_STDOUT,
+        TCMU_LOG_TO_SYSLOG,
+        TCMU_LOG_TO_FILE,
+} tcmu_log_destination;
+
+typedef int (*log_output_fn_t) (int priority, const char *timestamp, const char *str, void *data);
+typedef void (*log_close_fn_t) (void *data);
 
 void tcmu_set_log_level(int level);
 unsigned int tcmu_get_log_level(void);

--- a/libtcmu_time.c
+++ b/libtcmu_time.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017, China Mobile, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include <sys/time.h>
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "libtcmu_time.h"
+
+int time_string_now(char* buf)
+{
+	struct tm *tm;
+	struct timeval tv;
+
+	if (gettimeofday (&tv, NULL) < 0)
+		return -1;
+
+	/* The value maybe changed in multi-thread*/
+	tm = localtime(&tv.tv_sec);
+	if (tm == NULL)
+		return -1;
+
+	tm->tm_year += 1900;
+	tm->tm_mon += 1;
+
+	if (snprintf(buf, TCMU_TIME_STRING_BUFLEN,
+	    "%4d-%02d-%02d %02d:%02d:%02d.%03d",
+	    tm->tm_year, tm->tm_mon, tm->tm_mday,
+	    tm->tm_hour, tm->tm_min, tm->tm_sec,
+	    (int) (tv.tv_usec / 1000ull % 1000)) >= TCMU_TIME_STRING_BUFLEN)
+		return ERANGE;
+
+	return 0;
+}

--- a/libtcmu_time.h
+++ b/libtcmu_time.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017, China Mobile, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* The time format string
+ *
+ * Yr  Mon  Day  Hour  Min  Sec Ms
+ * %4d-%02d-%02d %02d:%02d:%02d.%03d
+ *
+ */
+
+# define TCMU_TIME_STRING_BUFLEN \
+    (4 + 1 + 2 + 1 + 2 + 1 + 2 + 1 + 2 + 1 + 2 + 1 + 3 + 1)
+/*   Yr      Mon     Day     Hour    Min     Sec     Ms  NULL */
+
+/* generate localtime string into buf */
+int time_string_now(char* buf);


### PR DESCRIPTION
Add multi-output support, file/stdout/sysylog are currently
supported and enabled in default.
Log format is made as "timestamp pid [log_level] msg".
The syslog level is INFO when others are DEBUG in default, and 
log level config should be moved to config file later instead the 
default configuration. 

Signed-off-by: Jianfei Hu hujianfei@cmss.chinamobile.com
Signed-off-by: Xiubo Li lixiubo@cmss.chinamobile.com
