### PR TITLE
ceph rbd ALUA failover/failback support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,9 @@ set_target_properties(handler_file
   PROPERTIES
   PREFIX ""
   )
+target_include_directories(handler_file
+  PUBLIC ${PROJECT_SOURCE_DIR}/ccan
+  )
 
 # Stuff for building the file optical handler
 add_library(handler_file_optical
@@ -155,6 +158,9 @@ add_library(handler_file_optical
 set_target_properties(handler_file_optical
   PROPERTIES
   PREFIX ""
+  )
+target_include_directories(handler_file_optical
+  PUBLIC ${PROJECT_SOURCE_DIR}/ccan
   )
 target_link_libraries(handler_file_optical ${PTHREAD})
 
@@ -177,6 +183,9 @@ if (with-rbd)
 	  PROPERTIES
 	  PREFIX ""
 	  )
+	target_include_directories(handler_rbd
+	  PUBLIC ${PROJECT_SOURCE_DIR}/ccan
+	  )
 	target_link_libraries(handler_rbd
 	  ${LIBRBD}
 	  )
@@ -195,6 +204,9 @@ if (with-glfs)
 	  PROPERTIES
 	  PREFIX ""
 	  )
+	target_include_directories(handler_glfs
+	  PUBLIC ${PROJECT_SOURCE_DIR}/ccan
+	  )
 	target_link_libraries(handler_glfs
 	  ${GFAPI}
 	  )
