### PR TITLE
runner: add possible repetitive handler registerring check.

### DIFF
--- a/file_optical.c
+++ b/file_optical.c
@@ -1692,8 +1692,8 @@ static struct tcmur_handler fbo_handler = {
 };
 
 /* Entry point must be named "handler_init". */
-void handler_init(void)
+int handler_init(void)
 {
-	tcmur_register_handler(&fbo_handler);
+	return tcmur_register_handler(&fbo_handler);
 }
 

--- a/main.c
+++ b/main.c
@@ -67,6 +67,18 @@ static struct tcmur_handler *find_handler_by_subtype(gchar *subtype)
 
 int tcmur_register_handler(struct tcmur_handler *handler)
 {
+	struct tcmur_handler *h;
+	int i;
+
+	for (i = 0; i < darray_size(g_runner_handlers); i++) {
+		h = darray_item(g_runner_handlers, i);
+		if (!strcmp(h->subtype, handler->subtype)) {
+			tcmu_err("Handler %s has already been registered\n",
+				 handler->subtype);
+			return -1;
+		}
+	}
+
 	darray_append(g_runner_handlers, handler);
 	return 0;
 }


### PR DESCRIPTION
Just encountered this when testing the old and new versions at
the same by renaming the old handlerXX.so to handlerYY.so, and
forgot to make clean or remove them. But this won't report any
warning or error message.

Maybe my way doing the test is not very wise, but this could be
a potential bug.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>