### PR TITLE
runner: Convert to _dev_ helper and fix debug message

### DIFF
--- a/main.c
+++ b/main.c
@@ -626,7 +626,7 @@ static int dev_added(struct tcmu_device *dev)
 		goto free_rdev;
 	tcmu_set_dev_max_xfer_len(dev, max_sectors * block_size);
 
-	tcmu_dev_dbg(dev, "Got block_size %ld, size in bytes %lld",
+	tcmu_dev_dbg(dev, "Got block_size %ld, size in bytes %lld\n",
 		     block_size, dev_size);
 
 	ret = pthread_spin_init(&rdev->lock, 0);


### PR DESCRIPTION
Also will fix some debug messages who are missing '\n'.

Such as the following, it will be a little hard to read:
[DEBUG] dev_added:630 lun1: Got block_size 512, size in bytes 10737418242017-05-21 11:33:45.844 30321 [DEBUG] file_open:103 : config file/file1