### PR TITLE
Libtcmu library update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(tcmu
   api.c
   alua.c
   tcmur_cmd_handler.c
-  tcmur_aio.c
+  libtcmu_aio.c
   libtcmu.c
   libtcmu-register.c
   tcmuhandler-generated.c
@@ -70,7 +70,7 @@ add_library(tcmu_static
   api.c
   alua.c
   tcmur_cmd_handler.c
-  tcmur_aio.c
+  libtcmu_aio.c
   libtcmu.c
   libtcmu-register.c
   tcmuhandler-generated.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library(tcmu
   configfs.c
   api.c
   alua.c
-  tcmur_cmd_handler.c
+  libtcmu_cmd_handler.c
   libtcmu_aio.c
   libtcmu.c
   libtcmu-register.c
@@ -69,7 +69,7 @@ add_library(tcmu_static
   configfs.c
   api.c
   alua.c
-  tcmur_cmd_handler.c
+  libtcmu_cmd_handler.c
   libtcmu_aio.c
   libtcmu.c
   libtcmu-register.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ add_library(tcmu
   SHARED
   configfs.c
   api.c
+  alua.c
+  tcmur_cmd_handler.c
+  tcmur_aio.c
   libtcmu.c
   libtcmu-register.c
   tcmuhandler-generated.c
@@ -65,6 +68,9 @@ install(TARGETS tcmu LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 add_library(tcmu_static
   configfs.c
   api.c
+  alua.c
+  tcmur_cmd_handler.c
+  tcmur_aio.c
   libtcmu.c
   libtcmu-register.c
   tcmuhandler-generated.c
@@ -82,9 +88,6 @@ target_link_libraries(tcmu_static
 
 # Stuff for building the main binary
 add_executable(tcmu-runner
-  tcmur_cmd_handler.c
-  tcmur_aio.c
-  alua.c
   main.c
   tcmuhandler-generated.c
   )

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -38,7 +38,7 @@
 #include "libtcmu_log.h"
 #include "libtcmu_priv.h"
 #include "libtcmu_aio.h"
-#include "tcmur_cmd_handler.h"
+#include "libtcmu_cmd_handler.h"
 #include "tcmu-runner.h"
 
 #define TCMU_NL_VERSION 2

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -37,7 +37,7 @@
 #include "libtcmu.h"
 #include "libtcmu_log.h"
 #include "libtcmu_priv.h"
-#include "tcmur_aio.h"
+#include "libtcmu_aio.h"
 #include "tcmur_cmd_handler.h"
 #include "tcmu-runner.h"
 

--- a/libtcmu_aio.c
+++ b/libtcmu_aio.c
@@ -25,7 +25,7 @@
 #include "libtcmu.h"
 #include "libtcmu_priv.h"
 #include "tcmur_device.h"
-#include "tcmur_aio.h"
+#include "libtcmu_aio.h"
 #include "tcmu-runner.h"
 
 struct tcmu_work {

--- a/libtcmu_aio.h
+++ b/libtcmu_aio.h
@@ -14,8 +14,8 @@
  * under the License.
  */
 
-#ifndef __TCMUR_AIO_H
-#define __TCMUR_AIO_H
+#ifndef __LIBTCMU_AIO_H
+#define __LIBTCMU_AIO_H
 
 #include <pthread.h>
 
@@ -55,4 +55,4 @@ int async_handle_cmd(struct tcmu_device *, struct tcmulib_cmd *,
 void track_aio_request_start(struct tcmur_device *);
 void track_aio_request_finish(struct tcmur_device *, int *);
 
-#endif /* __TCMUR_AIO_H */
+#endif /* __LIBTCMU_AIO_H */

--- a/libtcmu_cmd_handler.c
+++ b/libtcmu_cmd_handler.c
@@ -29,8 +29,8 @@
 #include "libtcmu_log.h"
 #include "libtcmu_priv.h"
 #include "libtcmu_aio.h"
+#include "libtcmu_cmd_handler.h"
 #include "tcmur_device.h"
-#include "tcmur_cmd_handler.h"
 #include "tcmu-runner.h"
 #include "alua.h"
 

--- a/libtcmu_cmd_handler.c
+++ b/libtcmu_cmd_handler.c
@@ -34,8 +34,9 @@
 #include "tcmu-runner.h"
 #include "alua.h"
 
-void tcmur_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
-			    int rc)
+void tcmulib_handle_cmd_complete(struct tcmu_device *dev,
+				 struct tcmulib_cmd *cmd,
+				 int rc)
 {
 	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);
 
@@ -54,7 +55,7 @@ static void aio_command_finish(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	int wakeup;
 
 	track_aio_request_finish(tcmu_get_daemon_dev_private(dev), &wakeup);
-	tcmur_command_complete(dev, cmd, rc);
+	tcmulib_handle_cmd_complete(dev, cmd, rc);
 	if (wakeup)
 		tcmulib_processing_complete(dev);
 }
@@ -1693,7 +1694,7 @@ static int handle_passthrough(struct tcmu_device *dev,
 	return async_handle_cmd(dev, cmd, passthrough_work_fn);
 }
 
-bool tcmur_handler_is_passthrough_only(struct tcmur_handler *rhandler)
+bool tcmulib_handler_is_passthrough_only(struct tcmur_handler *rhandler)
 {
 	if (rhandler->write || rhandler->read || rhandler->flush)
 		return false;
@@ -1701,7 +1702,7 @@ bool tcmur_handler_is_passthrough_only(struct tcmur_handler *rhandler)
 	return true;
 }
 
-int tcmur_cmd_passthrough_handler(struct tcmu_device *dev,
+int tcmulib_passthrough_cmds(struct tcmu_device *dev,
 				  struct tcmulib_cmd *cmd)
 {
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
@@ -1732,7 +1733,7 @@ int tcmur_cmd_passthrough_handler(struct tcmu_device *dev,
 	return ret;
 }
 
-static int tcmur_cmd_handler(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+static int handle_cmds(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 {
 	int ret = TCMU_NOT_HANDLED;
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
@@ -1820,7 +1821,7 @@ static int handle_inquiry(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	return ret;
 }
 
-static int handle_generic_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+static int handle_generic_cmds(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 {
 	uint8_t *cdb = cmd->cdb;
 	struct iovec *iovec = cmd->iovec;
@@ -1889,7 +1890,7 @@ static bool command_is_generic(struct tcmulib_cmd *cmd)
 	}
 }
 
-int tcmur_generic_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+int tcmulib_handle_cmds(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 {
 	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
@@ -1912,7 +1913,7 @@ int tcmur_generic_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 
 	/* Falls back to the runner's generic handle callout */
 	if (command_is_generic(cmd))
-		return handle_generic_cmd(dev, cmd);
+		return handle_generic_cmds(dev, cmd);
 	else
-		return tcmur_cmd_handler(dev, cmd);
+		return handle_cmds(dev, cmd);
 }

--- a/libtcmu_cmd_handler.h
+++ b/libtcmu_cmd_handler.h
@@ -22,10 +22,9 @@
 struct tcmu_device;
 struct tcmulib_cmd;
 
-int tcmur_generic_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
-int tcmur_cmd_passthrough_handler(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
-bool tcmur_handler_is_passthrough_only(struct tcmur_handler *rhandler);
-void tcmur_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
-			    int ret);
+int tcmulib_handle_cmds(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
+int tcmulib_passthrough_cmds(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
+bool tcmulib_handler_is_passthrough_only(struct tcmur_handler *rhandler);
+void tcmulib_handle_cmd_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int ret);
 
 #endif /* __LIBTCMU_CMD_HANDLER_H */

--- a/libtcmu_cmd_handler.h
+++ b/libtcmu_cmd_handler.h
@@ -14,8 +14,8 @@
  * under the License.
 */
 
-#ifndef __TCMUR_CMD_HANDLER_H
-#define __TCMUR_CMD_HANDLER_H
+#ifndef __LIBTCMU_CMD_HANDLER_H
+#define __LIBTCMU_CMD_HANDLER_H
 
 #include <stdint.h>
 
@@ -28,4 +28,4 @@ bool tcmur_handler_is_passthrough_only(struct tcmur_handler *rhandler);
 void tcmur_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 			    int ret);
 
-#endif /* __TCMUR_CMD_HANDLER_H */
+#endif /* __LIBTCMU_CMD_HANDLER_H */

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -31,7 +31,7 @@
 #include "scsi_defs.h"
 #include "darray.h"
 #include "ccan/list/list.h"
-#include "tcmur_aio.h"
+#include "libtcmu_aio.h"
 #include "tcmu-runner.h"
 
 #define KERN_IFACE_VER 2

--- a/main.c
+++ b/main.c
@@ -45,7 +45,7 @@
 #include "darray.h"
 #include "tcmu-runner.h"
 #include "tcmur_device.h"
-#include "tcmur_cmd_handler.h"
+#include "libtcmu_cmd_handler.h"
 #include "libtcmu.h"
 #include "tcmuhandler-generated.h"
 #include "version.h"

--- a/main.c
+++ b/main.c
@@ -579,10 +579,10 @@ static void *tcmur_cmdproc_thread(void *arg)
 			if (tcmu_get_log_level() == TCMU_LOG_DEBUG_SCSI_CMD)
 				tcmu_cdb_debug_info(cmd);
 
-			if (tcmur_handler_is_passthrough_only(rhandler))
-				ret = tcmur_cmd_passthrough_handler(dev, cmd);
+			if (tcmulib_handler_is_passthrough_only(rhandler))
+				ret = tcmulib_passthrough_cmds(dev, cmd);
 			else
-				ret = tcmur_generic_handle_cmd(dev, cmd);
+				ret = tcmulib_handle_cmds(dev, cmd);
 
 			if (ret == TCMU_NOT_HANDLED)
 				tcmu_warn("Command 0x%x not supported\n", cmd->cdb[0]);
@@ -596,7 +596,7 @@ static void *tcmur_cmdproc_thread(void *arg)
 			 */
 			if (ret != TCMU_ASYNC_HANDLED) {
 				completed = 1;
-				tcmur_command_complete(dev, cmd, ret);
+				tcmulib_handle_cmd_complete(dev, cmd, ret);
 			}
 		}
 

--- a/main.c
+++ b/main.c
@@ -44,12 +44,12 @@
 #include "target_core_user_local.h"
 #include "darray.h"
 #include "tcmu-runner.h"
-#include "tcmur_aio.h"
 #include "tcmur_device.h"
 #include "tcmur_cmd_handler.h"
 #include "libtcmu.h"
 #include "tcmuhandler-generated.h"
 #include "version.h"
+#include "libtcmu_aio.h"
 #include "libtcmu_config.h"
 #include "libtcmu_log.h"
 

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -28,7 +28,7 @@
 #include "libtcmu.h"
 #include "libtcmu_log.h"
 #include "libtcmu_priv.h"
-#include "tcmur_aio.h"
+#include "libtcmu_aio.h"
 #include "tcmur_device.h"
 #include "tcmur_cmd_handler.h"
 #include "tcmu-runner.h"

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -17,7 +17,7 @@
 #ifndef __TCMUR_DEVICE_H
 #define __TCMUR_DEVICE_H
 
-#include "tcmur_aio.h"
+#include "libtcmu_aio.h"
 
 #define TCMUR_DEV_FORMATTING		0x01
 


### PR DESCRIPTION
1, Move alua/tcmur_aio/tcmur_cmd-handler to libtcmu library.
2, Rename tcmur_aio to libtcmu_aio
3, Rename tcmur_cmd_handler to libtcmu_cmd_handler
4, Update some helpers name to make the code tidy and more readable.

These are all preparing for adding .handle_cmd support for handlers.