### PR TITLE
config: Convert to use darray and prepare for dynamic reloading

### DIFF
--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -97,6 +97,10 @@ unsigned int tcmu_get_log_level(void)
 
 void tcmu_set_log_level(int level)
 {
+	/* set the default log level to warning */
+	if (!level)
+		level = TCMU_CONF_LOG_WARN;
+
 	tcmu_log_level = to_syslog_level(level);
 }
 


### PR DESCRIPTION
This convert to use darray for the tcmu_options.

The following is the new helper to add and use the config feature:

/*
 * System config for TCMU, for now there are only 3 option types supported:
 * 1, The "int type" option, for example:
 *	log_level = 2
 *
 * 2, The "string type" option, for example:
 *	tcmu_str = "Tom"  --> Tom
 *    or
 *	tcmu_str = 'Tom'  --> Tom
 *    or
 *	tcmu_str = 'Tom is a "boy"' ---> Tom is a "boy"
 *    or
 *	tcmu_str = "'T' is short for Tom" --> 'T' is short for Tom
 *
 * 3, The "boolean type" option, for example:
 *	tcmu_bool
 *
 * ========================
 * How to add new options ?
 *
 * Using "log_level" as an example:
 *
 * 1, Add log_level member in:
 *	struct tcmu_config {
 *		int log_level;
 *	};
 *    in file libtcmu_config.h.
 *
 * 2, Add the following option in "tcmu.conf" file as default:
 *	log_level = 2
 *    or
 *	# log_level = 2
 *
 *    Note: the option name in config file must be the same as in
 *    tcmu_config.
 *
 * 3, You should add your own set method in:
 *	static void tcmu_conf_set_options(struct tcmu_config *cfg)
 *	{
 *		TCMU_PARSE_CFG_INT(cfg, log_level);
 *		TCMU_CONF_CHECK_LOG_LEVEL(log_level);
 *	}
 *
 * Note: For now, if the options have been changed in config file, the
 * tcmu-runner, consumer and tcmu-synthesizer daemons should be restarted.
 * And the dynamic reloading feature will be added later.
 */
Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>