@@ -212,6 +224,9 @@ if (with-qcow)
 	set_target_properties(handler_qcow
 	  PROPERTIES
 	  PREFIX ""
+	  )
+	target_include_directories(handler_qcow
+	  PUBLIC ${PROJECT_SOURCE_DIR}/ccan
 	  )
 
 	CHECK_INCLUDE_FILE("linux/falloc.h" HAVE_LINUX_FALLOC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(tcmu
   SHARED
   configfs.c
   api.c
+  alua.c
   libtcmu.c
   libtcmu-register.c
   tcmuhandler-generated.c
@@ -65,6 +66,7 @@ install(TARGETS tcmu LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 add_library(tcmu_static
   configfs.c
   api.c
+  alua.c
   libtcmu.c
   libtcmu-register.c
   tcmuhandler-generated.c

--- a/alua.c
+++ b/alua.c
@@ -407,3 +407,240 @@ struct tgt_port *tcmu_get_enabled_port(struct list_head *group_list)
 
 	return NULL;
 }
+
+static bool alua_check_sup_state(uint8_t state, uint8_t sup)
+{
+	switch (state) {
+	case ALUA_ACCESS_STATE_OPTIMIZED:
+		if (sup & ALUA_SUP_OPTIMIZED)
+			return true;
+		return false;
+	case ALUA_ACCESS_STATE_NON_OPTIMIZED:
+		if (sup & ALUA_SUP_NON_OPTIMIZED)
+			return true;
+		return false;
+	case ALUA_ACCESS_STATE_STANDBY:
+		if (sup & ALUA_SUP_STANDBY)
+			return true;
+		return false;
+	case ALUA_ACCESS_STATE_UNAVAILABLE:
+		if (sup & ALUA_SUP_UNAVAILABLE)
+			return true;
+		return false;
+	case ALUA_ACCESS_STATE_OFFLINE:
+		/*
+		 * TODO: support secondary states
+		 */
+		return false;
+	}
+
+	return false;
+}
+
+int tcmu_transition_tgt_port_grp(struct tgt_port_grp *group, uint8_t new_state,
+				 uint8_t alua_status, uint8_t *sense,
+				 tcmu_transition_state_fn_t *transition_fn)
+{
+	struct tcmu_device *dev = group->dev;
+	int ret;
+
+	tcmu_dbg("transition group %u new state %u old state %u sup 0x%x\n",
+		 group->id, new_state, group->state, group->supported_states);
+
+	if (!alua_check_sup_state(new_state, group->supported_states)) {
+		if (sense)
+			return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
+					ASC_INVALID_FIELD_IN_PARAMETER_LIST,
+					NULL);
+		else
+			return SAM_STAT_CHECK_CONDITION;
+	}
+
+	if (transition_fn) {
+		ret = transition_fn(dev, group, new_state, sense);
+		if (ret != SAM_STAT_GOOD)
+			return ret;
+	}
+
+	ret = tcmu_set_alua_int_setting(group, "alua_access_state", new_state);
+	if (ret) {
+		tcmu_err("Could not change kernel state to %u\n", new_state);
+		if (sense)
+			return tcmu_set_sense_data(sense, HARDWARE_ERROR,
+						   ASC_STPG_CMD_FAILED, NULL);
+		else
+			return SAM_STAT_CHECK_CONDITION;
+	}
+
+	ret = tcmu_set_alua_int_setting(group, "alua_access_status",
+					ALUA_STAT_ALTERED_BY_EXPLICIT_STPG);
+	if (ret)
+		tcmu_err("Could not set alua_access_status for group %s:%d\n",
+			 group->name, group->id);
+
+	group->state = new_state;
+	group->status = alua_status;
+	return SAM_STAT_GOOD;
+}
+
+int tcmu_emulate_report_tgt_port_grps(struct tcmu_device *dev,
+				      struct list_head *group_list,
+				      struct tcmulib_cmd *cmd,
+				      tcmu_report_state_fn_t *report_fn)
+{
+	struct tgt_port_grp *group;
+	struct tgt_port *port;
+	int ext_hdr = cmd->cdb[1] & 0x20;
+	uint32_t off = 4, ret_data_len = 0, ret32;
+	uint32_t alloc_len = tcmu_get_xfer_length(cmd->cdb);
+	uint8_t *buf, state;
+
+	if (alloc_len < 4)
+		return tcmu_set_sense_data(cmd->sense_buf, HARDWARE_ERROR,
+					   ASC_INTERNAL_TARGET_FAILURE, NULL);
+
+	buf = calloc(1, alloc_len);
+	if (!buf)
+		return tcmu_set_sense_data(cmd->sense_buf, HARDWARE_ERROR,
+					   ASC_INTERNAL_TARGET_FAILURE, NULL);
+
+	if (ext_hdr && alloc_len > 5 && !list_empty(group_list)) {
+		buf[4] = 0x10;
+		/*
+		 * assume all groups will have the same value for now.
+		 */
+		group = list_first_entry(group_list, struct tgt_port_grp,
+					 entry);
+		if (group)
+			buf[5] = group->implicit_trans_secs;
+		off = 8;
+	}
+
+	list_for_each(group_list, group, entry) {
+		int next_off = off + 8 + (group->num_tgt_ports * 4);
+
+		if (next_off > alloc_len) {
+			ret_data_len += next_off;
+			continue;
+		}
+
+		if (group->pref)
+			buf[off] = 0x80;
+
+		if (report_fn) {
+			state = report_fn(dev, group);
+			/*
+			 * Some handlers are not able to async update state,
+			 * so check it now and update.
+			 */
+			if (state != group->state) {
+				if (tcmu_transition_tgt_port_grp(group, state,
+							TPGS_ALUA_IMPLICIT,
+							NULL, NULL))
+					tcmu_err("Could not perform implicit state change for group %u\n", group->id);
+			}
+		} else {
+			state = group->state;
+		}
+
+		buf[off++] |= state;
+		buf[off++] |= group->supported_states;
+		buf[off++] = (group->id >> 8) & 0xff;
+		buf[off++] = group->id & 0xff;
+		/* reserved */
+		off++;
+		buf[off++] = group->status;
+		/* vendor specific */
+		off++;
+		buf[off++] = group->num_tgt_ports;
+
+		ret_data_len += 8;
+
+		list_for_each(&group->tgt_ports, port, entry) {
+			/* reserved */
+			off += 2;
+			buf[off++] = (port->rel_port_id >> 8) & 0xff;
+			buf[off++] = port->rel_port_id & 0xff;
+
+			ret_data_len += 4;
+		}
+
+	}
+	ret32 = htobe32(ret_data_len);
+	memcpy(&buf[0], &ret32, 4);
+
+	tcmu_memcpy_into_iovec(cmd->iovec, cmd->iov_cnt, buf, alloc_len);
+	free(buf);
+	return SAM_STAT_GOOD;
+}
+
+int tcmu_emulate_set_tgt_port_grps(struct tcmu_device *dev,
+				   struct list_head *group_list,
+				   struct tcmulib_cmd *cmd,
+				   tcmu_transition_state_fn_t *transition_fn)
+{
+	struct tgt_port_grp *group;
+	uint32_t off = 4, param_list_len = tcmu_get_xfer_length(cmd->cdb);
+	uint16_t id, tmp_id;
+	char *buf, new_state;
+	int found, ret = SAM_STAT_GOOD;
+
+	if (!param_list_len)
+		return SAM_STAT_GOOD;
+
+	buf = calloc(1, param_list_len);
+	if (!buf)
+		return tcmu_set_sense_data(cmd->sense_buf, HARDWARE_ERROR,
+					   ASC_INTERNAL_TARGET_FAILURE, NULL);
+
+	if (tcmu_memcpy_from_iovec(buf, param_list_len, cmd->iovec,
+				   cmd->iov_cnt) != param_list_len) {
+		ret = tcmu_set_sense_data(cmd->sense_buf, ILLEGAL_REQUEST,
+					  ASC_PARAMETER_LIST_LENGTH_ERROR,
+					  NULL);
+		goto free_buf;
+	}
+
+	while (off < param_list_len) {
+		new_state = buf[off++] & 0x0f;
+		/* reserved */
+		off++;
+		memcpy(&tmp_id, &buf[off], sizeof(tmp_id));
+		id = be16toh(tmp_id);
+		off += 2;
+
+		found = 0;
+		list_for_each(group_list, group, entry) {
+			if (group->id != id)
+				continue;
+
+			tcmu_dbg("Got STPG for group %u\n", id);
+			ret = tcmu_transition_tgt_port_grp(group, new_state,
+							   TPGS_ALUA_EXPLICIT,
+							   cmd->sense_buf,
+							   transition_fn);
+			if (ret) {
+				tcmu_err("Failing STPG for group %d\n", id);
+				goto free_buf;
+			}
+			found = 1;
+			break;
+		}
+
+		if (!found) {
+			/*
+			 * Could not find what error code to return in
+			 * SCSI spec.
+			 */
+			tcmu_err("Could not find group for %u for STPG\n", id);
+			ret = tcmu_set_sense_data(cmd->sense_buf,
+					HARDWARE_ERROR,
+					ASC_STPG_CMD_FAILED, NULL);
+			break;
+		}
+	}
+
+free_buf:
+	free(buf);
+	return ret;
+}

--- a/alua.c
+++ b/alua.c
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2017, Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+*/
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <dirent.h>
+#include <inttypes.h>
+#include <limits.h>
+
+#include "ccan/list/list.h"
+
+#include <scsi/scsi.h>
+
+#include "libtcmu_log.h"
+#include "libtcmu_common.h"
+#include "libtcmu_priv.h"
+#include "alua.h"
+
+static int tcmu_get_tpgt_int(struct tgt_port *port, const char *name)
+{
+	char path[PATH_MAX];
+
+	snprintf(path, sizeof(path),
+		 CFGFS_ROOT"/%s/%s/tpgt_%hu/%s",
+		 port->fabric, port->wwn, port->tpgt, name);
+	return tcmu_get_cfgfs_int(path);
+}
+
+static int tcmu_get_lun_int_stat(struct tgt_port *port, uint64_t lun,
+				 const char *stat_name)
+{
+	char path[PATH_MAX];
+
+	snprintf(path, sizeof(path),
+		 CFGFS_ROOT"/%s/%s/tpgt_%hu/lun/lun_%"PRIu64"/statistics/%s",
+		 port->fabric, port->wwn, port->tpgt, lun, stat_name);
+	return tcmu_get_cfgfs_int(path);
+}
+
+static char *tcmu_get_alua_str_setting(struct tgt_port_grp *group,
+				       const char *setting)
+{
+	char path[PATH_MAX];
+
+	snprintf(path, sizeof(path), CFGFS_CORE"/%s/%s/alua/%s/%s",
+		 group->dev->tcm_hba_name, group->dev->tcm_dev_name,
+		 group->name, setting);
+	return tcmu_get_cfgfs_str(path);
+}
+
+static int tcmu_get_alua_int_setting(struct tgt_port_grp *group,
+				     const char *setting)
+{
+	char path[PATH_MAX];
+
+	snprintf(path, sizeof(path), CFGFS_CORE"/%s/%s/alua/%s/%s",
+		 group->dev->tcm_hba_name, group->dev->tcm_dev_name,
+		 group->name, setting);
+	return tcmu_get_cfgfs_int(path);
+}
+
+static int tcmu_set_alua_int_setting(struct tgt_port_grp *group,
+				     const char *setting, int val)
+{
+	char path[PATH_MAX];
+
+	snprintf(path, sizeof(path), CFGFS_CORE"/%s/%s/alua/%s/%s",
+		 group->dev->tcm_hba_name, group->dev->tcm_dev_name,
+		 group->name, setting);
+	return tcmu_set_cfgfs_ul(path, val);
+}
+
+static void tcmu_free_tgt_port(struct tgt_port *port)
+{
+	if (port->wwn)
+		free(port->wwn);
+	if (port->fabric)
+		free(port->fabric);
+	free(port);
+}
+
+static void tcmu_release_tgt_ports(struct tgt_port_grp *group)
+{
+	struct tgt_port *port, *port_next;
+
+	list_for_each_safe(&group->tgt_ports, port, port_next, entry) {
+		list_del(&port->entry);
+		tcmu_free_tgt_port(port);
+	}
+}
+
+static struct tgt_port *
+tcmu_get_tgt_port(struct tgt_port_grp *group, char *member_str)
+{
+	struct tgt_port *port;
+	char fabric[17], wwn[224];
+	uint64_t lun;
+	uint16_t tpgt;
+	int ret;
+
+	if (!strlen(member_str))
+		return NULL;
+
+	ret = sscanf(member_str, "%16[^/]/%223[^/]/tpgt_%hu/lun_%"PRIu64,
+		     fabric, wwn, &tpgt, &lun);
+	if (ret != 4) {
+		tcmu_err("Invalid ALUA member %s for group %s\n", member_str,
+			 group->name);
+		return NULL;
+	}
+
+	port = calloc(1, sizeof(*port));
+	if (!port)
+		return NULL;
+	list_node_init(&port->entry);
+	port->grp = group;
+
+	if (!strcmp(fabric, "iSCSI"))
+		/*
+		 * iSCSI's fabric name and target_core_fabric_ops name do
+		 * not match.
+		 */
+		port->fabric = strdup("iscsi");
+	else
+		port->fabric = strdup(fabric);
+	if (!port->fabric)
+		goto free_port;
+
+	port->wwn = strdup(wwn);
+	if (!port->wwn)
+		goto free_port;
+
+	port->tpgt = tpgt;
+
+	ret = tcmu_get_lun_int_stat(port, lun, "scsi_port/indx");
+	if (ret < 0)
+		goto free_port;
+
+	port->rel_port_id = ret;
+
+	ret = tcmu_get_lun_int_stat(port, lun, "scsi_transport/proto_id");
+	if (ret < 0)
+		goto free_port;
+	port->proto_id = ret;
+
+	ret = tcmu_get_tpgt_int(port, "enable");
+	if (ret < 0)
+		goto free_port;
+	port->enabled = ret;
+
+	return port;
+
+free_port:
+	tcmu_free_tgt_port(port);
+	return NULL;
+}
+
+static void tcmu_free_tgt_port_grp(struct tgt_port_grp *group)
+{
+	tcmu_release_tgt_ports(group);
+
+	if (group->name)
+		free(group->name);
+	free(group);
+}
+
+static struct tgt_port_grp *
+tcmu_get_tgt_port_grp(struct tcmu_device *dev, const char *name)
+{
+	struct tgt_port_grp *group;
+	struct tgt_port *port;
+	char *str_val, *orig_str_val, *member;
+	int val;
+
+	group = calloc(1, sizeof(*group));
+	if (!group)
+		return NULL;
+	list_head_init(&group->tgt_ports);
+	list_node_init(&group->entry);
+	group->dev = dev;
+	group->name = strdup(name);
+	if (!group->name)
+		goto free_group;
+
+	val = tcmu_get_alua_int_setting(group, "alua_access_state");
+	if (val < 0)
+		goto free_group;
+	group->state = val;
+
+	val = tcmu_get_alua_int_setting(group, "alua_support_active_nonoptimized");
+	if (val < 0)
+		goto free_group;
+	if (val)
+		group->supported_states |= ALUA_SUP_NON_OPTIMIZED;
+
+	val = tcmu_get_alua_int_setting(group, "alua_support_active_optimized");
+	if (val < 0)
+		goto free_group;
+	if (val)
+		group->supported_states |= ALUA_SUP_OPTIMIZED;
+
+	val = tcmu_get_alua_int_setting(group, "alua_support_lba_dependent");
+	if (val < 0)
+		goto free_group;
+	if (val)
+		group->supported_states |= ALUA_SUP_LBA_DEPENDENT;
+
+	val = tcmu_get_alua_int_setting(group, "alua_support_offline");
+	if (val < 0)
+		goto free_group;
+	if (val)
+		group->supported_states |= ALUA_SUP_OFFLINE;
+
+	val = tcmu_get_alua_int_setting(group, "alua_support_standby");
+	if (val < 0)
+		goto free_group;
+	if (val)
+		group->supported_states |= ALUA_SUP_STANDBY;
+
+	val = tcmu_get_alua_int_setting(group, "alua_support_transitioning");
+	if (val < 0)
+		goto free_group;
+	if (val)
+		group->supported_states |= ALUA_SUP_TRANSITIONING;
+
+	val = tcmu_get_alua_int_setting(group, "alua_support_unavailable");
+	if (val < 0)
+		goto free_group;
+	if (val)
+		group->supported_states |= ALUA_SUP_UNAVAILABLE;
+
+	val = tcmu_get_alua_int_setting(group, "implicit_trans_secs");
+	if (val < 0)
+		goto free_group;
+	group->implicit_trans_secs = val;
+
+	val = tcmu_get_alua_int_setting(group, "nonop_delay_msecs");
+	if (val < 0)
+		goto free_group;
+	group->nonop_delay_msecs = val;
+
+	val = tcmu_get_alua_int_setting(group, "trans_delay_msecs");
+	if (val < 0)
+		goto free_group;
+	group->trans_delay_msecs = val;
+
+	val = tcmu_get_alua_int_setting(group, "tg_pt_gp_id");
+	if (val < 0)
+		goto free_group;
+	group->id = val;
+
+	val = tcmu_get_alua_int_setting(group, "preferred");
+	if (val < 0)
+		goto free_group;
+	group->pref = val ? true : false;
+
+	str_val = tcmu_get_alua_str_setting(group, "alua_access_status");
+	if (!str_val)
+		goto free_group;
+
+	if (!strcmp(str_val, "None"))
+		group->status = ALUA_STAT_NONE;
+	else if (!strcmp(str_val, "Altered by Explicit STPG"))
+		group->status = ALUA_STAT_ALTERED_BY_EXPLICIT_STPG;
+	else if (!strcmp(str_val, "Altered by Implicit ALUA"))
+		group->status = ALUA_STAT_ALTERED_BY_IMPLICIT_ALUA;
+	else
+		tcmu_err("Invalid ALUA status %s", str_val);
+	free(str_val);
+
+	str_val = tcmu_get_alua_str_setting(group, "alua_access_type");
+	if (!str_val)
+		goto free_group;
+
+	if (!strcmp(str_val, "None"))
+		group->tpgs = TPGS_ALUA_NONE;
+	else if (!strcmp(str_val, "Implicit"))
+		group->tpgs = TPGS_ALUA_IMPLICIT;
+	else if (!strcmp(str_val, "Explicit"))
+		group->tpgs = TPGS_ALUA_EXPLICIT;
+	else if (!strcmp(str_val, "Implicit and Explicit"))
+		group->tpgs = (TPGS_ALUA_IMPLICIT | TPGS_ALUA_EXPLICIT);
+	else
+		tcmu_err("Invalid ALUA type %s", str_val);
+	free(str_val);
+
+	str_val = orig_str_val = tcmu_get_alua_str_setting(group, "members");
+	if (str_val) {
+		while ((member = strsep(&str_val, "\n"))) {
+			if (!strlen(member))
+				continue;
+
+			port = tcmu_get_tgt_port(group, member);
+			if (!port) {
+				free(orig_str_val);
+				goto free_ports;
+			}
+			group->num_tgt_ports++;
+			list_add_tail(&group->tgt_ports, &port->entry);
+		}
+	}
+
+	free(orig_str_val);
+	return group;
+
+free_ports:
+	tcmu_release_tgt_ports(group);
+free_group:
+	tcmu_free_tgt_port_grp(group);
+	return NULL;
+}
+
+void tcmu_release_tgt_port_grps(struct list_head *group_list)
+{
+	struct tgt_port_grp *group, *group_next;
+
+	list_for_each_safe(group_list, group, group_next, entry) {
+		list_del(&group->entry);
+		tcmu_free_tgt_port_grp(group);
+	}
+}
+
+static int alua_filter(const struct dirent *dir)
+{
+        return strcmp(dir->d_name, ".") && strcmp(dir->d_name, "..");
+}
+
+/**
+ * tcmu_get_tgt_port_grps: Fill group_list with the kernel's port groups.
+ * @dev: device to get groups for.
+ * @group_list: list allocated by the caller to add groups to.
+ *
+ * User must call tcmu_release_tgt_port_grps when finished with the list of
+ * groups.
+ */
+int tcmu_get_tgt_port_grps(struct tcmu_device *dev,
+			   struct list_head *group_list)
+{
+	struct tgt_port_grp *group;
+	struct dirent **namelist;
+	char path[PATH_MAX];
+	int i, n, ret = 0;
+
+	snprintf(path, sizeof(path), CFGFS_CORE"/%s/%s/alua",
+		 dev->tcm_hba_name, dev->tcm_dev_name);
+	n = scandir(path, &namelist, alua_filter, alphasort);
+	if (n < 0) {
+		tcmu_err("Could not get ALUA dirs for %s\n", path);
+		return -errno;
+	}
+
+	for (i = 0; i < n; i++) {
+		group = tcmu_get_tgt_port_grp(dev, namelist[i]->d_name);
+		if (!group)
+			goto free_groups;
+		list_add_tail(group_list, &group->entry);
+	}
+	goto free_names;
+
+free_groups:
+	tcmu_release_tgt_port_grps(group_list);
+free_names:
+	for (i = 0; i < n; i++)
+		free(namelist[i]);
+	free(namelist);
+	return ret;
+}
+
+/*
+ * tcmu does not pass up the target port that the command was
+ * received on, so if a LUN is exported through multiple ports
+ * in different ALUA target port group we do not know which group
+ * to use.
+ *
+ * For now we support one target port group that contains all
+ * enabled ports, or for HA configs one local target port group with
+ * enabled ports and N remote port groups which are marked disabled
+ * on the the local node.
+ */
+struct tgt_port *tcmu_get_enabled_port(struct list_head *group_list)
+{
+	struct tgt_port_grp *group;
+	struct tgt_port *port;
+
+	list_for_each(group_list, group, entry) {
+		list_for_each(&group->tgt_ports, port, entry) {
+			if (port->enabled)
+				return port;
+		}
+	}
+
+	return NULL;
+}

--- a/alua.h
+++ b/alua.h
@@ -20,6 +20,7 @@
 #include "ccan/list/list.h"
 
 struct tcmu_device;
+struct tcmulibc_cmd;
 
 struct tgt_port {
 	uint16_t rel_port_id;
@@ -59,6 +60,20 @@ struct tgt_port_grp {
 	struct list_head tgt_ports;
 };
 
+typedef int (tcmu_transition_state_fn_t)(struct tcmu_device *,
+					 struct tgt_port_grp *,
+					 uint8_t new_state, uint8_t *sense);
+typedef int tcmu_report_state_fn_t(struct tcmu_device *,
+				   struct tgt_port_grp *);
+
+int tcmu_emulate_set_tgt_port_grps(struct tcmu_device *dev,
+				   struct list_head *group_list,
+				   struct tcmulib_cmd *cmd,
+				   tcmu_transition_state_fn_t *transition_fn);
+int tcmu_emulate_report_tgt_port_grps(struct tcmu_device *dev,
+				      struct list_head *group_list,
+				      struct tcmulib_cmd *cmd,
+				      tcmu_report_state_fn_t *report_fn);
 struct tgt_port *tcmu_get_enabled_port(struct list_head *);
 int tcmu_get_tgt_port_grps(struct tcmu_device *, struct list_head *);
 void tcmu_release_tgt_port_grps(struct list_head *);

--- a/alua.h
+++ b/alua.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017, Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+*/
+
+#ifndef __TCMU_ALUA_H
+#define __TCMU_ALUA_H
+
+#include "ccan/list/list.h"
+
+struct tcmu_device;
+
+struct tgt_port {
+	uint16_t rel_port_id;
+	uint8_t proto_id;
+	char *wwn;
+
+	/* LIO settings */
+	char *fabric;
+	bool enabled;
+	/* configfs tpgt */
+	uint16_t tpgt;
+
+	struct tgt_port_grp *grp;
+	/* entry on group's tgt_ports list */
+	struct list_node entry;
+};
+
+struct tgt_port_grp {
+	/* ALUA spec values */
+	uint8_t state;
+	uint8_t supported_states;
+	uint8_t tpgs;
+	uint8_t status;
+	uint8_t implicit_trans_secs;
+	bool pref;
+	uint16_t id;
+
+	/* LIO settings */
+	char *name;
+	unsigned nonop_delay_msecs;
+	unsigned trans_delay_msecs;
+
+	struct tcmu_device *dev;
+	uint8_t num_tgt_ports;
+	/* entry on list returned by lib */
+	struct list_node entry;
+	struct list_head tgt_ports;
+};
+
+struct tgt_port *tcmu_get_enabled_port(struct list_head *);
+int tcmu_get_tgt_port_grps(struct tcmu_device *, struct list_head *);
+void tcmu_release_tgt_port_grps(struct list_head *);
+
+#endif

--- a/api.c
+++ b/api.c
@@ -330,6 +330,7 @@ static bool char_to_hex(unsigned char *val, char c)
 
 int tcmu_emulate_evpd_inquiry(
 	struct tcmu_device *dev,
+	struct tgt_port *port,
 	uint8_t *cdb,
 	struct iovec *iovec,
 	size_t iov_cnt,
@@ -374,7 +375,7 @@ int tcmu_emulate_evpd_inquiry(
 
 		ptr = &data[4];
 
-		/* 1/3: T10 Vendor id */
+		/* 1/5: T10 Vendor id */
 		ptr[0] = 2; /* code set: ASCII */
 		ptr[1] = 1; /* identifier: T10 vendor id */
 		memcpy(&ptr[4], "LIO-ORG ", 8);
@@ -384,7 +385,7 @@ int tcmu_emulate_evpd_inquiry(
 		used += (uint8_t)ptr[3] + 4;
 		ptr += used;
 
-		/* 2/3: NAA binary */
+		/* 2/5: NAA binary */
 		ptr[0] = 1; /* code set: binary */
 		ptr[1] = 3; /* identifier: NAA */
 		ptr[3] = 16; /* body length for naa registered extended format */
@@ -425,7 +426,7 @@ int tcmu_emulate_evpd_inquiry(
 		used += 20;
 		ptr += 20;
 
-		/* 3/3: Vendor specific */
+		/* 3/6: Vendor specific */
 		ptr[0] = 2; /* code set: ASCII */
 		ptr[1] = 0; /* identifier: vendor-specific */
 
@@ -433,7 +434,37 @@ int tcmu_emulate_evpd_inquiry(
 		ptr[3] = len + 1;
 
 		used += (uint8_t)ptr[3] + 4;
+		ptr += (uint8_t)ptr[3] + 4;
 
+		if (!port)
+			goto finish_page83;
+
+		/* 4/5: Relative target port ID */
+		ptr[0] = port->proto_id << 4; /* proto id */
+		ptr[0] |= 0x1; /* Code set: binary */
+		ptr[1] = 0x80; /* PIV set */
+		ptr[1] |= 0x10; /* Association: 1b assoc with target port */
+		ptr[1] |= 0x4; /* Designator type: Relative target port ID */
+		ptr[3] = 4;
+		/* rel tgt port ID */
+		ptr[6] = (port->rel_port_id >> 8) & 0xff;
+		ptr[7] = port->rel_port_id & 0xff;
+		used += 8;
+		ptr += 8;
+
+		/* 5/5: Target port group */
+		ptr[0] = port->proto_id << 4; /* proto id */
+		ptr[0] |= 0x1; /* Code set: binary */
+		ptr[1] = 0x80; /* PIV set */
+		ptr[1] |= 0x10; /* Association: 1b assoc with target port */
+		ptr[1] |= 0x5; /* Designator type: target port group */
+		ptr[3] = 4;
+		/* tpg id */
+		ptr[6] = (port->grp->id >> 8) & 0xff;
+		ptr[7] = port->grp->id & 0xff;
+		used += 8;
+
+finish_page83:
 		/* Done with descriptor list */
 
 		*tot_len = htobe16(used);
@@ -512,9 +543,9 @@ int tcmu_emulate_inquiry(
 		else
 			return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
 						   ASC_INVALID_FIELD_IN_CDB, NULL);
-	}
-	else {
-		return tcmu_emulate_evpd_inquiry(dev, cdb, iovec, iov_cnt, sense);
+	} else {
+		return tcmu_emulate_evpd_inquiry(dev, port, cdb, iovec, iov_cnt,
+						 sense);
 	}
 }
 

--- a/configfs.c
+++ b/configfs.c
@@ -26,7 +26,6 @@
 #include "libtcmu_common.h"
 #include "libtcmu_priv.h"
 
-#define CFGFS_CORE "/sys/kernel/config/target/core"
 #define CFGFS_BUF_SIZE 4096
 
 int tcmu_get_cfgfs_int(const char *path)

--- a/consumer.c
+++ b/consumer.c
@@ -91,7 +91,8 @@ static int foo_handle_cmd(
 
 	switch (cmd) {
 	case INQUIRY:
-		return tcmu_emulate_inquiry(dev, cdb, iovec, iov_cnt, sense);
+		return tcmu_emulate_inquiry(dev, NULL, cdb, iovec, iov_cnt,
+					    sense);
 		break;
 	case TEST_UNIT_READY:
 		return tcmu_emulate_test_unit_ready(cdb, iovec, iov_cnt, sense);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 struct tcmu_device;
+struct tgt_port;
 struct tcmulib_cmd;
 
 #define TCMU_NOT_HANDLED -1
@@ -91,7 +92,7 @@ size_t tcmu_iovec_length(struct iovec *iovec, size_t iov_cnt);
 
 /* Basic implementations of mandatory SCSI commands */
 int tcmu_set_sense_data(uint8_t *sense_buf, uint8_t key, uint16_t asc_ascq, uint32_t *info);
-int tcmu_emulate_inquiry(struct tcmu_device *dev, uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+int tcmu_emulate_inquiry(struct tcmu_device *dev, struct tgt_port *port, uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
 int tcmu_emulate_start_stop(struct tcmu_device *dev, uint8_t *cdb, uint8_t *sense);
 int tcmu_emulate_test_unit_ready(uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
 int tcmu_emulate_read_capacity_10(uint64_t num_lbas, uint32_t block_size, uint8_t *cdb,

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -35,6 +35,9 @@ struct tcmulib_cmd;
 
 #define SENSE_BUFFERSIZE 96
 
+#define CFGFS_ROOT "/sys/kernel/config/target"
+#define CFGFS_CORE CFGFS_ROOT"/core"
+
 typedef void (*cmd_done_t)(struct tcmu_device *, struct tcmulib_cmd *, int);
 
 struct tcmulib_cmd {

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -69,6 +69,10 @@ struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev);
 struct tcmur_handler *tcmu_get_runner_handler(struct tcmu_device *dev);
 
 /* Helper routines for processing commands */
+char *tcmu_get_cfgfs_str(const char *path);
+int tcmu_set_cfgfs_str(const char *path, const char *val, int val_len);
+int tcmu_get_cfgfs_int(const char *path);
+int tcmu_set_cfgfs_ul(const char *path, unsigned long val);
 int tcmu_get_attribute(struct tcmu_device *dev, const char *name);
 long long tcmu_get_device_size(struct tcmu_device *dev);
 char *tcmu_get_wwn(struct tcmu_device *dev);

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -42,19 +42,28 @@ typedef enum {
 typedef int (*log_output_fn_t) (int priority, const char *timestamp, const char *str, void *data);
 typedef void (*log_close_fn_t) (void *data);
 
+struct tcmu_device;
+
 void tcmu_set_log_level(int level);
 unsigned int tcmu_get_log_level(void);
 void tcmu_cancel_log_thread(void);
 
-void tcmu_err_message(const char *funcname, int linenr, const char *fmt, ...);
-void tcmu_warn_message(const char *funcname, int linenr, const char *fmt, ...);
-void tcmu_info_message(const char *funcname, int linenr, const char *fmt, ...);
-void tcmu_dbg_message(const char *funcname, int linenr, const char *fmt, ...);
-void tcmu_dbg_scsi_cmd_message(const char *funcname, int linenr, const char *fmt, ...);
+void tcmu_err_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
+void tcmu_warn_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
+void tcmu_info_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
+void tcmu_dbg_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
+void tcmu_dbg_scsi_cmd_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
 
-#define tcmu_err(...)  {tcmu_err_message(__func__, __LINE__, __VA_ARGS__);}
-#define tcmu_warn(...) {tcmu_warn_message(__func__, __LINE__, __VA_ARGS__);}
-#define tcmu_info(...) {tcmu_info_message(__func__, __LINE__, __VA_ARGS__);}
-#define tcmu_dbg(...)  {tcmu_dbg_message(__func__, __LINE__, __VA_ARGS__);}
-#define tcmu_dbg_scsi_cmd(...)  {tcmu_dbg_scsi_cmd_message(__func__, __LINE__, __VA_ARGS__);}
+#define tcmu_dev_err(dev, ...)  {tcmu_err_message(dev, __func__, __LINE__, __VA_ARGS__);}
+#define tcmu_dev_warn(dev, ...) {tcmu_warn_message(dev, __func__, __LINE__, __VA_ARGS__);}
+#define tcmu_dev_info(dev, ...) {tcmu_info_message(dev, __func__, __LINE__, __VA_ARGS__);}
+#define tcmu_dev_dbg(dev, ...)  {tcmu_dbg_message(dev, __func__, __LINE__, __VA_ARGS__);}
+#define tcmu_dev_dbg_scsi_cmd(dev, ...)  {tcmu_dbg_scsi_cmd_message(dev, __func__, __LINE__, __VA_ARGS__);}
+
+
+#define tcmu_err(...)  {tcmu_err_message(NULL, __func__, __LINE__, __VA_ARGS__);}
+#define tcmu_warn(...) {tcmu_warn_message(NULL, __func__, __LINE__, __VA_ARGS__);}
+#define tcmu_info(...) {tcmu_info_message(NULL, __func__, __LINE__, __VA_ARGS__);}
+#define tcmu_dbg(...)  {tcmu_dbg_message(NULL, __func__, __LINE__, __VA_ARGS__);}
+#define tcmu_dbg_scsi_cmd(...)  {tcmu_dbg_scsi_cmd_message(NULL, __func__, __LINE__, __VA_ARGS__);}
 #endif /* __TCMU_LOG_H */

--- a/rbd.c
+++ b/rbd.c
@@ -547,7 +547,7 @@ static int tcmu_rbd_read(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 
 	aio_cb = calloc(1, sizeof(*aio_cb));
 	if (!aio_cb) {
-		tcmu_err("could not allocated aio_cb\n");
+		tcmu_dev_err(dev, "Could not allocate aio_cb.\n");
 		goto out;
 	}
 
@@ -557,7 +557,7 @@ static int tcmu_rbd_read(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 
 	aio_cb->bounce_buffer = malloc(length);
 	if (!aio_cb->bounce_buffer) {
-		tcmu_err("could not allocate bounce buffer\n");
+		tcmu_dev_err(dev, "Could not allocate bounce buffer.\n");
 		goto out_free_aio_cb;
 	}
 
@@ -628,7 +628,7 @@ static int tcmu_rbd_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 
 	aio_cb = calloc(1, sizeof(*aio_cb));
 	if (!aio_cb) {
-		tcmu_err("could not allocated aio_cb\n");
+		tcmu_dev_err(dev, "Could not allocate aio_cb.\n");
 		goto out;
 	}
 
@@ -638,7 +638,7 @@ static int tcmu_rbd_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 
 	aio_cb->bounce_buffer = malloc(length);
 	if (!aio_cb->bounce_buffer) {
-		tcmu_err("failed to allocate bounce buffer\n");
+		tcmu_dev_err(dev, "Failed to allocate bounce buffer.\n");
 		goto out_free_aio_cb;
 	}
 
@@ -677,7 +677,7 @@ static int tcmu_rbd_flush(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 
 	aio_cb = calloc(1, sizeof(*aio_cb));
 	if (!aio_cb) {
-		tcmu_err("could not allocated aio_cb\n");
+		tcmu_dev_err(dev, "Could not allocate aio_cb.\n");
 		goto out;
 	}
 

--- a/rbd.c
+++ b/rbd.c
@@ -27,18 +27,33 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <endian.h>
-#include <scsi/scsi.h>
 #include <errno.h>
+#include <pthread.h>
+
+#include <scsi/scsi.h>
 
 #include "tcmu-runner.h"
 #include "libtcmu.h"
 
 #include <rbd/librbd.h>
 
+enum {
+	TCMU_RBD_OPENING,
+	TCMU_RBD_OPENED,
+	TCMU_RBD_CLOSING,
+	TCMU_RBD_CLOSED,
+};
+
 struct tcmu_rbd_state {
 	rados_t cluster;
 	rados_ioctx_t io_ctx;
 	rbd_image_t image;
+
+	char *image_name;
+	char *pool_name;
+
+	pthread_spinlock_t lock;	/* protect state */
+	int state;
 };
 
 struct rbd_aio_cb {
@@ -49,9 +64,334 @@ struct rbd_aio_cb {
 	char *bounce_buffer;
 };
 
+/*
+ * Returns:
+ * 0 = client is not owner.
+ * 1 = client is owner.
+ * -ESHUTDOWN/-EBLACKLISTED(-108) = client is blacklisted.
+ * -EIO = misc error.
+ */
+static int is_exclusive_lock_owner(struct tcmu_device *dev)
+{
+	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
+	int ret, is_owner;
+
+	ret = rbd_is_exclusive_lock_owner(state->image, &is_owner);
+	if (ret == -ESHUTDOWN) {
+		return ret;
+	} else if (ret < 0) {
+		/* let initiator figure things out */
+		tcmu_dev_err(dev, "Could not check lock ownership. (Err %d).\n", ret);
+		return -EIO;
+	} else if (is_owner) {
+		tcmu_dev_dbg(dev, "Is owner\n");
+		return 1;
+	}
+	tcmu_dev_dbg(dev, "Not owner\n");
+
+	return 0;
+}
+
+static void tcmu_rbd_image_close(struct tcmu_device *dev)
+{
+	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
+
+	pthread_spin_lock(&state->lock);
+	if (state->state != TCMU_RBD_OPENED) {
+		tcmu_dev_dbg(dev, "skipping close. state %d\n", state->state);
+		pthread_spin_unlock(&state->lock);
+		return;
+	}
+	state->state = TCMU_RBD_CLOSING;
+	pthread_spin_unlock(&state->lock);
+
+	rbd_close(state->image);
+	rados_ioctx_destroy(state->io_ctx);
+	rados_shutdown(state->cluster);
+
+	state->cluster = NULL;
+	state->io_ctx = NULL;
+	state->image = NULL;
+
+	pthread_spin_lock(&state->lock);
+	state->state = TCMU_RBD_CLOSED;
+	pthread_spin_unlock(&state->lock);
+}
+
+static int tcmu_rbd_image_open(struct tcmu_device *dev)
+{
+	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
+	int ret;
+
+	pthread_spin_lock(&state->lock);
+	if (state->state == TCMU_RBD_OPENED) {
+		tcmu_dev_dbg(dev, "skipping open. Already opened\n");
+		pthread_spin_unlock(&state->lock);
+		return 0;
+	}
+
+	if (state->state != TCMU_RBD_CLOSED) {
+		tcmu_dev_dbg(dev, "skipping open. state %d\n", state->state);
+		pthread_spin_unlock(&state->lock);
+		return -EBUSY;
+	}
+	state->state = TCMU_RBD_OPENING;
+	pthread_spin_unlock(&state->lock);
+
+	/* TODO locking */
+	ret = rados_create(&state->cluster, NULL);
+	if (ret < 0) {
+		tcmu_dev_dbg(dev, "Could not create cluster. (Err %d)\n", ret);
+		goto set_closed;
+	}
+
+	/* Fow now, we will only read /etc/ceph/ceph.conf */
+	rados_conf_read_file(state->cluster, NULL);
+	rados_conf_set(state->cluster, "rbd_cache", "false");
+
+	ret = rados_connect(state->cluster);
+	if (ret < 0) {
+		tcmu_dev_err(dev, "Could not connect to cluster. (Err %d)\n",
+			     ret);
+		goto rados_shutdown;
+	}
+
+	ret = rados_ioctx_create(state->cluster, state->pool_name,
+				 &state->io_ctx);
+	if (ret < 0) {
+		tcmu_dev_err(dev, "Could not create ioctx for pool %s. (Err %d)\n",
+			     state->pool_name, ret);
+		goto rados_destroy;
+	}
+
+	ret = rbd_open(state->io_ctx, state->image_name, &state->image, NULL);
+	if (ret < 0) {
+		tcmu_dev_err(dev, "Could not open image %s. (Err %d)\n",
+			     state->image_name, ret);
+		goto rados_destroy;
+	}
+
+	pthread_spin_lock(&state->lock);
+	state->state = TCMU_RBD_OPENED;
+	pthread_spin_unlock(&state->lock);
+	return 0;
+
+rados_destroy:
+	rados_ioctx_destroy(state->io_ctx);
+	state->io_ctx = NULL;
+rados_shutdown:
+	rados_shutdown(state->cluster);
+	state->cluster = NULL;
+set_closed:
+	pthread_spin_lock(&state->lock);
+	state->state = TCMU_RBD_CLOSED;
+	pthread_spin_unlock(&state->lock);
+	return ret;
+}
+
+static int tcmu_rbd_image_reopen(struct tcmu_device *dev)
+{
+	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
+	int ret;
+
+	tcmu_rbd_image_close(dev);
+	ret = tcmu_rbd_image_open(dev);
+
+	if (!ret) {
+		tcmu_dev_warn(dev, "image %s/%s was blacklisted. Successfully reopened.\n",
+			      state->pool_name, state->image_name);
+	} else {
+		tcmu_dev_warn(dev, "image %s/%s was blacklisted. Reopen failed with error %d.\n",
+			      state->pool_name, state->image_name, ret);
+	}
+
+	return ret;
+}
+
+/**
+ * tcmu_rbd_lock_break - break rbd exclusive lock if needed
+ * @dev: device to break the lock for.
+ * @orig_owner: if non null, only break the lock if get owners matches
+ *
+ * If orig_owner is null and tcmu_rbd_lock_break fails to break the lock
+ * for a retryable error (-EAGAIN) the owner of the lock will be returned.
+ * The caller must free the string returned.
+ *
+ * Returns:
+ * 0 = lock has been broken.
+ * -EAGAIN = retryable error
+ * -EIO = hard failure.
+ */
+static int tcmu_rbd_lock_break(struct tcmu_device *dev, char **orig_owner)
+{
+	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
+	rbd_lock_mode_t lock_mode;
+	char *owners[1];
+	size_t num_owners = 1;
+	int ret;
+
+	ret = rbd_lock_get_owners(state->image, &lock_mode, owners,
+				  &num_owners);
+	if (ret == -ENOENT || (!ret && !num_owners))
+		return 0;
+
+	if (ret < 0) {
+		tcmu_dev_err(dev, "Could not get lock owners %d\n", ret);
+		return -EIO;
+	}
+
+	if (lock_mode != RBD_LOCK_MODE_EXCLUSIVE) {
+		tcmu_dev_err(dev, "Invalid lock type (%d) found\n", lock_mode);
+		ret = -EIO;
+		goto free_owners;
+	}
+
+	if (*orig_owner && strcmp(*orig_owner, owners[0])) {
+		/* someone took the lock while we were retrying */
+		ret = -EINVAL;
+		goto free_owners;
+	}
+
+	tcmu_dev_dbg(dev, "Attempting to break lock from %s.\n", owners[0]);
+
+	ret = rbd_lock_break(state->image, lock_mode, owners[0]);
+	if (ret < 0) {
+		tcmu_dev_err(dev, "Could not break lock from %s. (Err %d)\n",
+			     owners[0], ret);
+		ret = -EAGAIN;
+		if (!*orig_owner) {
+			*orig_owner = strdup(owners[0]);
+			if (!*orig_owner)
+				ret = -EIO;
+		}
+	}
+
+free_owners:
+	rbd_lock_get_owners_cleanup(owners, num_owners);
+	return ret;
+}
+
+static int tcmu_rbd_lock(struct tcmu_device *dev)
+{
+	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
+	int ret = 0, attempts = 0;
+	char *orig_owner = NULL;
+
+	/*
+	 * TODO: Add retry/timeout settings to handle windows/ESX.
+	 * Or, set to transitioning and grab the lock in the background.
+	 */
+	while (attempts++ < 5) {
+		/*
+		 * This should only happen if a test is injecting STPGs.
+		 * Normally the initiators will do a RTPG first, so we never
+		 * have the lock and we have cleaned up from blacklisting
+		 * there.
+		 */
+		ret = is_exclusive_lock_owner(dev);
+		tcmu_dev_err(dev, "rnd lock is exlusive lock got %d\n", ret);
+		if (ret == 1) {
+			ret = 0;
+			break;
+		} else if (ret == -ESHUTDOWN) {
+			ret = tcmu_rbd_image_reopen(dev);
+			continue;
+		} else if (ret < 0) {
+			sleep(1);
+			continue;
+		}
+
+		ret = tcmu_rbd_lock_break(dev, &orig_owner);
+		if (ret == -EIO)
+			break;
+		else if (ret == -EAGAIN) {
+			sleep(1);
+			continue;
+		}
+
+		ret = rbd_lock_acquire(state->image, RBD_LOCK_MODE_EXCLUSIVE);
+		if (!ret) {
+			tcmu_dev_warn(dev, "Acquired exclusive lock.\n");
+			break;
+		}
+
+		tcmu_dev_err(dev, "Unknown error %d while trying to acquire lock.\n",
+			     ret);
+	}
+
+	if (orig_owner)
+		free(orig_owner);
+
+	return ret;
+}
+
+static int tcmu_rbd_report_state(struct tcmu_device *dev,
+				 struct tgt_port_grp *group)
+{
+	int ret;
+
+	/* TODO: For ESX return remote ports */
+
+	ret = is_exclusive_lock_owner(dev);
+	if (ret == -ESHUTDOWN) {
+		tcmu_rbd_image_reopen(dev);
+		return ALUA_ACCESS_STATE_STANDBY;
+	} else if (ret <= 0) {
+		return ALUA_ACCESS_STATE_STANDBY;
+	} else {
+		return ALUA_ACCESS_STATE_OPTIMIZED;
+	}
+}
+
+static int tcmu_rbd_transition(struct tcmu_device *dev,
+			       struct tgt_port_grp *group, uint8_t new_state,
+			       uint8_t *sense)
+{
+	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
+	int ret;
+
+	switch (new_state) {
+	case ALUA_ACCESS_STATE_OPTIMIZED:
+	case ALUA_ACCESS_STATE_NON_OPTIMIZED:
+		if (tcmu_rbd_lock(dev))
+			return tcmu_set_sense_data(sense, HARDWARE_ERROR,
+						   ASC_STPG_CMD_FAILED, NULL);
+		/* TODO for ESX set remote ports to standby */
+		return SAM_STAT_GOOD;
+	case ALUA_ACCESS_STATE_STANDBY:
+	case ALUA_ACCESS_STATE_UNAVAILABLE:
+	case ALUA_ACCESS_STATE_OFFLINE:
+		ret = rbd_lock_release(state->image);
+		if (ret < 0)
+			/*
+			 * Return success even though we failed. The initiator
+			 * will send a STPG to the port it wants to activate,
+			 * and that node will grab the lock from us if it hasn't
+			 * already.
+			 */
+			tcmu_dev_err(dev, "Could not release lock. (Err %d)\n",
+				     ret);
+		return SAM_STAT_GOOD;
+	}
+
+	return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
+				   ASC_INVALID_FIELD_IN_PARAMETER_LIST, NULL);
+}
+
+
+static void tcmu_rbd_state_free(struct tcmu_rbd_state *state)
+{
+	pthread_spin_destroy(&state->lock);
+
+	if (state->image_name)
+		free(state->image_name);
+	if (state->pool_name)
+		free(state->pool_name);
+	free(state);
+}
+
 static int tcmu_rbd_open(struct tcmu_device *dev)
 {
-
 	char *pool, *name;
 	char *config;
 	struct tcmu_rbd_state *state;
@@ -61,12 +401,20 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 	state = calloc(1, sizeof(*state));
 	if (!state)
 		return -ENOMEM;
-
+	state->state = TCMU_RBD_CLOSED;
 	tcmu_set_dev_private(dev, state);
 
+	ret = pthread_spin_init(&state->lock, 0);
+	if (ret < 0) {
+		free(state);
+		return ret;
+	}
+
 	config = strchr(tcmu_get_dev_cfgstring(dev), '/');
+	tcmu_dev_dbg(dev, "tcmu_rbd_open config %s\n", config);
+
 	if (!config) {
-		tcmu_err("no configuration found in cfgstring\n");
+		tcmu_dev_err(dev, "no configuration found in cfgstring\n");
 		ret = -EINVAL;
 		goto free_state;
 	}
@@ -74,7 +422,7 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 
 	block_size = tcmu_get_attribute(dev, "hw_block_size");
 	if (block_size < 0) {
-		tcmu_err("Could not get hw_block_size\n");
+		tcmu_dev_err(dev, "Could not get hw_block_size\n");
 		ret = -EINVAL;
 		goto free_state;
 	}
@@ -82,7 +430,7 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 
 	size = tcmu_get_device_size(dev);
 	if (size < 0) {
-		tcmu_err("Could not get device size\n");
+		tcmu_dev_err(dev, "Could not get device size\n");
 		goto free_state;
 	}
 	tcmu_set_dev_num_lbas(dev, size / block_size);
@@ -92,68 +440,52 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 		ret = -EINVAL;
 		goto free_state;
 	}
+	state->pool_name = strdup(pool);
+	if (!state->pool_name) {
+		ret = -ENOMEM;
+		tcmu_dev_err(dev, "Could copy pool name\n");
+		goto free_state;
+	}
+
 	name = strtok(NULL, "/");
 	if (!name) {
 		ret = -EINVAL;
 		goto free_state;
 	}
 
-	ret = rados_create(&state->cluster, NULL);
-	if (ret < 0) {
-		tcmu_err("error initializing\n");
+	state->image_name = strdup(name);
+	if (!state->image_name) {
+		ret = -ENOMEM;
+		tcmu_dev_err(dev, "Could copy image name\n");
 		goto free_state;
 	}
 
-	/* Fow now, we will only read /etc/ceph/ceph.conf */
-	rados_conf_read_file(state->cluster, NULL);
-	rados_conf_set(state->cluster, "rbd_cache", "false");
-
-	ret = rados_connect(state->cluster);
+	ret = tcmu_rbd_image_open(dev);
 	if (ret < 0) {
-		tcmu_err("error connecting\n");
-		goto rados_shutdown;
-	}
-
-	ret = rados_ioctx_create(state->cluster, pool, &state->io_ctx);
-	if (ret < 0) {
-		tcmu_err("error opening pool %s\n", pool);
-		goto rados_destroy;
-	}
-
-	ret = rbd_open(state->io_ctx, name, &state->image, NULL);
-	if (ret < 0) {
-		tcmu_err("error reading header from %s\n", name);
-		goto rados_destroy;
+		goto free_state;
 	}
 
 	ret = rbd_get_size(state->image, &rbd_size);
-	if(ret < 0) {
-		tcmu_err("error get rbd_size %s\n", name);
-		goto rados_destroy;
+	if (ret < 0) {
+		tcmu_dev_err(dev, "error getting rbd_size %s\n", name);
+		goto stop_image;
 	}
 
-	if(size != rbd_size) {
-		tcmu_err("device size and backing size disagree: "
-		     "device %lld backing %lld\n",
-		     size,
-		     rbd_size);
+	if (size != rbd_size) {
+		tcmu_dev_err(dev, "device size and backing size disagree: device %lld backing %lld\n",
+			     size, rbd_size);
 		ret = -EIO;
-		goto rbd_close;
+		goto stop_image;
 	}
 
-	tcmu_dbg("config %s, size %lld\n", tcmu_get_dev_cfgstring(dev),
-		 rbd_size);
-
+	tcmu_dev_dbg(dev, "config %s, size %lld\n", tcmu_get_dev_cfgstring(dev),
+		     rbd_size);
 	return 0;
 
-rbd_close:
-	rbd_close(state->image);
-rados_destroy:
-	rados_ioctx_destroy(state->io_ctx);
-rados_shutdown:
-	rados_shutdown(state->cluster);
+stop_image:
+	tcmu_rbd_image_close(dev);
 free_state:
-	free(state);
+	tcmu_rbd_state_free(state);
 	return ret;
 }
 
@@ -161,10 +493,8 @@ static void tcmu_rbd_close(struct tcmu_device *dev)
 {
 	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
 
-	rbd_close(state->image);
-	rados_ioctx_destroy(state->io_ctx);
-	rados_shutdown(state->cluster);
-	free(state);
+	tcmu_rbd_image_close(dev);
+	tcmu_rbd_state_free(state);
 }
 
 /*
@@ -187,7 +517,11 @@ static void rbd_finish_aio_read(rbd_completion_t completion,
 	ret = rbd_aio_get_return_value(completion);
 	rbd_aio_release(completion);
 
-	if (ret < 0) {
+	if (ret == -ESHUTDOWN) {
+		tcmu_r = tcmu_set_sense_data(tcmulib_cmd->sense_buf,
+					     NOT_READY, ASC_PORT_IN_STANDBY,
+					     NULL);
+	} else if (ret < 0) {
 		tcmu_r = tcmu_set_sense_data(tcmulib_cmd->sense_buf,
 					     MEDIUM_ERROR, ASC_READ_ERROR, NULL);
 	} else {
@@ -262,7 +596,11 @@ static void rbd_finish_aio_generic(rbd_completion_t completion,
 	ret = rbd_aio_get_return_value(completion);
 	rbd_aio_release(completion);
 
-	if (ret < 0) {
+	if (ret == -ESHUTDOWN) {
+		tcmu_r = tcmu_set_sense_data(tcmulib_cmd->sense_buf,
+					     NOT_READY, ASC_PORT_IN_STANDBY,
+					     NULL);
+	} else if (ret < 0) {
 		tcmu_r = tcmu_set_sense_data(tcmulib_cmd->sense_buf,
 					     MEDIUM_ERROR, ASC_WRITE_ERROR,
 					     NULL);
@@ -397,6 +735,8 @@ struct tcmur_handler tcmu_rbd_handler = {
 #ifdef LIBRBD_SUPPORTS_AIO_FLUSH
 	.flush	       = tcmu_rbd_flush,
 #endif
+	.transition_state = tcmu_rbd_transition,
+	.report_state  = tcmu_rbd_report_state,
 };
 
 int handler_init(void)

--- a/scsi_defs.h
+++ b/scsi_defs.h
@@ -71,6 +71,7 @@ enum scsi_protocol {
  * Sense codes
  */
 #define ASC_NOT_READY_FORMAT_IN_PROGRESS        0x0404
+#define ASC_PORT_IN_STANDBY			0x040B
 #define ASC_READ_ERROR                          0x1100
 #define ASC_WRITE_ERROR                         0x0C00
 #define ASC_PARAMETER_LIST_LENGTH_ERROR         0x1a00
@@ -82,6 +83,7 @@ enum scsi_protocol {
 #define ASC_SAVING_PARAMETERS_NOT_SUPPORTED     0x3900
 #define ASC_INTERNAL_TARGET_FAILURE             0x4400
 #define ASC_STPG_CMD_FAILED			0x670A
+
 
 #define ALUA_ACCESS_STATE_OPTIMIZED		0x0
 #define ALUA_ACCESS_STATE_NON_OPTIMIZED		0x1

--- a/scsi_defs.h
+++ b/scsi_defs.h
@@ -27,6 +27,10 @@
 #define SERVICE_ACTION_IN_16            0x9e
 #define READ_DVD_STRUCTURE              0xad
 #define MECHANISM_STATUS                0xbd
+#define MAINTENANCE_IN			0xa3
+#define MAINTENANCE_OUT			0xa4
+#define MI_REPORT_TARGET_PGS		0x0a
+#define MO_SET_TARGET_PGS		0x0a
 
 /*
  * Service action opcodes
@@ -77,6 +81,7 @@ enum scsi_protocol {
 #define ASC_CANT_WRITE_INCOMPATIBLE_FORMAT      0x3005
 #define ASC_SAVING_PARAMETERS_NOT_SUPPORTED     0x3900
 #define ASC_INTERNAL_TARGET_FAILURE             0x4400
+#define ASC_STPG_CMD_FAILED			0x670A
 
 #define ALUA_ACCESS_STATE_OPTIMIZED		0x0
 #define ALUA_ACCESS_STATE_NON_OPTIMIZED		0x1

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -32,6 +32,7 @@ extern "C" {
 #include "scsi_defs.h"
 #include "libtcmu_log.h"
 #include "libtcmu_common.h"
+#include "alua.h"
 
 typedef int (*rw_fn_t)(struct tcmu_device *, struct tcmulib_cmd *,
 		       struct iovec *, size_t, size_t, off_t);
@@ -71,6 +72,15 @@ struct tcmur_handler {
 	 * completion context for compound commands.
 	 */
 	int nr_threads;
+
+	/*
+	 * Synchronously change the state to new_state.
+	 * Returns
+	 * - SAM_STAT_GOOD on success.
+	 * - SCSI status with sense set if needed on failure.
+	 */
+	tcmu_transition_state_fn_t *transition_state;
+	tcmu_report_state_fn_t *report_state;
 
 	/*
 	 * Async handle_cmd only handlers return:

--- a/tcmu-synthesizer.c
+++ b/tcmu-synthesizer.c
@@ -56,7 +56,8 @@ static int syn_handle_cmd(struct tcmu_device *dev, uint8_t *cdb,
 
 	switch (cmd) {
 	case INQUIRY:
-		return tcmu_emulate_inquiry(dev, cdb, iovec, iov_cnt, sense);
+		return tcmu_emulate_inquiry(dev, NULL, cdb, iovec, iov_cnt,
+					    sense);
 		break;
 	case TEST_UNIT_READY:
 		return tcmu_emulate_test_unit_ready(cdb, iovec, iov_cnt, sense);

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -595,7 +595,8 @@ static int handle_generic_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 
 	switch (cdb[0]) {
 	case INQUIRY:
-		return tcmu_emulate_inquiry(dev, cdb, iovec, iov_cnt, sense);
+		return tcmu_emulate_inquiry(dev, NULL, cdb, iovec, iov_cnt,
+					    sense);
 	case TEST_UNIT_READY:
 		return tcmu_emulate_test_unit_ready(cdb, iovec, iov_cnt, sense);
 	case SERVICE_ACTION_IN_16:

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -19,6 +19,8 @@
 #include <errno.h>
 #include <inttypes.h>
 
+#include "ccan/list/list.h"
+
 #include "libtcmu.h"
 #include "libtcmu_log.h"
 #include "libtcmu_priv.h"
@@ -26,6 +28,7 @@
 #include "tcmur_device.h"
 #include "tcmur_cmd_handler.h"
 #include "tcmu-runner.h"
+#include "alua.h"
 
 void tcmur_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 			    int rc)
@@ -478,6 +481,45 @@ static int handle_read(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	return async_handle_cmd(dev, cmd, read_work_fn);
 }
 
+/* ALUA */
+static int handle_stpg(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+{
+	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
+	struct list_head group_list;
+	int ret;
+
+	list_head_init(&group_list);
+
+	ret = tcmu_get_tgt_port_grps(dev, &group_list);
+	if (ret)
+		return tcmu_set_sense_data(cmd->sense_buf, HARDWARE_ERROR,
+					   ASC_INTERNAL_TARGET_FAILURE, NULL);
+
+	ret = tcmu_emulate_set_tgt_port_grps(dev, &group_list, cmd,
+					     rhandler->transition_state);
+	tcmu_release_tgt_port_grps(&group_list);
+	return ret;
+}
+
+static int handle_rtpg(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+{
+	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
+	struct list_head group_list;
+	int ret;
+
+	list_head_init(&group_list);
+
+	ret = tcmu_get_tgt_port_grps(dev, &group_list);
+	if (ret)
+		return tcmu_set_sense_data(cmd->sense_buf, HARDWARE_ERROR,
+					   ASC_INTERNAL_TARGET_FAILURE, NULL);
+
+	ret = tcmu_emulate_report_tgt_port_grps(dev, &group_list, cmd,
+						rhandler->report_state);
+	tcmu_release_tgt_port_grps(&group_list);
+	return ret;
+}
+
 /* command passthrough */
 static void
 handle_passthrough_cbk(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
@@ -573,7 +615,20 @@ static int tcmur_cmd_handler(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	case WRITE_VERIFY_16:
 		ret = handle_write_verify(dev, cmd);
 		break;
+	case MAINTENANCE_IN:
+		if ((cdb[1] & 0x1f) == MI_REPORT_TARGET_PGS) {
+			ret = handle_rtpg(dev, cmd);
+			break;
+		}
+		goto passthrough;
+	case MAINTENANCE_OUT:
+		if (cdb[1] == MO_SET_TARGET_PGS) {
+			ret = handle_stpg(dev, cmd);
+			break;
+		}
+		goto passthrough;
 	default:
+passthrough:
 		/* Try to passthrough the default cmds */
 		if (rhandler->handle_cmd)
 			ret = handle_passthrough(dev, cmd);
@@ -581,6 +636,36 @@ static int tcmur_cmd_handler(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 
 	if (ret != TCMU_ASYNC_HANDLED)
 		track_aio_request_finish(rdev, NULL);
+	return ret;
+}
+
+static int handle_inquiry(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+{
+	struct list_head group_list;
+	struct tgt_port *port;
+	int ret;
+
+	list_head_init(&group_list);
+
+	ret = tcmu_get_tgt_port_grps(dev, &group_list);
+	if (ret)
+		return tcmu_set_sense_data(cmd->sense_buf, HARDWARE_ERROR,
+					   ASC_INTERNAL_TARGET_FAILURE, NULL);
+
+	/*
+	 * Detect if the user did not setup ALUA or the kernel did not fully
+	 * support it. ALUA tcmu support was added in 4.11. Before that and
+	 * in the unsetup case, we will end up with at least the default ALUA
+	 * group and a empty members (groups are not set to any LUNs) file. For
+	 * these cases we just return tpgs=0.
+	 */
+	port = tcmu_get_enabled_port(&group_list);
+	if (!port)
+		tcmu_dbg("no enabled ports found. Skipping ALUA support\n");
+
+	ret = tcmu_emulate_inquiry(dev, port, cmd->cdb, cmd->iovec,
+				   cmd->iov_cnt, cmd->sense_buf);
+	tcmu_release_tgt_port_grps(&group_list);
 	return ret;
 }
 
@@ -595,8 +680,7 @@ static int handle_generic_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 
 	switch (cdb[0]) {
 	case INQUIRY:
-		return tcmu_emulate_inquiry(dev, NULL, cdb, iovec, iov_cnt,
-					    sense);
+		return handle_inquiry(dev, cmd);
 	case TEST_UNIT_READY:
 		return tcmu_emulate_test_unit_ready(cdb, iovec, iov_cnt, sense);
 	case SERVICE_ACTION_IN_16:


### PR DESCRIPTION
Very limited ceph rbd failover/failback support using linux and windows initiators. You can export N images as SCSI LUNs through M targets. The major limitation is that you can only have one enabled port per LUN per node. In targetcli, if you were to export an image, testtcmulock, through one HA iscsi target that spans 2 nodes (so running LIO on 2 nodes and each node is exporting a iscsi target ion.1999-09.com.tcmu:alua) and each node has a iscsi portal, it would look like this on one node. On the other node, you would have the opposite tpgs enabled/disabled:


targetcli ls
o- / .................................................................... [...]
  o- backstores ......................................................... [...]
  | o- block ............................................. [Storage Objects: 0]
  | o- fileio ............................................ [Storage Objects: 0]
  | o- pscsi ............................................. [Storage Objects: 0]
  | o- ramdisk ........................................... [Storage Objects: 0]
  | o- user:qcow ......................................... [Storage Objects: 0]
  | o- user:rbd .......................................... [Storage Objects: 1]
  |   o- rbd1 .......................... [rbd/testtcmulock (10.0GiB) activated]
  |     o- alua .............................................. [ALUA Groups: 3]
  |       o- default_tg_pt_gp ........................... [ALUA state: Standby]
  |       o- tcmu2 ...................................... [ALUA state: Standby]
  |       o- tcmu3 ...................................... [ALUA state: Standby]
  o- iscsi ....................................................... [Targets: 1]
  | o- iqn.1999-09.com.tcmu:alua .................................... [TPGs: 2]
  |   o- tpg1 ...................................................... [disabled]
  |   | o- acls ..................................................... [ACLs: 0]
  |   | o- luns ..................................................... [LUNs: 1]
  |   | | o- lun0 ......................................... [user/rbd1 (tcmu2)]
  |   | o- portals ............................................... [Portals: 1]
  |   |   o- 192.168.32.101:3260 ......................................... [OK]
  |   o- tpg2 ............................................. [gen-acls, no-auth]
  |     o- acls ..................................................... [ACLs: 0]
  |     o- luns ..................................................... [LUNs: 1]
  |     | o- lun0 ......................................... [user/rbd1 (tcmu3)]
  |     o- portals ............................................... [Portals: 1]
  |       o- 20.15.0.18:3260 ............................................. [OK]



The next patches will add ESX support, but require changes to gwcli and ceph-iscsi-config and are a little more complicated because we have to be able to return all the port groups from all nodes.