### PR TITLE
main: close the glib io-channel

### DIFF
--- a/main.c
+++ b/main.c
@@ -904,6 +904,7 @@ int main(int argc, char **argv)
 	tcmu_dbg("Exiting...\n");
 	g_bus_unown_name(reg_id);
 	g_main_loop_unref(loop);
+	g_io_channel_shutdown(libtcmu_gio, TRUE, NULL);
 	tcmulib_close(tcmulib_context);
 	tcmu_config_destroy(cfg);
 


### PR DESCRIPTION
by closing the IO channel, any pending data to be written will be flushed.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>