### PR TITLE
Fix memory allocations in parse_imagepath

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -298,12 +298,12 @@ static int parse_imagepath(char *cfgstring, gluster_server **hosts)
 
 	*hosts = calloc(1, sizeof(gluster_server));
 	if (!hosts)
-		return -ENOMEM;
+                goto fail;
 	entry = *hosts;
 
 	entry->server = calloc(1, sizeof(gluster_hostdef));
 	if (!entry->server)
-		return -ENOMEM;
+                goto fail;
 
 	*sep = '\0';
 	entry->volname = strdup(p);
@@ -344,7 +344,7 @@ static int parse_imagepath(char *cfgstring, gluster_server **hosts)
 	return 0;
 
 fail:
-	gluster_free_server(&entry);
+	gluster_free_server(hosts);
 	free(origp);
 
 	return -1;


### PR DESCRIPTION
1) Free partially allocated structure on failures
Instead of returning -ENOMEM use 'goto fail' which
is cleaning up partially allocated structure.

2) Fix use-after-free
We need to set *hosts = NULL as well in case of failures.
So pass hosts instead of &entry for gluster_free_server()

This is the asan trace:
==1482==ERROR: AddressSanitizer: heap-use-after-free on address 0x60300000db70 at pc 0x7ffff0bfb93f bp 0x7fffffffc830 sp 0x7fffffffc820
READ of size 8 at 0x60300000db70 thread T0
    #0 0x7ffff0bfb93e in gluster_free_server /root/tcmu-runner/glfs.c:270
    #1 0x7ffff0bfc851 in tcmu_create_glfs_object /root/tcmu-runner/glfs.c:415
    #2 0x7ffff0bfcda3 in tcmu_glfs_open /root/tcmu-runner/glfs.c:503
    #3 0x417ced in dev_added /root/tcmu-runner/main.c:678
    #4 0x7ffff6c12662 in add_device /root/tcmu-runner/libtcmu.c:296
    #5 0x7ffff6c13503 in open_devices /root/tcmu-runner/libtcmu.c:436
    #6 0x7ffff6c13c62 in tcmulib_initialize /root/tcmu-runner/libtcmu.c:477
    #7 0x418720 in main /root/tcmu-runner/main.c:871
    #8 0x7ffff5500400 in __libc_start_main (/lib64/libc.so.6+0x20400)
    #9 0x407dd9 in _start (/root/tcmu-runner/tcmu-runner+0x407dd9)

0x60300000db70 is located 0 bytes inside of 24-byte region [0x60300000db70,0x60300000db88)
freed by thread T0 here:
    #0 0x7ffff6efbb00 in free (/lib64/libasan.so.3+0xc6b00)
    #1 0x7ffff0bfbaa8 in gluster_free_server /root/tcmu-runner/glfs.c:276
    #2 0x7ffff0bfc336 in parse_imagepath /root/tcmu-runner/glfs.c:347
    #3 0x7ffff0bfc464 in tcmu_create_glfs_object /root/tcmu-runner/glfs.c:360
    #4 0x7ffff0bfcda3 in tcmu_glfs_open /root/tcmu-runner/glfs.c:503
    #5 0x417ced in dev_added /root/tcmu-runner/main.c:678
    #6 0x7ffff6c12662 in add_device /root/tcmu-runner/libtcmu.c:296
    #7 0x7ffff6c13503 in open_devices /root/tcmu-runner/libtcmu.c:436
    #8 0x7ffff6c13c62 in tcmulib_initialize /root/tcmu-runner/libtcmu.c:477
    #9 0x418720 in main /root/tcmu-runner/main.c:871
    #10 0x7ffff5500400 in __libc_start_main (/lib64/libc.so.6+0x20400)

previously allocated by thread T0 here:
    #0 0x7ffff6efc020 in calloc (/lib64/libasan.so.3+0xc7020)
    #1 0x7ffff0bfbbe5 in parse_imagepath /root/tcmu-runner/glfs.c:299
    #2 0x7ffff0bfc464 in tcmu_create_glfs_object /root/tcmu-runner/glfs.c:360
    #3 0x7ffff0bfcda3 in tcmu_glfs_open /root/tcmu-runner/glfs.c:503
    #4 0x417ced in dev_added /root/tcmu-runner/main.c:678
    #5 0x7ffff6c12662 in add_device /root/tcmu-runner/libtcmu.c:296
    #6 0x7ffff6c13503 in open_devices /root/tcmu-runner/libtcmu.c:436
    #7 0x7ffff6c13c62 in tcmulib_initialize /root/tcmu-runner/libtcmu.c:477
    #8 0x418720 in main /root/tcmu-runner/main.c:871
    #9 0x7ffff5500400 in __libc_start_main (/lib64/libc.so.6+0x20400)

Signed-off-by: Pranith Kumar K <pkarampu@redhat.com>