### PR TITLE
Avoid free of uninitialized ptr

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -436,7 +436,7 @@ static bool glfs_check_config(const char *cfgstring, char **reason)
 	char *path;
 	glfs_t *fs = NULL;
 	glfs_fd_t *gfd = NULL;
-	gluster_server *hosts; /* gluster server defination */
+	gluster_server *hosts = NULL; /* gluster server defination */
 	bool result = true;
 
 	path = strchr(cfgstring, '/');


### PR DESCRIPTION
If glfs_check_config() is called with a cfgstring that doesn't have '/'
then it can lead to crash as ptr 'hosts' is not initialized to NULL.
Fixing that in this commit.

Signed-off-by: Pranith Kumar K <pkarampu@redhat.com>