### PR TITLE
fix IO max xfer limits

### DIFF
--- a/api.c
+++ b/api.c
@@ -35,8 +35,6 @@
 #include "libtcmu_priv.h"
 #include "alua.h"
 
-#define SECTOR_SIZE 512
-
 int tcmu_get_cdb_length(uint8_t *cdb)
 {
 	uint8_t group_code = cdb[0] >> 5;
@@ -475,7 +473,6 @@ finish_page83:
 	{
 		char data[64];
 		int block_size;
-		int max_sectors;
 		int max_xfer_length;
 		uint16_t val16;
 		uint32_t val32;
@@ -506,14 +503,11 @@ finish_page83:
 						   ASC_INVALID_FIELD_IN_CDB, NULL);
 		}
 
-		max_sectors = tcmu_get_attribute(dev, "hw_max_sectors");
-		if (max_sectors < 0) {
+		max_xfer_length = tcmu_get_attribute(dev, "hw_max_sectors");
+		if (max_xfer_length < 0) {
 			return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
 						   ASC_INVALID_FIELD_IN_CDB, NULL);
 		}
-
-		/* Convert from sectors to blocks */
-		max_xfer_length = max_sectors / (block_size / SECTOR_SIZE);
 
 		val32 = htobe32(max_xfer_length);
 		/* Max xfer length */

