### PR TITLE
build: fix compiler warnings

### DIFF
--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -311,7 +311,7 @@ static int output_to_fd(int pri, const char *timestamp,
 {
 	int fd = (intptr_t) data;
 	char *buf, *msg;
-	int count, ret, written, r, pid = 0;
+	int count, ret, written = 0, r, pid = 0;
 
 	if (fd < 0)
 		return -1;


### PR DESCRIPTION
fixed warnings: uninitialized format-truncation unused-results

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>