### PR TITLE
Config fixes

### DIFF
--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -304,6 +304,9 @@ static void tcmu_parse_option(char **cur, const char *end)
 		if (*r == '"' || *r == '\'')
 			*r = '\0';
 
+		if (option->opt_str)
+			/* free if this is reconfig */
+			free(option->opt_str);
 		option->opt_str = strdup(s);
 		break;
 	default:

--- a/libtcmu_config.h
+++ b/libtcmu_config.h
@@ -20,6 +20,8 @@
 #include <stdbool.h>
 #include <pthread.h>
 
+#include "ccan/list/list.h"
+
 struct tcmu_config {
 	pthread_t thread_id;
 	char *path;
@@ -56,6 +58,8 @@ typedef enum {
 } tcmu_option_type;
 
 struct tcmu_conf_option {
+	struct list_node list;
+
 	char *key;
 	tcmu_option_type type;
 	union {

--- a/libtcmu_config.h
+++ b/libtcmu_config.h
@@ -70,5 +70,5 @@ struct tcmu_conf_option {
 };
 
 void tcmu_destroy_config(struct tcmu_config *cfg);
-struct tcmu_config * tcmu_setup_config(void);
+struct tcmu_config * tcmu_setup_config(const char *path);
 #endif /* __TCMU_CONFIG_H */

--- a/main.c
+++ b/main.c
@@ -830,7 +830,7 @@ int main(int argc, char **argv)
 	guint reg_id;
 	int ret;
 
-	tcmu_cfg = tcmu_setup_config();
+	tcmu_cfg = tcmu_setup_config(NULL);
 	if (!tcmu_cfg)
 		exit(1);
 


### PR DESCRIPTION
The patches fix the following bugs:

1. runner segfault during dynamic reconfig.

2. memory leak for string opts.

@lxbsz You know the config code best, so please review.