### PR TITLE
tcmur: Allow the handlers to handle the cmds through its own method 

### DIFF
--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -774,22 +774,15 @@ static int tcmur_cmd_handler(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		ret = handle_format_unit(dev, cmd);
 		break;
 	case MAINTENANCE_IN:
-		if ((cdb[1] & 0x1f) == MI_REPORT_TARGET_PGS) {
+		if ((cdb[1] & 0x1f) == MI_REPORT_TARGET_PGS)
 			ret = handle_rtpg(dev, cmd);
-			break;
-		}
-		goto passthrough;
+		break;
 	case MAINTENANCE_OUT:
-		if (cdb[1] == MO_SET_TARGET_PGS) {
+		if (cdb[1] == MO_SET_TARGET_PGS)
 			ret = handle_stpg(dev, cmd);
-			break;
-		}
-		goto passthrough;
+		break;
 	default:
-passthrough:
-		/* Try to passthrough the default cmds */
-		if (rhandler->handle_cmd)
-			ret = handle_passthrough(dev, cmd);
+		ret = TCMU_NOT_HANDLED;
 	}
 
 	if (ret != TCMU_ASYNC_HANDLED)
@@ -899,12 +892,25 @@ static bool command_is_generic(struct tcmulib_cmd *cmd)
 int tcmur_generic_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 {
 	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);
+	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
+	int ret;
 
 	if (rdev->flags & TCMUR_DEV_FORMATTING && cmd->cdb[0] != INQUIRY)
 		return tcmu_set_sense_data(cmd->sense_buf, NOT_READY,
 					   ASC_NOT_READY_FORMAT_IN_PROGRESS,
 					   &rdev->format_progress);
 
+	/*
+	 * The handler want to handle some commands by itself,
+	 * try to passthrough it first
+	 */
+	if (rhandler->handle_cmd) {
+		ret = rhandler->handle_cmd(dev, cmd);
+		if (ret != TCMU_NOT_HANDLED)
+			return ret;
+	}
+
+	/* Falls back to the runner's generic handle callout */
 	if (command_is_generic(cmd))
 		return handle_generic_cmd(dev, cmd);
 	else


### PR DESCRIPTION
This will allow the handlers could handle part commands through its
own ways firstly, and then try to handle the other through the
generic methods.

This will be helpful for some case, for example the XCOPY command:
The runner could implement one generic method by using handle_read()
and handle_write(), and the device could also implement its own
higher efficiency ways to do this, and the other handlers could fall
back to the generic methods.

Generically, if the generic command handle callout could handle the
specify commands correctly and hasn't any lower efficiency problem,
the handlers shouldn't implement it again.

For the ->handle_cmd callout by handlers, it should obey a rule that
only when the cmds are not supported by it should return
TCMU_NOT_HANDLED. Then the runner will try to handle the cmds in
generic methods.


Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>