### PR TITLE
Perform netlink operations synchronously and add reconfig support

### DIFF
--- a/file_example.c
+++ b/file_example.c
@@ -41,6 +41,7 @@
 #include <scsi/scsi.h>
 
 #include "scsi_defs.h"
+#include "libtcmu.h"
 #include "tcmu-runner.h"
 
 struct file_state {
@@ -193,6 +194,18 @@ done:
 	return 0;
 }
 
+static int file_reconfig(struct tcmu_device *dev, struct tcmulib_cfg_info *cfg)
+{
+	switch (cfg->type) {
+	case TCMULIB_CFG_DEV_SIZE:
+		return tcmu_update_num_lbas(dev, cfg->data.dev_size);
+	case TCMULIB_CFG_DEV_CFGSTR:
+	case TCMULIB_CFG_WRITE_CACHE:
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
 static const char file_cfg_desc[] =
 	"The path to the file to use as a backstore.";
 
@@ -200,6 +213,7 @@ static struct tcmur_handler file_handler = {
 	.cfg_desc = file_cfg_desc,
 
 	.check_config = file_check_config,
+	.reconfig = file_reconfig,
 
 	.open = file_open,
 	.close = file_close,

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -32,6 +32,22 @@ extern "C" {
 #include "libtcmu_common.h"
 #include "libtcmu_log.h"
 
+enum tcmulib_cfg_type {
+	TCMULIB_CFG_DEV_CFGSTR,
+	TCMULIB_CFG_DEV_SIZE,
+	TCMULIB_CFG_WRITE_CACHE,
+};
+
+struct tcmulib_cfg_info {
+	enum tcmulib_cfg_type type;
+
+	union {
+		uint64_t dev_size;
+		char *dev_cfgstring;
+		bool write_cache;
+	} data;
+};
+
 struct tcmulib_handler {
 	const char *name;	/* Human-friendly name */
 	const char *subtype;	/* Name for cfgstring matching */
@@ -54,6 +70,8 @@ struct tcmulib_handler {
 	 * Suggest using asprintf().
 	 */
 	bool (*check_config)(const char *cfgstring, char **reason);
+
+	int (*reconfig)(struct tcmu_device *dev, struct tcmulib_cfg_info *cfg);
 
 	/* Per-device added/removed callbacks */
 	int (*added)(struct tcmu_device *dev);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -93,6 +93,7 @@ int tcmu_get_dev_fd(struct tcmu_device *dev);
 char *tcmu_get_dev_cfgstring(struct tcmu_device *dev);
 void tcmu_set_dev_num_lbas(struct tcmu_device *dev, uint64_t num_lbas);
 uint64_t tcmu_get_dev_num_lbas(struct tcmu_device *dev);
+int tcmu_update_num_lbas(struct tcmu_device *dev, uint64_t new_size);
 void tcmu_set_dev_block_size(struct tcmu_device *dev, uint32_t block_size);
 uint32_t tcmu_get_dev_block_size(struct tcmu_device *dev);
 void tcmu_set_dev_max_xfer_len(struct tcmu_device *dev, uint32_t len);

--- a/main.c
+++ b/main.c
@@ -855,6 +855,7 @@ int main(int argc, char **argv)
 		tmp_handler.subtype = (*tmp_r_handler)->subtype;
 		tmp_handler.cfg_desc = (*tmp_r_handler)->cfg_desc;
 		tmp_handler.check_config = (*tmp_r_handler)->check_config;
+		tmp_handler.reconfig = (*tmp_r_handler)->reconfig;
 		tmp_handler.added = dev_added;
 		tmp_handler.removed = dev_removed;
 

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -39,6 +39,8 @@ typedef int (*rw_fn_t)(struct tcmu_device *, struct tcmulib_cmd *,
 typedef int (*flush_fn_t)(struct tcmu_device *, struct tcmulib_cmd *);
 typedef int (*handle_cmd_fn_t)(struct tcmu_device *, struct tcmulib_cmd *);
 
+struct tcmulib_cfg_info;
+
 struct tcmur_handler {
 	const char *name;	/* Human-friendly name */
 	const char *subtype;	/* Name for cfgstring matching */
@@ -60,6 +62,8 @@ struct tcmur_handler {
 	 * Suggest using asprintf().
 	 */
 	bool (*check_config)(const char *cfgstring, char **reason);
+
+	int (*reconfig)(struct tcmu_device *dev, struct tcmulib_cfg_info *cfg);
 
 	/* Per-device added/removed callbacks */
 	int (*open)(struct tcmu_device *dev);


### PR DESCRIPTION
These patches fix the issue where the kernel does not wait for userspace responses to add/delete/reconfigure, so if runner failed to execute them, the kernel will still end up updating its state. This can result in the kernel returning LUNs that are not setup in userspace, a race where close is called on the uio device after the kernel has done unregister, and the userspace and kernel device state out of sync.

These patches along with these kernel changes:
https://www.spinics.net/lists/target-devel/msg15706.html
fix the problem by having the kernel  wait for runner's response to these operations.