### PR TITLE
config: Add dynamic reloading support

### DIFF
--- a/libtcmu_config.h
+++ b/libtcmu_config.h
@@ -18,8 +18,12 @@
 # define __TCMU_CONFIG_H
 
 #include <stdbool.h>
+#include <pthread.h>
 
 struct tcmu_config {
+	pthread_t thread_id;
+	char *path;
+
 	int log_level;
 };
 
@@ -63,4 +67,5 @@ struct tcmu_conf_option {
 int tcmu_load_config(struct tcmu_config *cfg, const char *path);
 void tcmu_config_destroy(struct tcmu_config *cfg);
 struct tcmu_config * tcmu_config_new(void);
+void tcmu_cancel_config_thread(struct tcmu_config *cfg);
 #endif /* __TCMU_CONFIG_H */

--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -64,7 +64,7 @@ struct log_output {
 	tcmu_log_destination dest;
 };
 
-static int tcmu_log_level = TCMU_LOG_WARN;
+static int tcmu_log_level = TCMU_LOG_INFO;
 static struct log_buf *tcmu_log_initialize(void);
 
 static struct log_buf *logbuf = NULL;
@@ -85,7 +85,7 @@ static inline int to_syslog_level(int level)
 		case TCMU_CONF_LOG_DEBUG_SCSI_CMD:
 			return TCMU_LOG_DEBUG_SCSI_CMD;
 		default:
-			return TCMU_LOG_WARN;
+			return TCMU_LOG_INFO;
 	}
 }
 
@@ -97,9 +97,9 @@ unsigned int tcmu_get_log_level(void)
 
 void tcmu_set_log_level(int level)
 {
-	/* set the default log level to warning */
+	/* set the default log level to info */
 	if (!level)
-		level = TCMU_CONF_LOG_WARN;
+		level = TCMU_CONF_LOG_INFO;
 
 	tcmu_log_level = to_syslog_level(level);
 }

--- a/main.c
+++ b/main.c
@@ -57,6 +57,8 @@ static char *handler_path = DEFAULT_HANDLER_PATH;
 /* tcmu log dir path */
 extern char *tcmu_log_dir;
 
+static struct tcmu_config *tcmu_cfg;
+
 darray(struct tcmur_handler *) g_runner_handlers = darray_new();
 
 static struct tcmur_handler *find_handler_by_subtype(gchar *subtype)
@@ -165,6 +167,7 @@ static void sighandler(int signal)
 {
 	tcmulib_cleanup_all_cmdproc_threads();
 	tcmu_cancel_log_thread();
+	tcmu_cancel_config_thread(tcmu_cfg);
 	exit(1);
 }
 
@@ -787,13 +790,11 @@ int main(int argc, char **argv)
 	struct tcmulib_context *tcmulib_context;
 	darray(struct tcmulib_handler) handlers = darray_new();
 	struct tcmur_handler **tmp_r_handler;
-	struct tcmu_config *cfg;
 
-	cfg = tcmu_config_new();
-	if (!cfg)
+	tcmu_cfg = tcmu_config_new();
+	if (!tcmu_cfg)
 		exit(1);
-	tcmu_load_config(cfg, NULL);
-	tcmu_set_log_level(cfg->log_level);
+	tcmu_load_config(tcmu_cfg, NULL);
 
 	while (1) {
 		int option_index = 0;
@@ -905,13 +906,13 @@ int main(int argc, char **argv)
 	g_bus_unown_name(reg_id);
 	g_main_loop_unref(loop);
 	tcmulib_close(tcmulib_context);
-	tcmu_config_destroy(cfg);
+	tcmu_config_destroy(tcmu_cfg);
 
 	return 0;
 
 err_tcmulib_close:
 	tcmulib_close(tcmulib_context);
 err_out:
-	tcmu_config_destroy(cfg);
+	tcmu_config_destroy(tcmu_cfg);
 	exit(1);
 }


### PR DESCRIPTION
Using the inotify, if write to the unwritable or crashed config file
forcely, the vi/vim will try to move and delete the old config file
and then recreate it again via the *.swp. When deleting the old
config file, the inotify watching handler will be removed from the
monitor too, so needs to add it back again.


Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>