### PR TITLE
Fix use-after-free bugs found 

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -412,7 +412,7 @@ static glfs_t* tcmu_create_glfs_object(char *config, gluster_server **hosts)
 	gluster_cache_refresh(fs, config);
 
  fail:
-	gluster_free_server(&entry);
+	gluster_free_server(hosts);
 	return NULL;
 }
 

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -293,13 +293,13 @@ static int add_device(struct tcmulib_context *ctx,
 
 	dev->ctx = ctx;
 
-	darray_append(ctx->devices, dev);
-
 	ret = dev->handler->added(dev);
 	if (ret < 0) {
 		tcmu_err("handler open failed for %s\n", dev->dev_name);
 		goto err_munmap;
 	}
+
+	darray_append(ctx->devices, dev);
 
 	return 0;
 


### PR DESCRIPTION
FirstCommit:
It seems like there is still one possibility for use-after-free in glfs handler when tcmu-runner is started when the gluster volume is not running. This is the trace we get in AddressSanitizer:

==1343==ERROR: AddressSanitizer: heap-use-after-free on address 0x60300000dc30 at pc 0x7fd8ab4fb93f bp 0x7fff4a7eddf0 sp 0x7fff4a7edde0
READ of size 8 at 0x60300000dc30 thread T0
2017-05-28 07:58:13.930 1343 [ERROR] glfs_check_config:453 : tcmu_create_glfs_object failed
    #0 0x7fd8ab4fb93e in gluster_free_server /root/tcmu-runner/glfs.c:270
    #1 0x7fd8ab4fcc50 in glfs_check_config /root/tcmu-runner/glfs.c:480
    #2 0x7fd8b15330a4 in add_device /root/tcmu-runner/libtcmu.c:243
    #3 0x7fd8b1534500 in open_devices /root/tcmu-runner/libtcmu.c:436
    #4 0x7fd8b1534c5f in tcmulib_initialize /root/tcmu-runner/libtcmu.c:477
    #5 0x418720 in main /root/tcmu-runner/main.c:871
    #6 0x7fd8afe21400 in __libc_start_main (/lib64/libc.so.6+0x20400)
    #7 0x407dd9 in _start (/root/tcmu-runner/tcmu-runner+0x407dd9)

0x60300000dc30 is located 0 bytes inside of 24-byte region [0x60300000dc30,0x60300000dc48)
freed by thread T0 here:
    #0 0x7fd8b181cb00 in free (/lib64/libasan.so.3+0xc6b00)
    #1 0x7fd8ab4fbaa8 in gluster_free_server /root/tcmu-runner/glfs.c:276
    #2 0x7fd8ab4fc878 in tcmu_create_glfs_object /root/tcmu-runner/glfs.c:415
    #3 0x7fd8ab4fca89 in glfs_check_config /root/tcmu-runner/glfs.c:451
    #4 0x7fd8b15330a4 in add_device /root/tcmu-runner/libtcmu.c:243
    #5 0x7fd8b1534500 in open_devices /root/tcmu-runner/libtcmu.c:436
    #6 0x7fd8b1534c5f in tcmulib_initialize /root/tcmu-runner/libtcmu.c:477
    #7 0x418720 in main /root/tcmu-runner/main.c:871
    #8 0x7fd8afe21400 in __libc_start_main (/lib64/libc.so.6+0x20400)

previously allocated by thread T0 here:
    #0 0x7fd8b181d020 in calloc (/lib64/libasan.so.3+0xc7020)
    #1 0x7fd8ab4fbbe5 in parse_imagepath /root/tcmu-runner/glfs.c:299
    #2 0x7fd8ab4fc47c in tcmu_create_glfs_object /root/tcmu-runner/glfs.c:360
    #3 0x7fd8ab4fca89 in glfs_check_config /root/tcmu-runner/glfs.c:451
    #4 0x7fd8b15330a4 in add_device /root/tcmu-runner/libtcmu.c:243
    #5 0x7fd8b1534500 in open_devices /root/tcmu-runner/libtcmu.c:436
    #6 0x7fd8b1534c5f in tcmulib_initialize /root/tcmu-runner/libtcmu.c:477
    #7 0x418720 in main /root/tcmu-runner/main.c:871
    #8 0x7fd8afe21400 in __libc_start_main (/lib64/libc.so.6+0x20400)

Second commit:
When we try to do targetcli clearconfig confirm=True while the gluster volume is stopped and deleted add_device() failed so it went ahead and freed the device, but it was still in the darray. So remove was attempted on it and AddressSanitizer complained about it and crashed tcmu-runner. It seemed better to not add it until everything succeeded.
here is the address sanitizer trace:
==5644==ERROR: AddressSanitizer: heap-use-after-free on address 0x61500000e1b0 at pc 0x7f92228cf987 bp 0x7ffffbb6f980 sp 0x7ffffbb6f128
READ of size 5 at 0x61500000e1b0 thread T0
All configuration cleared
    #0 0x7f92228cf986 in strnlen (/lib64/libasan.so.3+0x47986)
    #1 0x7f9222665bb8 in remove_device /root/tcmu-runner/libtcmu.c:338
    #2 0x7f9222664808 in handle_netlink /root/tcmu-runner/libtcmu.c:72
    #3 0x7f92212fc634  (/lib64/libnl-genl-3.so.200+0x3634)
    #4 0x7f9221510a7b in nl_recvmsgs_report (/lib64/libnl-3.so.200+0x11a7b)
    #5 0x7f9221510ea8 in nl_recvmsgs (/lib64/libnl-3.so.200+0x11ea8)
    #6 0x7f9222666f05 in tcmulib_master_fd_ready /root/tcmu-runner/libtcmu.c:509
    #7 0x415e6b in tcmulib_callback /root/tcmu-runner/main.c:181
    #8 0x7f9221da1e51 in g_main_context_dispatch (/lib64/libglib-2.0.so.0+0x49e51)
    #9 0x7f9221da21cf  (/lib64/libglib-2.0.so.0+0x4a1cf)
    #10 0x7f9221da24f1 in g_main_loop_run (/lib64/libglib-2.0.so.0+0x4a4f1)
    #11 0x418846 in main /root/tcmu-runner/main.c:899
    #12 0x7f9220f53400 in __libc_start_main (/lib64/libc.so.6+0x20400)
    #13 0x407dd9 in _start (/root/tcmu-runner/tcmu-runner+0x407dd9)

0x61500000e1b0 is located 48 bytes inside of 496-byte region [0x61500000e180,0x61500000e370)
freed by thread T0 here:
    #0 0x7f922294eb00 in free (/lib64/libasan.so.3+0xc6b00)
    #1 0x7f9222665978 in add_device /root/tcmu-runner/libtcmu.c:311
    #2 0x7f9222666500 in open_devices /root/tcmu-runner/libtcmu.c:436
    #3 0x7f9222666c5f in tcmulib_initialize /root/tcmu-runner/libtcmu.c:477
    #4 0x418720 in main /root/tcmu-runner/main.c:871
    #5 0x7f9220f53400 in __libc_start_main (/lib64/libc.so.6+0x20400)

previously allocated by thread T0 here:
    #0 0x7f922294f020 in calloc (/lib64/libasan.so.3+0xc7020)
    #1 0x7f9222664c7f in add_device /root/tcmu-runner/libtcmu.c:191
    #2 0x7f9222666500 in open_devices /root/tcmu-runner/libtcmu.c:436
    #3 0x7f9222666c5f in tcmulib_initialize /root/tcmu-runner/libtcmu.c:477
    #4 0x418720 in main /root/tcmu-runner/main.c:871
    #5 0x7f9220f53400 in __libc_start_main (/lib64/libc.so.6+0x20400)