### PR TITLE
tcmu: Add Structure for Reconfiguration Support

### DIFF
--- a/file_example.c
+++ b/file_example.c
@@ -42,6 +42,7 @@
 
 #include "scsi_defs.h"
 #include "tcmu-runner.h"
+#include "libtcmu.h"
 
 struct file_state {
 	int fd;
@@ -74,6 +75,25 @@ static bool file_check_config(const char *cfgstring, char **reason)
 	unlink(path);
 
 	return true;
+}
+
+static int file_reconfig(struct tcmu_device *dev, uint32_t cfgtype)
+{
+	int ret = 0;
+
+	switch (cfgtype) {
+	case CONFIG_PATH:
+		tcmu_dev_err(dev, "device path reconfiguration is not supported\n");
+		return -EINVAL;
+	case CONFIG_SIZE:
+		ret = tcmu_config_size(dev);
+		break;
+	case CONFIG_WRITECACHE:
+		tcmu_dev_err(dev, "write_cache reconfiguration is not supported\n");
+		return -EINVAL;
+	}
+
+	return ret;
 }
 
 static int file_open(struct tcmu_device *dev)
@@ -200,6 +220,7 @@ static struct tcmur_handler file_handler = {
 	.cfg_desc = file_cfg_desc,
 
 	.check_config = file_check_config,
+	.reconfig = file_reconfig,
 
 	.open = file_open,
 	.close = file_close,

--- a/file_example.c
+++ b/file_example.c
@@ -44,6 +44,10 @@
 #include "tcmu-runner.h"
 #include "libtcmu.h"
 
+#define TCMU_ATTR_DEV_CFG 	4
+#define TCMU_ATTR_DEV_SIZE	5
+#define TCMU_ATTR_WRITECACHE	6
+
 struct file_state {
 	int fd;
 };
@@ -77,18 +81,18 @@ static bool file_check_config(const char *cfgstring, char **reason)
 	return true;
 }
 
