### PR TITLE
qcow: Clarify bad magic error message

### DIFF
--- a/qcow.c
+++ b/qcow.c
@@ -319,7 +319,7 @@ static int qcow2_probe(struct bdev *bdev, int dirfd, const char *pathname)
 		goto err;
 	}
 	if (be32toh(head.magic) != QCOW_MAGIC) {
-		perror("bad magic");
+		tcmu_warn("not qcow: will treat as raw: %s", pathname);
 		goto err;
 	}
 	if (be32toh(head.version) < 2) {


### PR DESCRIPTION
Previously, if you mapped a raw file using user:qcow, it would display
an error message saying "bad magic" with a stale errno message.  Now
make it clear that this may be expected if it's a raw file.

Signed-off-by: Steven Royer <seroyer@us.ibm.com>