### PR TITLE
api: Add Logical Block Provisioning VPD page (B2h) support

### DIFF
--- a/api.c
+++ b/api.c
@@ -332,7 +332,7 @@ int tcmu_emulate_evpd_inquiry(
 	switch (cdb[2]) {
 	case 0x0: /* Supported VPD pages */
 	{
-		char data[8];
+		char data[9];
 
 		memset(data, 0, sizeof(data));
 
@@ -341,8 +341,9 @@ int tcmu_emulate_evpd_inquiry(
 		data[5] = 0x83;
 		data[6] = 0xb0;
 		data[7] = 0xb1;
+		data[8] = 0xb2;
 
-		data[3] = 4;
+		data[3] = 5;
 
 		tcmu_memcpy_into_iovec(iovec, iov_cnt, data, sizeof(data));
 		return SAM_STAT_GOOD;
@@ -546,6 +547,34 @@ finish_page83:
 		val16 = htobe16(0x003c);
 		memcpy(&data[2], &val16, 2);
 
+		tcmu_memcpy_into_iovec(iovec, iov_cnt, data, sizeof(data));
+		return SAM_STAT_GOOD;
+	}
+	break;
+	case 0xb2: /* Logical Block Provisioning VPD page */
+	{
+		char data[64];
+		uint16_t val16;
+
+		memset(data, 0, sizeof(data));
+
+		/*
+		 * From spc-5 Revision 14, section 6.7.2 Standard INQUIRY data
+		 * set the device type to Direct access block device.
+		 */
+		data[0] = 0x00;
+
+		/* PAGE CODE (B2h) */
+		data[1] = 0xb2;
+
+		/*
+		 * PAGE LENGTH field: PROVISIONING GROUP DESCRIPTOR field will be
+		 * not present.
+		 */
+		val16 = htobe16(0x0004);
+		memcpy(&data[2], &val16, 2);
+
+		tcmu_memcpy_into_iovec(iovec, iov_cnt, data, sizeof(data));
 		return SAM_STAT_GOOD;
 	}
 	break;


### PR DESCRIPTION
Prepare for the UNMAP command and for now in this VPD code the
UNMAP and Write Same UNMAP are both disabled.

They will be enabled later when needed.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>