### PR TITLE
glfs: remove O_SYNC

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -30,7 +30,7 @@
 
 #include "tcmu-runner.h"
 
-#define ALLOWED_BSOFLAGS (O_SYNC | O_DIRECT | O_RDWR | O_LARGEFILE)
+#define ALLOWED_BSOFLAGS (O_DIRECT | O_RDWR | O_LARGEFILE)
 
 #define GLUSTER_PORT "24007"
 #define TCMU_GLFS_LOG_FILENAME "tcmu-runner-glfs.log"  /* MAX 32 CHAR */


### PR DESCRIPTION
O_SYNC makes IO a bit slow and as anyway we are ensuring the data
reaches onto nonvolatile disk with fdatasync() as part of flush op,
O_SYNC seems to be unworthy.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>