### PR TITLE
libtcmu: Fix a bug with read capacity condition check

### DIFF
--- a/libtcmu.c
+++ b/libtcmu.c
@@ -211,8 +211,8 @@ static int generic_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		else
 			return TCMU_NOT_HANDLED;
 	case READ_CAPACITY:
-		if ((cdb[1] & 0x01) || (cdb[8] & 0x01))
-			/* Reserved bits for MM logical units */
+		if ((cdb[1] & 0x01) || (!(cdb[8] & 0x01) &&
+					!!(cdb[2] | cdb[3] | cdb[4] | cdb[5]))
 			return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
 						   ASC_INVALID_FIELD_IN_CDB,
 						   NULL);


### PR DESCRIPTION
For the generic cmd handler should keep the same with the
SCSI proto.

SBC-2 says:
  If the PMI bit is set to zero and the LOGICAL BLOCK
  ADDRESS field is not set to zero, the device server shall
  terminate the command with CHECK CONDITION status with
  the sense key set to ILLEGAL REQUEST and the additional
  sense code set to INVALID FIELD IN CDB.

In SBC-3, these fields are obsolete, but some SCSI
compliance tests actually check this, so we might as well
follow SBC-2.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>