### PR TITLE
runner: Add Emulate xcopy support

### DIFF
--- a/api.c
+++ b/api.c
@@ -288,6 +288,16 @@ int tcmu_emulate_std_inquiry(
 
 	buf[2] = 0x05; /* SPC-3 */
 	buf[3] = 0x02; /* response data format */
+
+	/*
+	 * A Third-Party Copy (3PC)
+	 *
+	 * Enable the XCOPY
+	 */
+	buf[5] = 0x08;
+	if (port)
+		buf[5] |= port->grp->tpgs;
+
 	buf[7] = 0x02; /* CmdQue */
 
 	memcpy(&buf[8], "LIO-ORG ", 8);
@@ -295,9 +305,6 @@ int tcmu_emulate_std_inquiry(
 	memcpy(&buf[16], "TCMU device", 11);
 	memcpy(&buf[32], "0002", 4);
 	buf[4] = 31; /* Set additional length to 31 */
-
-	if (port)
-		buf[5] = port->grp->tpgs;
 
 	tcmu_memcpy_into_iovec(iovec, iov_cnt, buf, sizeof(buf));
 	return SAM_STAT_GOOD;

--- a/scsi_defs.h
+++ b/scsi_defs.h
@@ -18,6 +18,7 @@
 #define READ_DISC_INFORMATION           0x51
 #define MODE_SELECT_10                  0x55
 #define MODE_SENSE_10                   0x5a
+#define EXTENDED_COPY                   0x83
 #define RECEIVE_COPY_RESULTS            0x84 /* RECEIVE COPY STATUS */
 #define READ_16                         0x88
 #define COMPARE_AND_WRITE               0x89
@@ -100,18 +101,23 @@ enum scsi_protocol {
  * Sense codes
  */
 #define ASC_NOT_READY_FORMAT_IN_PROGRESS        0x0404
-#define ASC_PORT_IN_STANDBY			0x040B
+#define ASC_PORT_IN_STANDBY                     0x040B
+#define ASC_COPY_TARGET_DEVICE_NOT_REACHABLE    0x0D02
+#define ASC_INCORRECT_COPY_TARGET_DEVICE_TYPE   0x0D03
 #define ASC_READ_ERROR                          0x1100
+#define ASC_LOGICAL_UNIT_COMMUNICATION_FAILURE  0x0800
 #define ASC_WRITE_ERROR                         0x0C00
 #define ASC_PARAMETER_LIST_LENGTH_ERROR         0x1a00
 #define ASC_MISCOMPARE_DURING_VERIFY_OPERATION  0x1d00
 #define ASC_LBA_OUT_OF_RANGE                    0x2100
 #define ASC_INVALID_FIELD_IN_CDB                0x2400
 #define ASC_INVALID_FIELD_IN_PARAMETER_LIST     0x2600
+#define ASC_UNSUPPORTED_SEGMENT_DESC_TYPE_CODE  0x2609
+#define ASC_UNSUPPORTED_TARGET_DESC_TYPE_CODE   0x2607
 #define ASC_CANT_WRITE_INCOMPATIBLE_FORMAT      0x3005
 #define ASC_SAVING_PARAMETERS_NOT_SUPPORTED     0x3900
 #define ASC_INTERNAL_TARGET_FAILURE             0x4400
-#define ASC_STPG_CMD_FAILED			0x670A
+#define ASC_STPG_CMD_FAILED                     0x670A
 
 
 #define ALUA_ACCESS_STATE_OPTIMIZED		0x0

--- a/scsi_defs.h
+++ b/scsi_defs.h
@@ -18,6 +18,7 @@
 #define READ_DISC_INFORMATION           0x51
 #define MODE_SELECT_10                  0x55
 #define MODE_SENSE_10                   0x5a
+#define RECEIVE_COPY_RESULTS            0x84 /* RECEIVE COPY STATUS */
 #define READ_16                         0x88
 #define COMPARE_AND_WRITE               0x89
 #define WRITE_16                        0x8a
@@ -31,6 +32,34 @@
 #define MAINTENANCE_OUT			0xa4
 #define MI_REPORT_TARGET_PGS		0x0a
 #define MO_SET_TARGET_PGS		0x0a
+
+/*
+ * Receive Copy Results Sevice Actions
+ */
+#define RCR_SA_COPY_STATUS              0x00
+#define RCR_SA_RECEIVE_DATA             0x01
+#define RCR_SA_OPERATING_PARAMETERS     0x03
+#define RCR_SA_FAILED_SEGMENT_DETAILS   0x04
+
+/*
+ * Receive Copy Results Operating Parameters
+ */
+#define RCR_OP_MAX_TARGET_DESC_COUNT    0x02
+#define RCR_OP_MAX_SEGMENT_DESC_COUNT   0x01
+#define RCR_OP_MAX_DESC_LIST_LEN        1024
+#define RCR_OP_MAX_SEGMENT_LEN          1024
+#define RCR_OP_TOTAL_CONCURR_COPIES     0x01
+#define RCR_OP_MAX_CONCURR_COPIES       0x01
+#define RCR_OP_DATA_SEG_GRAN_LOG2       0x09
+#define RCR_OP_INLINE_DATA_GRAN_LOG2    0x09
+#define RCR_OP_HELD_DATA_GRAN_LOG2      0x09
+
+/*
+ * Receive Copy Results descriptor type codes supports
+ */
+#define RCR_OP_IMPLE_DES_LIST_LENGTH    0x02
+#define XCOPY_SEG_DESC_TYPE_CODE_B2B    0x02 /* block --> block */
+#define XCOPY_TARGET_DESC_TYPE_CODE_ID  0xe4 /* Identification descriptor */
 
 /*
  * Service action opcodes


### PR DESCRIPTION
This adds emulate xcopy support in tcmur and then enable it.

Tested Evironment:  ESXI 5.5
Backstore: file_example

