### PR TITLE
libtcmu: free ctx in tcmulib_initialize

### DIFF
--- a/libtcmu.c
+++ b/libtcmu.c
@@ -653,6 +653,8 @@ struct tcmulib_context *tcmulib_initialize(
 		teardown_netlink(ctx->nl_sock);
 		darray_free(ctx->handlers);
 		darray_free(ctx->devices);
+		genl_unregister_family(&tcmu_ops);
+		free(ctx);
 		return NULL;
 	}
 


### PR DESCRIPTION
when open_devices() failed in tcmulib_initialize ，need to free ctx and unregistered tcmu_ops。

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>