### PR TITLE
Runner: revert free internal handlers to fix a static memory leak wh…

### DIFF
--- a/main.c
+++ b/main.c
@@ -954,7 +954,6 @@ int main(int argc, char **argv)
 
 	tcmu_destroy_config(tcmu_cfg);
 	tcmu_destroy_log();
-	darray_free(handlers);
 
 	return 0;
 


### PR DESCRIPTION
This reverts

commit 17608b8c957f0433654705d5623dfa19a67497e6
Author: Matthias Gerstner <matthias.gerstner@suse.de>
Date:   Fri Jul 14 15:24:23 2017 +0200

    free internal handlers to fix a static memory leak when exiting

It was supposed to be dropped, becuase this patch

commit 00ea12ae54499be1c34a94661aa77946aa8de6ff
Merge: 94fc9a5 aaf121b
Author: mikechristie <mikenc@gmail.com>
Date:   Wed Jul 19 21:30:27 2017 -0500

    Merge pull request #201 from lxbsz/handlers_free

    tcmur: free useless darray type handlers memory.

already fixed it.

Signed-off-by: Mike Christie <mchristi@redhat.com>