### PR TITLE
fix memory leak in gluster_cache_add

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -171,7 +171,7 @@ static int gluster_cache_add(gluster_server *dst, glfs_t *fs, char* cfgstring)
 
 	entry->server = calloc(1, sizeof(gluster_hostdef));
 	if (!entry->server)
-		goto error;
+		goto free_entry;
 
 	entry->server->type = dst->server->type;
 
@@ -192,6 +192,10 @@ static int gluster_cache_add(gluster_server *dst, glfs_t *fs, char* cfgstring)
 
 	return 0;
 
+free_entry:
+	if (entry->volname)
+		free(entry->volname);
+	free(entry);
  error:
 	return -1;
 }


### PR DESCRIPTION
When memory allocation failed, the allocated memory has to be freed

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>