### PR TITLE
file_example: Fix endless reading the file.

### DIFF
--- a/api.c
+++ b/api.c
@@ -320,6 +320,18 @@ int tcmu_set_sense_data(uint8_t *sense_buf, uint8_t key, uint16_t asc_ascq,
 }
 
 /*
+ * Zero iovec.
+ */
+void tcmu_zero_iovec(struct iovec *iovec, size_t iov_cnt)
+{
+	while (iov_cnt) {
+		bzero(iovec->iov_base, iovec->iov_len);
+
+		iovec++;
+		iov_cnt--;
+	}
+}
+/*
  * Copy data into an iovec, and consume the space in the iovec.
  *
  * Will truncate instead of overrunning the iovec.

--- a/file_example.c
+++ b/file_example.c
@@ -148,6 +148,13 @@ static int file_read(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 						  ASC_READ_ERROR, NULL);
 			goto done;
 		}
+
+		if (ret == 0) {
+			/* EOF, then zeros the iovecs left */
+			tcmu_zero_iovec(iov, iov_cnt);
+			break;
+		}
+
 		tcmu_seek_in_iovec(iov, ret);
 		offset += ret;
 		remaining -= ret;

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -78,6 +78,7 @@ uint64_t tcmu_get_lba(uint8_t *cdb);
 uint32_t tcmu_get_xfer_length(uint8_t *cdb);
 off_t tcmu_compare_with_iovec(void *mem, struct iovec *iovec, size_t size);
 void tcmu_seek_in_iovec(struct iovec *iovec, size_t count);
+void tcmu_zero_iovec(struct iovec *iovec, size_t iov_cnt);
 size_t tcmu_memcpy_into_iovec(struct iovec *iovec, size_t iov_cnt, void *src, size_t len);
 size_t tcmu_memcpy_from_iovec(void *dest, size_t len, struct iovec *iovec, size_t iov_cnt);
 size_t tcmu_iovec_length(struct iovec *iovec, size_t iov_cnt);


### PR DESCRIPTION
When the current file size is less than its real capacity for
some reason, such just after created by file_check_config,
the preadv will return 0, and the file_read will in a infinite
loop.

Then try to zero the iovecs left.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>