-static int file_reconfig(struct tcmu_device *dev, uint32_t cfgtype)
+static int file_reconfig(struct tcmu_device *dev, int cfgtype)
 {
 	int ret = 0;
 
 	switch (cfgtype) {
-	case CONFIG_PATH:
+	case TCMU_ATTR_DEV_CFG:
 		tcmu_dev_err(dev, "device path reconfiguration is not supported\n");
 		return -EINVAL;
-	case CONFIG_SIZE:
+	case TCMU_ATTR_DEV_SIZE:
 		ret = tcmu_config_size(dev);
 		break;
-	case CONFIG_WRITECACHE:
+	case TCMU_ATTR_WRITECACHE:
 		tcmu_dev_err(dev, "write_cache reconfiguration is not supported\n");
 		return -EINVAL;
 	}

--- a/file_optical.c
+++ b/file_optical.c
@@ -61,6 +61,10 @@
 #include "tcmu-runner.h"
 #include "libtcmu.h"
 
+#define TCMU_ATTR_DEV_CFG       4
+#define TCMU_ATTR_DEV_SIZE      5
+#define TCMU_ATTR_WRITECACHE    6
+
 struct fbo_state {
 	int fd;
 	uint64_t num_lbas;
@@ -148,18 +152,18 @@ static bool fbo_check_config(const char *cfgstring, char **reason)
 	return true;
 }
 
-static int fbo_reconfig(struct tcmu_device *dev, uint32_t cfgtype)
+static int fbo_reconfig(struct tcmu_device *dev, int cfgtype)
 {
 	int ret = 0;
 
 	switch (cfgtype) {
-	case CONFIG_PATH:
+	case TCMU_ATTR_DEV_CFG:
 		tcmu_dev_err(dev, "device path reconfiguration is not supported\n");
 		return -EINVAL;
-	case CONFIG_SIZE:
+	case TCMU_ATTR_DEV_SIZE:
 		tcmu_dev_err(dev, "device size reconfiguration is not supported\n");
 		return -EINVAL;
-	case CONFIG_WRITECACHE:
+	case TCMU_ATTR_WRITECACHE:
 		tcmu_dev_err(dev, "Write_cache reconfiguration is not supported\n");
 		return -EINVAL;
 	}

--- a/file_optical.c
+++ b/file_optical.c
@@ -148,6 +148,25 @@ static bool fbo_check_config(const char *cfgstring, char **reason)
 	return true;
 }
 
+static int fbo_reconfig(struct tcmu_device *dev, uint32_t cfgtype)
+{
+	int ret = 0;
+
+	switch (cfgtype) {
+	case CONFIG_PATH:
+		tcmu_dev_err(dev, "device path reconfiguration is not supported\n");
+		return -EINVAL;
+	case CONFIG_SIZE:
+		tcmu_dev_err(dev, "device size reconfiguration is not supported\n");
+		return -EINVAL;
+	case CONFIG_WRITECACHE:
+		tcmu_dev_err(dev, "Write_cache reconfiguration is not supported\n");
+		return -EINVAL;
+	}
+
+	return ret;
+}
+
 /* Note: this is called per lun, not per mapping */
 static int fbo_open(struct tcmu_device *dev)
 {
@@ -1677,7 +1696,7 @@ static struct tcmur_handler fbo_handler = {
 	.cfg_desc = fbo_cfg_desc,
 
 	.check_config = fbo_check_config,
-
+	.reconfig = fbo_reconfig,
 	.open = fbo_open,
 	.close = fbo_close,
 	.name = "File-backed optical Handler",

--- a/glfs.c
+++ b/glfs.c
@@ -29,7 +29,6 @@
 #include "darray.h"
 
 #include "tcmu-runner.h"
-#include "libtcmu.h"
 
 #define ALLOWED_BSOFLAGS (O_SYNC | O_DIRECT | O_RDWR | O_LARGEFILE)
 
@@ -483,25 +482,6 @@ done:
 	return result;
 }
 
-static int glfs_reconfig(struct tcmu_device *dev, uint32_t cfgtype)
-{
-	int ret = 0;
-
-	switch (cfgtype) {
-	case CONFIG_PATH:
-		tcmu_dev_err(dev, "device path reconfiguration is not supported\n");
-		return -EINVAL;
-	case CONFIG_SIZE:
-		ret = tcmu_config_size(dev);
-		break;
-	case CONFIG_WRITECACHE:
-		tcmu_dev_err(dev, "write_cache reconfiguration is not supported\n");
-		return -EINVAL;
-	}
-
-	return ret;
-}
-
 static int tcmu_glfs_open(struct tcmu_device *dev)
 {
 	struct glfs_state *gfsp;
@@ -702,7 +682,6 @@ struct tcmur_handler glfs_handler = {
 	.cfg_desc	= glfs_cfg_desc,
 
 	.check_config	= glfs_check_config,
-	.reconfig	= glfs_reconfig,
 
 	.open		= tcmu_glfs_open,
 	.close		= tcmu_glfs_close,

--- a/glfs.c
+++ b/glfs.c
@@ -29,6 +29,7 @@
 #include "darray.h"
 
 #include "tcmu-runner.h"
+#include "libtcmu.h"
 
 #define ALLOWED_BSOFLAGS (O_SYNC | O_DIRECT | O_RDWR | O_LARGEFILE)
 
@@ -482,6 +483,25 @@ done:
 	return result;
 }
 
+static int glfs_reconfig(struct tcmu_device *dev, uint32_t cfgtype)
+{
+	int ret = 0;
+
+	switch (cfgtype) {
+	case CONFIG_PATH:
+		tcmu_dev_err(dev, "device path reconfiguration is not supported\n");
+		return -EINVAL;
+	case CONFIG_SIZE:
+		ret = tcmu_config_size(dev);
+		break;
+	case CONFIG_WRITECACHE:
+		tcmu_dev_err(dev, "write_cache reconfiguration is not supported\n");
+		return -EINVAL;
+	}
+
+	return ret;
+}
+
 static int tcmu_glfs_open(struct tcmu_device *dev)
 {
 	struct glfs_state *gfsp;
@@ -677,15 +697,16 @@ static const char glfs_cfg_desc[] =
 	"  filename:  The backing file";
 
 struct tcmur_handler glfs_handler = {
-	.name 		= "Gluster glfs handler",
-	.subtype 	= "glfs",
+	.name		= "Gluster glfs handler",
+	.subtype	= "glfs",
 	.cfg_desc	= glfs_cfg_desc,
 
-	.check_config 	= glfs_check_config,
+	.check_config	= glfs_check_config,
+	.reconfig	= glfs_reconfig,
 
-	.open 		= tcmu_glfs_open,
-	.close 		= tcmu_glfs_close,
-	.read 		= tcmu_glfs_read,
+	.open		= tcmu_glfs_open,
+	.close		= tcmu_glfs_close,
+	.read		= tcmu_glfs_read,
 	.write		= tcmu_glfs_write,
 	.flush		= tcmu_glfs_flush,
 };

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -882,3 +882,24 @@ void tcmulib_cleanup_all_cmdproc_threads()
 		cancel_thread(thread->thread_id);
 	}
 }
+
+int tcmu_config_size(struct tcmu_device *dev)
+{
+	int64_t dev_size;
+	uint32_t block_size;
+
+	block_size = tcmu_get_attribute(dev, "hw_block_size");
+	if (block_size <= 0) {
+		tcmu_dev_err(dev, "Could not get hw_block_size\n");
+		return -EINVAL;
+	}
+
+	dev_size = tcmu_get_device_size(dev);
+	if (dev_size < 0) {
+		tcmu_dev_err(dev, "Could not get device size\n");
+		return -EINVAL;
+	}
+
+	tcmu_set_dev_num_lbas(dev, dev_size / block_size);
+	return 0;
+}

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -28,11 +28,11 @@
 #include <dirent.h>
 #include <scsi/scsi.h>
 
-#include <linux/target_core_user.h>
-
 #include <libnl3/netlink/genl/genl.h>
 #include <libnl3/netlink/genl/mngt.h>
 #include <libnl3/netlink/genl/ctrl.h>
+
+#include <linux/target_core_user.h>
 
 #include "libtcmu.h"
 #include "libtcmu_log.h"
@@ -41,10 +41,17 @@
 #include "tcmur_cmd_handler.h"
 #include "tcmu-runner.h"
 
+#define TCMU_NL_VERSION 2
+
 static struct nla_policy tcmu_attr_policy[TCMU_ATTR_MAX+1] = {
 	[TCMU_ATTR_DEVICE]	= { .type = NLA_STRING },
 	[TCMU_ATTR_MINOR]	= { .type = NLA_U32 },
-	[TCMU_ATTR_TYPE]	= { .type = NLA_U32 },
+	[TCMU_ATTR_DEV_CFG]	= { .type = NLA_STRING },
+	[TCMU_ATTR_DEV_SIZE]	= { .type = NLA_U64 },
+	[TCMU_ATTR_WRITECACHE]	= { .type = NLA_U8 },
+	[TCMU_ATTR_CMD_STATUS]	= { .type = NLA_S32 },
+	[TCMU_ATTR_DEVICE_ID]	= { .type = NLA_U32 },
+	[TCMU_ATTR_SUPP_KERN_CMD_REPLY] = { .type = NLA_U8 },
 };
 
 static darray(struct tcmu_thread) g_threads = darray_new();
@@ -52,42 +59,9 @@ static darray(struct tcmu_thread) g_threads = darray_new();
 static int add_device(struct tcmulib_context *ctx, char *dev_name, char *cfgstring);
 static void remove_device(struct tcmulib_context *ctx, char *dev_name, char *cfgstring);
 static int reconfig_device(struct tcmulib_context *ctx, char *dev_name, char *cfgstring,
-			   uint32_t cfgtype);
-
+			   int cfgtype);
 static int handle_netlink(struct nl_cache_ops *unused, struct genl_cmd *cmd,
-			  struct genl_info *info, void *arg)
-{
-	struct tcmulib_context *ctx = arg;
-	char buf[32];
-
-	if (!info->attrs[TCMU_ATTR_MINOR] || !info->attrs[TCMU_ATTR_DEVICE]) {
-		tcmu_err("TCMU_ATTR_MINOR or TCMU_ATTR_DEVICE not set, doing nothing\n");
-		return 0;
-	}
-
-	snprintf(buf, sizeof(buf), "uio%d", nla_get_u32(info->attrs[TCMU_ATTR_MINOR]));
-
-	switch (cmd->c_id) {
-	case TCMU_CMD_ADDED_DEVICE:
-		add_device(ctx, buf, nla_get_string(info->attrs[TCMU_ATTR_DEVICE]));
-		break;
-	case TCMU_CMD_REMOVED_DEVICE:
-		remove_device(ctx, buf, nla_get_string(info->attrs[TCMU_ATTR_DEVICE]));
-		break;
-	case TCMU_CMD_RECONFIG_DEVICE:
-		if (!info->attrs[TCMU_ATTR_TYPE]) {
-			tcmu_err("TCMU_ATTR_TYPE not set, doing nothing\n");
-			return 0;
-		}
-		return reconfig_device(ctx, buf, nla_get_string(info->attrs[TCMU_ATTR_DEVICE]),
-				       nla_get_u32(info->attrs[TCMU_ATTR_TYPE]));
-		break;
-	default:
-		tcmu_err("Unknown notification %d\n", cmd->c_id);
-	}
-
-	return 0;
-}
+			  struct genl_info *info, void *arg);
 
 static struct genl_cmd tcmu_cmds[] = {
 	{
@@ -118,6 +92,127 @@ static struct genl_ops tcmu_ops = {
 	.o_cmds		= tcmu_cmds,
 	.o_ncmds	= ARRAY_SIZE(tcmu_cmds),
 };
+
+static int send_netlink_reply(struct tcmulib_context *ctx, int reply_cmd,
+			      uint32_t dev_id, int status)
+{
+	struct nl_sock *sock = ctx->nl_sock;
+	struct nl_msg *msg;
+	void *hdr;
+	int ret = -ENOMEM;
+
+	msg = nlmsg_alloc();
+	if (!msg)
+		return ret;
+
+	hdr = genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, tcmu_ops.o_id,
+			  0, 0, reply_cmd, TCMU_NL_VERSION);
+
+	if (!hdr)
+		goto free_msg;
+
+	ret = nla_put_s32(msg, TCMU_ATTR_CMD_STATUS, status);
+	if (ret < 0)
+		goto free_msg;
+
+	ret = nla_put_u32(msg, TCMU_ATTR_DEVICE_ID, dev_id);
+	if (ret < 0)
+		goto free_msg;
+
+	/* Ignore ack. There is nothing we can do. */
+	ret = nl_send_auto(sock, msg);
+
+free_msg:
+	nlmsg_free(msg);
+
+	if (ret < 0)
+		tcmu_err("Could not send netlink cmd %d\n", reply_cmd);
+	return ret;
+}
+
+static int handle_netlink(struct nl_cache_ops *unused, struct genl_cmd *cmd,
+			  struct genl_info *info, void *arg)
+{
+	struct tcmulib_context *ctx = arg;
+	int ret, reply_cmd, version = info->genlhdr->version;
+	char buf[32];
+
+	tcmu_dbg("cmd %d. Got header version %d. Supported %d.\n",
+		 cmd->c_id, info->genlhdr->version, TCMU_NL_VERSION);
+
+	if (!info->attrs[TCMU_ATTR_MINOR] || !info->attrs[TCMU_ATTR_DEVICE]) {
+		tcmu_err("TCMU_ATTR_MINOR or TCMU_ATTR_DEVICE not set, doing nothing\n");
+		return 0;
+	}
+
+	if (version > 1 && !info->attrs[TCMU_ATTR_DEVICE_ID]) {
+		tcmu_err("TCMU_ATTR_DEVICE_ID not set in v%d cmd %d, dropping netink command.\n",
+			 version, cmd->c_id);
+		return 0;
+	}
+
+	snprintf(buf, sizeof(buf), "uio%d", nla_get_u32(info->attrs[TCMU_ATTR_MINOR]));
+
+	switch (cmd->c_id) {
+	case TCMU_CMD_ADDED_DEVICE:
+		reply_cmd = TCMU_CMD_ADDED_DEVICE_DONE;
+		ret = add_device(ctx, buf,
+				 nla_get_string(info->attrs[TCMU_ATTR_DEVICE]));
+		break;
+	case TCMU_CMD_REMOVED_DEVICE:
+		reply_cmd = TCMU_CMD_REMOVED_DEVICE_DONE;
+		remove_device(ctx, buf, nla_get_string(info->attrs[TCMU_ATTR_DEVICE]));
+		ret = 0;
+		break;
+	case TCMU_CMD_RECONFIG_DEVICE:
+		return reconfig_device(ctx, buf, nla_get_string(info->attrs[TCMU_ATTR_DEVICE]),
+					nla_type(*info->attrs));
+		break;
+	default:
+		tcmu_err("Unknown netlink command %d. Netlink header received version %d. libtcmu supports %d\n",
+			 cmd->c_id, version, TCMU_NL_VERSION);
+		return -EOPNOTSUPP;
+	}
+
+	if (version > 1)
+		ret = send_netlink_reply(ctx, reply_cmd,
+					 nla_get_u32(info->attrs[TCMU_ATTR_DEVICE_ID]),
+					 ret);
+
+	return ret;
+}
+
+static int set_genl_features(struct nl_sock *sock)
+{
+	struct nl_msg *msg;
+	void *hdr;
+	int ret = -ENOMEM;
+
+	msg = nlmsg_alloc();
+	if (!msg)
+		return ret;
+
+	hdr = genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, tcmu_ops.o_id,
+			  0, NLM_F_ACK, TCMU_CMD_SET_FEATURES, TCMU_NL_VERSION);
+	if (!hdr)
+		goto free_msg;
+
+	ret = nla_put_u8(msg, TCMU_ATTR_SUPP_KERN_CMD_REPLY, 1);
+	if (ret < 0)
+		goto free_msg;
+
+	ret = nl_send_sync(sock, msg);
+	goto done;
+
+free_msg:
+	nlmsg_free(msg);
+
+done:
+	if (ret < 0)
+		tcmu_err("Could not set features. Error %d\n", ret);
+
+	return ret;
+}
 
 static struct nl_sock *setup_netlink(struct tcmulib_context *ctx)
 {
@@ -159,6 +254,12 @@ static struct nl_sock *setup_netlink(struct tcmulib_context *ctx)
 		tcmu_err("couldn't add membership\n");
 		goto err_close;
 	}