--- a/file_example.c
+++ b/file_example.c
@@ -79,30 +79,13 @@ static bool file_check_config(const char *cfgstring, char **reason)
 static int file_open(struct tcmu_device *dev)
 {
 	struct file_state *state;
-	int64_t size;
 	char *config;
-	int block_size;
 
 	state = calloc(1, sizeof(*state));
 	if (!state)
 		return -ENOMEM;
 
 	tcmu_set_dev_private(dev, state);
-
-	block_size = tcmu_get_attribute(dev, "hw_block_size");
-	if (block_size <= 0) {
-		tcmu_err("Could not get device block size\n");
-		goto err;
-	}
-	tcmu_set_dev_block_size(dev, block_size);
-
-	size = tcmu_get_device_size(dev);
-	if (size < 0) {
-		tcmu_err("Could not get device size\n");
-		goto err;
-	}
-
-	tcmu_set_dev_num_lbas(dev, size / block_size);
 
 	config = strchr(tcmu_get_dev_cfgstring(dev), '/');
 	if (!config) {
@@ -117,7 +100,7 @@ static int file_open(struct tcmu_device *dev)
 		goto err;
 	}
 
-	tcmu_dbg("config %s, size %lld\n", tcmu_get_dev_cfgstring(dev), size);
+	tcmu_dbg("config %s\n", tcmu_get_dev_cfgstring(dev));
 
 	return 0;
 

--- a/glfs.c
+++ b/glfs.c
@@ -461,28 +461,12 @@ static int tcmu_glfs_open(struct tcmu_device *dev)
 	int ret = 0;
 	char *config;
 	struct stat st;
-	int block_size;
-	int64_t size;
 
 	gfsp = calloc(1, sizeof(*gfsp));
 	if (!gfsp)
 		return -ENOMEM;
 
 	tcmu_set_dev_private(dev, gfsp);
-
-	block_size = tcmu_get_attribute(dev, "hw_block_size");
-	if (block_size <= 0) {
-		tcmu_err("Could not get hw_block_size setting\n");
-		goto fail;
-	}
-	tcmu_set_dev_block_size(dev, block_size);
-
-	size = tcmu_get_device_size(dev);
-	if (size < 0) {
-		tcmu_err("Could not get device size\n");
-		goto fail;
-	}
-	tcmu_set_dev_num_lbas(dev, size / block_size);
 
 	config = tcmu_get_path(dev);
 	if (!config) {

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -549,6 +549,21 @@ uint32_t tcmu_get_dev_block_size(struct tcmu_device *dev)
 	return dev->block_size;
 }
 
+/**
+ * tcmu_set_dev_max_xfer_len - set device's max command size
+ * @dev: tcmu device
+ * @len: max transfer length in bytes
+ */
+void tcmu_set_dev_max_xfer_len(struct tcmu_device *dev, uint32_t len)
+{
+	dev->max_xfer_len = len;
+}
+
+uint32_t tcmu_get_dev_max_xfer_len(struct tcmu_device *dev)
+{
+	return dev->max_xfer_len;
+}
+
 int tcmu_get_dev_fd(struct tcmu_device *dev)
 {
 	return dev->fd;

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -83,6 +83,8 @@ void tcmu_set_dev_num_lbas(struct tcmu_device *dev, uint64_t num_lbas);
 uint64_t tcmu_get_dev_num_lbas(struct tcmu_device *dev);
 void tcmu_set_dev_block_size(struct tcmu_device *dev, uint32_t block_size);
 uint32_t tcmu_get_dev_block_size(struct tcmu_device *dev);
+void tcmu_set_dev_max_xfer_len(struct tcmu_device *dev, uint32_t len);
+uint32_t tcmu_get_dev_max_xfer_len(struct tcmu_device *dev);
 struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev);
 struct tcmur_handler *tcmu_get_runner_handler(struct tcmu_device *dev);
 

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -60,6 +60,7 @@ struct tcmu_device {
 
 	uint64_t num_lbas;
 	uint32_t block_size;
+	uint32_t max_xfer_len;
 
 	char dev_name[16]; /* e.g. "uio14" */
 	char tcm_hba_name[16]; /* e.g. "user_8" */

--- a/main.c
+++ b/main.c
@@ -565,7 +565,7 @@ static int dev_added(struct tcmu_device *dev)
 {
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
 	struct tcmur_device *rdev;
-	int32_t block_size;
+	int32_t block_size, max_sectors;
 	int64_t dev_size;
 	int ret;
 
@@ -588,6 +588,11 @@ static int dev_added(struct tcmu_device *dev)
 		goto free_rdev;
 	}
 	tcmu_set_dev_num_lbas(dev, dev_size / block_size);
+
+	max_sectors = tcmu_get_attribute(dev, "hw_max_sectors");
+	if (max_sectors < 0)
+		goto free_rdev;
+	tcmu_set_dev_max_xfer_len(dev, max_sectors * block_size);
 
 	tcmu_dev_dbg(dev, "Got block_size %ld, size in bytes %lld",
 		     block_size, dev_size);

--- a/main.c
+++ b/main.c
@@ -565,12 +565,32 @@ static int dev_added(struct tcmu_device *dev)
 {
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
 	struct tcmur_device *rdev;
+	int32_t block_size;
+	int64_t dev_size;
 	int ret;
 
 	rdev = calloc(1, sizeof(*rdev));
 	if (!rdev)
 		return -ENOMEM;
 	tcmu_set_daemon_dev_private(dev, rdev);
+
+	ret = -EINVAL;
+	block_size = tcmu_get_attribute(dev, "hw_block_size");
+	if (block_size <= 0) {
+		tcmu_dev_err(dev, "Could not get hw_block_size\n");
+		goto free_rdev;
+	}
+	tcmu_set_dev_block_size(dev, block_size);
+
+	dev_size = tcmu_get_device_size(dev);
+	if (dev_size < 0) {
+		tcmu_dev_err(dev, "Could not get device size\n");
+		goto free_rdev;
+	}
+	tcmu_set_dev_num_lbas(dev, dev_size / block_size);
+
+	tcmu_dev_dbg(dev, "Got block_size %ld, size in bytes %lld",
+		     block_size, dev_size);
 
 	ret = pthread_spin_init(&rdev->lock, 0);
 	if (ret < 0)

--- a/rbd.c
+++ b/rbd.c
@@ -336,6 +336,7 @@ static void tcmu_rbd_state_free(struct tcmu_rbd_state *state)
 
 static int tcmu_rbd_open(struct tcmu_device *dev)
 {
+	rbd_image_info_t image_info;
 	char *pool, *name;
 	char *config;
 	struct tcmu_rbd_state *state;
@@ -410,6 +411,13 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 		ret = -EIO;
 		goto stop_image;
 	}
+
+	ret = rbd_stat(state->image, &image_info, sizeof(image_info));
+	if (ret < 0) {
+		tcmu_dev_err(dev, "Could not stat image.\n");
+		goto stop_image;
+	}
+	tcmu_set_dev_max_xfer_len(dev, image_info.obj_size);
 
 	tcmu_dev_dbg(dev, "config %s, size %lld\n", tcmu_get_dev_cfgstring(dev),
 		     rbd_size);


### PR DESCRIPTION
This patchset fixes the calculation for the max xfer size and allows handlers like rbd to set their preferred value.