### PR TITLE
load_module: defend on modules directory

### DIFF
--- a/main.c
+++ b/main.c
@@ -40,6 +40,7 @@
 #include <scsi/scsi.h>
 
 #include <libkmod.h>
+#include <sys/utsname.h>
 #include <linux/target_core_user.h>
 #include "darray.h"
 #include "tcmu-runner.h"
@@ -464,21 +465,46 @@ static int load_our_module(void)
 	struct kmod_list *list = NULL, *itr;
 	struct kmod_ctx *ctx;
 	int ret;
+	struct stat sb;
+	struct utsname u;
 
 	ctx = kmod_new(NULL, NULL);
 	if (!ctx) {
-		tcmu_err("kmod_new() failed\n");
+		tcmu_err("kmod_new() failed: %m\n");
 		return -1;
 	}
 
 	ret = kmod_module_new_from_lookup(ctx, "target_core_user", &list);
 	if (ret < 0) {
-		tcmu_err("kmod_module_new_from_lookup() failed to lookup alias target_core_user\n");
+		/* In some environments like containers, /lib/modules/`uname -r`
+		 * will not exist, in such cases the load module job be taken
+		 * care by admin, either by manual load or makesure it's builtin
+		 */
+		if (ENOENT == errno) {
+			if (uname(&u) < 0) {
+				tcmu_err("uname() failed: %m\n");
+			} else {
+				tcmu_info("no modules directory '/lib/modules/%s', checking "
+					  "module target_core_user entry in '/sys/modules/'\n",
+					  u.release);
+				ret = stat("/sys/module/target_core_user", &sb);
+				if (!ret) {
+					tcmu_dbg("Module target_core_user already loaded\n");
+				} else {
+					tcmu_err("stat() on '/sys/module/target_core_user' failed: %m\n");
+				}
+			}
+		} else {
+			tcmu_err("kmod_module_new_from_lookup() failed to lookup alias target_core_use %m\n");
+		}
+
+		kmod_unref(ctx);
 		return ret;
 	}
 
 	if (!list) {
 		tcmu_err("kmod_module_new_from_lookup() failed to find module target_core_user\n");
+		kmod_unref(ctx);
 		return -ENOENT;
 	}
 
@@ -519,6 +545,7 @@ static int load_our_module(void)
 	}
 
 	kmod_module_unref_list(list);
+	kmod_unref(ctx);
 
 	return ret;
 }


### PR DESCRIPTION
In some environments (ex: containers) modules dir doesn't exist, in such cases
the load_module job is left to admin.

This patch checks if modules dir exist before a kmod lookup.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>