### PR TITLE
fix: judge the function tcmu_config_new return value

### DIFF
--- a/main.c
+++ b/main.c
@@ -790,6 +790,8 @@ int main(int argc, char **argv)
 	struct tcmu_config *cfg;
 
 	cfg = tcmu_config_new();
+	if (!cfg)
+		exit(1);
 	tcmu_load_config(cfg, NULL);
 	tcmu_set_log_level(cfg->log_level);
 


### PR DESCRIPTION
If the function tcmu_config_new return NULL，the process shoud exit，otherwise  it may cause coredump。

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>