### PR TITLE
fixup fd leakage in libtcmu_config.c

### DIFF
--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -371,12 +371,11 @@ int tcmu_load_config(struct tcmu_config *cfg, const char *path)
 	}
 
 	len = tcmu_read_config(fd, buf, TCMU_MAX_CFG_FILE_SIZE);
+	close(fd);
 	if (len < 0) {
 		tcmu_err("Failed to read file '%s'\n", path);
 		return -1;
 	}
-
-	close(fd);
 
 	buf[len] = '\0';
 


### PR DESCRIPTION
We open a PID filedescriptor, but never close it while a read() is interrrupted 
after reading some data to retrun -1.
So close the PID fd properly.

Signed-off-by: kai zhang <zhang.kai16@zte.com.cn>