### PR TITLE
tcmur: Add WRITE_SAME_16 command support

### DIFF
--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -53,6 +53,8 @@ struct tcmulib_cmd;
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
+#define VPD_MAX_WRITE_SAME_LENGTH 0xFFFF
+
 typedef void (*cmd_done_t)(struct tcmu_device *, struct tcmulib_cmd *, int);
 
 struct tcmulib_cmd {


### PR DESCRIPTION
This will add a emulator for WRITE_SAME_16 command in runner. For
now the unmap option is not supported, and will be added later
when needed.

The Write Same Not Zero bit is set to one, and will be added later.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>