### PR TITLE
lock: fix return value check of pthread_*() calls

### DIFF
--- a/main.c
+++ b/main.c
@@ -656,15 +656,15 @@ static int dev_added(struct tcmu_device *dev)
 		     block_size, dev_size);
 
 	ret = pthread_spin_init(&rdev->lock, 0);
-	if (ret < 0)
+	if (ret != 0)
 		goto free_rdev;
 
 	ret = pthread_mutex_init(&rdev->caw_lock, NULL);
-	if (ret < 0)
+	if (ret != 0)
 		goto cleanup_dev_lock;
 
 	ret = pthread_mutex_init(&rdev->format_lock, NULL);
-	if (ret < 0)
+	if (ret != 0)
 		goto cleanup_caw_lock;
 
 	ret = setup_io_work_queue(dev);
@@ -721,15 +721,15 @@ static void dev_removed(struct tcmu_device *dev)
 	cleanup_aio_tracking(rdev);
 
 	ret = pthread_mutex_destroy(&rdev->format_lock);
-	if (ret < 0)
+	if (ret != 0)
 		tcmu_err("could not cleanup format lock %d\n", ret);
 
 	ret = pthread_mutex_destroy(&rdev->caw_lock);
-	if (ret < 0)
+	if (ret != 0)
 		tcmu_err("could not cleanup caw lock %d\n", ret);
 
 	ret = pthread_spin_destroy(&rdev->lock);
-	if (ret < 0)
+	if (ret != 0)
 		tcmu_err("could not cleanup mailbox lock %d\n", ret);
 
 	free(rdev);

--- a/rbd.c
+++ b/rbd.c
@@ -361,7 +361,7 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 	tcmu_set_dev_private(dev, state);
 
 	ret = pthread_spin_init(&state->lock, 0);
-	if (ret < 0) {
+	if (ret != 0) {
 		free(state);
 		return ret;
 	}

--- a/tcmur_aio.c
+++ b/tcmur_aio.c
@@ -164,7 +164,7 @@ int setup_aio_tracking(struct tcmur_device *rdev)
 
 	aio_track->tracked_aio_ops = 0;
 	ret = pthread_spin_init(&aio_track->track_lock, 0);
-	if (ret < 0) {
+	if (ret != 0) {
 		return ret;
 	}
 
@@ -179,7 +179,7 @@ void cleanup_aio_tracking(struct tcmur_device *rdev)
 	assert(aio_track->tracked_aio_ops == 0);
 
 	ret = pthread_spin_destroy(&aio_track->track_lock);
-	if (ret < 0) {
+	if (ret != 0) {
 		tcmu_err("failed to destroy track lock\n");
 	}
 }
@@ -215,11 +215,11 @@ int setup_io_work_queue(struct tcmu_device *dev)
 	list_head_init(&io_wq->io_queue);
 
 	ret = pthread_mutex_init(&io_wq->io_lock, NULL);
-	if (ret < 0) {
+	if (ret != 0) {
 		goto out;
 	}
 	ret = pthread_cond_init(&io_wq->io_cond, NULL);
-	if (ret < 0) {
+	if (ret != 0) {
 		goto cleanup_lock;
 	}
 
@@ -231,7 +231,7 @@ int setup_io_work_queue(struct tcmu_device *dev)
 	for (i = 0; i < nr_threads; i++) {
 		ret = pthread_create(&io_wq->io_wq_threads[i], NULL,
 				      io_work_queue, dev);
-		if (ret < 0) {
+		if (ret != 0) {
 			goto cleanup_threads;
 		}
 	}


### PR DESCRIPTION
Summary of manual pages of all pthread_*() functions,
On success, pthread_*() returns 0; on error, they returns an error number

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>