### PR TITLE
runner: Add RESERVE and RELEASE cmds handle support.

### DIFF
--- a/api.c
+++ b/api.c
@@ -731,6 +731,16 @@ static struct {
 };
 
 /*
+ * Handle RESERVE and RELEASE.
+ */
+int tcmu_emulate_reserve_release(uint8_t *sense)
+{
+	tcmu_set_sense_data(sense, NO_SENSE, 0, NULL);
+
+	return SAM_STAT_GOOD;
+}
+
+/*
  * Handle MODE_SENSE(6) and MODE_SENSE(10).
  *
  * For TYPE_DISK only.

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -273,6 +273,9 @@ static int generic_handle_cmd(struct tcmu_device *dev,
 							     block_size,
 							     cdb, iovec,
 							     iov_cnt, sense);
+	case RESERVE:
+	case RELEASE:
+		return tcmu_emulate_reserve_release(sense);
 	case MODE_SENSE:
 	case MODE_SENSE_10:
 		return tcmu_emulate_mode_sense(cdb, iovec, iov_cnt, sense);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -74,6 +74,7 @@ int tcmu_emulate_read_capacity_10(uint64_t num_lbas, uint32_t block_size, uint8_
 				  struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
 int tcmu_emulate_read_capacity_16(uint64_t num_lbas, uint32_t block_size, uint8_t *cdb,
 				  struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+int tcmu_emulate_reserve_release(uint8_t *sense);
 int tcmu_emulate_mode_sense(uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
 int tcmu_emulate_mode_select(uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
 int tcmu_emulate_write_verify(struct tcmu_device *, struct tcmulib_cmd *,


### PR DESCRIPTION
For the EXSI(such as v5.5), when discovering and mounting the
targets, the runner will fail to handle the RESERVE cmd and then
lead the EXSI failed with I/O errors.

Here just set the sense key to NO_SENSE and return SAM_STAT_GOOD.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>