### PR TITLE
tcmur: format unit make sure the write length is muti of max_xfer_length 

### DIFF
--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -39,17 +39,27 @@ struct tcmulib_cmd;
 #define CFGFS_ROOT "/sys/kernel/config/target"
 #define CFGFS_CORE CFGFS_ROOT"/core"
 
-#define max(a,b) ({			\
+#define max(a, b) ({			\
 	__typeof__ (a) _a = (a);	\
 	__typeof__ (b) _b = (b);	\
 	(void) (&_a == &_b);		\
 	_a < _b ? _b : _a; })
 
-#define min(a,b) ({			\
+#define min(a, b) ({			\
 	__typeof__ (a) _a = (a);	\
 	__typeof__ (b) _b = (b);	\
 	(void) (&_a == &_b);		\
 	_a < _b ? _a : _b; })
+
+#define round_up(a, b) ({		\
+	__typeof__ (a) _a = (a);	\
+	__typeof__ (b) _b = (b);	\
+	((_a + (_b - 1)) / _b) * _b; })
+
+#define round_down(a, b) ({		\
+	__typeof__ (a) _a = (a);	\
+	__typeof__ (b) _b = (b);	\
+	(_a - (_a % _b)); })
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -1498,7 +1498,7 @@ static int handle_format_unit(struct tcmu_device *dev, struct tcmulib_cmd *cmd) 
 	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);
 	struct tcmulib_cmd *writecmd;
 	struct format_unit_state *state;
-	size_t length = 1024 * 1024;
+	size_t max_xfer_length, length = 1024 * 1024;
 	uint8_t *sense = cmd->sense_buf;
 	uint32_t block_size = tcmu_get_dev_block_size(dev);
 	uint64_t num_lbas = tcmu_get_dev_num_lbas(dev);
@@ -1527,6 +1527,9 @@ static int handle_format_unit(struct tcmu_device *dev, struct tcmulib_cmd *cmd) 
 
 	cmd->cmdstate = state;
 	state->done_blocks = 0;
+
+	max_xfer_length = tcmu_get_dev_max_xfer_len(dev);
+	length = round_up(length, max_xfer_length);
 	state->length = length;
 
 	/* Check length on first write to make sure its not less than 1MB */


### PR DESCRIPTION
For the FORMAT_UNIT write options, the default length is 1MB and
this will round it up to the device's maximum xter length.

Then we can make sure that all the requests/BIO in IO queue is full.