+
+	/*
+	 * Could be a older kernel. Ignore failure and just work in degraded
+	 * mode.
+	 */
+	set_genl_features(sock);
 
 	return sock;
 
@@ -344,16 +445,13 @@ static void close_devices(struct tcmulib_context *ctx)
 }
 
 static int reconfig_device(struct tcmulib_context *ctx, char *dev_name, char *cfgstring,
-			   uint32_t cfgtype)
+			   int cfgtype)
 {
 	struct tcmu_device **dev_ptr;
 	struct tcmu_device *dev;
 	int i = 0;
 	bool found = false;
 	int ret;
-
-	if (cfgtype == NO_RECONFIG)
-		return 0;
 
 	darray_foreach(dev_ptr, ctx->devices) {
 		dev = *dev_ptr;

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -55,7 +55,7 @@ struct tcmulib_handler {
 	 */
 	bool (*check_config)(const char *cfgstring, char **reason);
 
-	int (*reconfig)(struct tcmu_device *dev, uint32_t cfgtype);
+	int (*reconfig)(struct tcmu_device *dev, int cfgtype);
 
 	/* Per-device added/removed callbacks */
 	int (*added)(struct tcmu_device *dev);

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -55,6 +55,8 @@ struct tcmulib_handler {
 	 */
 	bool (*check_config)(const char *cfgstring, char **reason);
 
+	int (*reconfig)(struct tcmu_device *dev, uint32_t cfgtype);
+
 	/* Per-device added/removed callbacks */
 	int (*added)(struct tcmu_device *dev);
 	void (*removed)(struct tcmu_device *dev);

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -126,6 +126,9 @@ void tcmulib_cleanup_cmdproc_thread(struct tcmu_device *dev);
 /* cleanup all (devices) command processing threads */
 void tcmulib_cleanup_all_cmdproc_threads();
 
+/* Functions for reconfiguration */
+int tcmu_config_size(struct tcmu_device *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -84,6 +84,13 @@ struct tcmulib_cmd {
 	cmd_done_t done;
 };
 
+enum tcmu_reconfig_types {
+	NO_RECONFIG,
+	CONFIG_PATH,
+	CONFIG_SIZE,
+	CONFIG_WRITECACHE,
+};
+
 /* Set/Get methods for the opaque tcmu_device */
 void *tcmu_get_dev_private(struct tcmu_device *dev);
 void tcmu_set_dev_private(struct tcmu_device *dev, void *priv);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -84,13 +84,6 @@ struct tcmulib_cmd {
 	cmd_done_t done;
 };
 
-enum tcmu_reconfig_types {
-	NO_RECONFIG,
-	CONFIG_PATH,
-	CONFIG_SIZE,
-	CONFIG_WRITECACHE,
-};
-
 /* Set/Get methods for the opaque tcmu_device */
 void *tcmu_get_dev_private(struct tcmu_device *dev);
 void tcmu_set_dev_private(struct tcmu_device *dev, void *priv);

--- a/main.c
+++ b/main.c
@@ -855,6 +855,7 @@ int main(int argc, char **argv)
 		tmp_handler.subtype = (*tmp_r_handler)->subtype;
 		tmp_handler.cfg_desc = (*tmp_r_handler)->cfg_desc;
 		tmp_handler.check_config = (*tmp_r_handler)->check_config;
+		tmp_handler.reconfig = (*tmp_r_handler)->reconfig;
 		tmp_handler.added = dev_added;
 		tmp_handler.removed = dev_removed;
 

--- a/qcow.c
+++ b/qcow.c
@@ -73,6 +73,7 @@
 #include "scsi_defs.h"
 #include "qcow.h"
 #include "qcow2.h"
+#include "libtcmu.h"
 
 /* Block Device abstraction to support multiple image types */
 
@@ -1398,6 +1399,25 @@ static bool qcow_check_config(const char *cfgstring, char **reason)
 	return true; /* File exists and is writable */
 }
 
+static int qcow_reconfig(struct tcmu_device *dev, uint32_t cfgtype)
+{
+	int ret = 0;
+
+	switch (cfgtype) {
+	case CONFIG_PATH:
+		tcmu_dev_err(dev, "device path reconfiguration is not supported\n");
+		return -EINVAL;
+	case CONFIG_SIZE:
+		ret = tcmu_config_size(dev);
+		break;
+	case CONFIG_WRITECACHE:
+		tcmu_dev_err(dev, "write_cache reconfiguration is not supported\n");
+		return -EINVAL;
+	}
+
+	return ret;
+}
+
 static int qcow_open(struct tcmu_device *dev)
 {
 	struct bdev *bdev;
@@ -1502,6 +1522,7 @@ static struct tcmur_handler qcow_handler = {
 	.cfg_desc = qcow_cfg_desc,
 
 	.check_config = qcow_check_config,
+	.reconfig = qcow_reconfig,
 
 	.open = qcow_open,
 	.close = qcow_close,

--- a/qcow.c
+++ b/qcow.c
@@ -75,6 +75,10 @@
 #include "qcow2.h"
 #include "libtcmu.h"
 
+#define TCMU_ATTR_DEV_CFG       4
+#define TCMU_ATTR_DEV_SIZE      5
+#define TCMU_ATTR_WRITECACHE    6
+
 /* Block Device abstraction to support multiple image types */
 
 struct bdev_ops;
@@ -1399,18 +1403,18 @@ static bool qcow_check_config(const char *cfgstring, char **reason)
 	return true; /* File exists and is writable */
 }
 
-static int qcow_reconfig(struct tcmu_device *dev, uint32_t cfgtype)
+static int qcow_reconfig(struct tcmu_device *dev, int cfgtype)
 {
 	int ret = 0;
 
 	switch (cfgtype) {
-	case CONFIG_PATH:
+	case TCMU_ATTR_DEV_CFG:
 		tcmu_dev_err(dev, "device path reconfiguration is not supported\n");
 		return -EINVAL;
-	case CONFIG_SIZE:
+	case TCMU_ATTR_DEV_SIZE:
 		ret = tcmu_config_size(dev);
 		break;
-	case CONFIG_WRITECACHE:
+	case TCMU_ATTR_WRITECACHE:
 		tcmu_dev_err(dev, "write_cache reconfiguration is not supported\n");
 		return -EINVAL;
 	}

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -61,7 +61,7 @@ struct tcmur_handler {
 	 */
 	bool (*check_config)(const char *cfgstring, char **reason);
 
-	int (*reconfig)(struct tcmu_device *dev, uint32_t cfgtype);
+	int (*reconfig)(struct tcmu_device *dev, int cfgtype);
 
 	/* Per-device added/removed callbacks */
 	int (*open)(struct tcmu_device *dev);

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -61,6 +61,8 @@ struct tcmur_handler {
 	 */
 	bool (*check_config)(const char *cfgstring, char **reason);
 
+	int (*reconfig)(struct tcmu_device *dev, uint32_t cfgtype);
+
 	/* Per-device added/removed callbacks */
 	int (*open)(struct tcmu_device *dev);
 	void (*close)(struct tcmu_device *dev);


### PR DESCRIPTION
This patch adds the backbone for reconfiguration of any of the
backstores.

Signed-off-by: Bryant G. Ly <bryantly@linux.vnet.ibm.com>