### PR TITLE
cmake: add additional option -Wdeclaration-after-statement support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 2.8 FATAL_ERROR)
 project (tcmu-runner C)
 set(VERSION 1.2.0)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=c99")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wdeclaration-after-statement -std=c99")
 
 include(GNUInstallDirs)
 include(CheckIncludeFile)

--- a/api.c
+++ b/api.c
@@ -394,11 +394,11 @@ int tcmu_emulate_evpd_inquiry(
 	case 0x83: /* Device identification */
 	{
 		char data[512];
-		char *ptr;
-		size_t used = 0;
-		char *wwn;
-		size_t len;
+		char *ptr, *p, *wwn;
+		size_t len, used = 0;
 		uint16_t *tot_len = (uint16_t*) &data[2];
+		bool next;
+		int i;
 
 		memset(data, 0, sizeof(data));
 
@@ -442,10 +442,8 @@ int tcmu_emulate_evpd_inquiry(
 		 * WWN, but this is what the kernel does, and it's nice for our
 		 * values to match.
 		 */
-		char *p = wwn;
-		bool next = true;
-		int i = 7;
-		for ( ; *p && i < 20; p++) {
+		next = true;
+		for (p = wwn, i = 7; *p && i < 20; p++) {
 			uint8_t val;
 
 			if (!char_to_hex(&val, *p))

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -136,8 +136,10 @@ lookup_dev_by_name(struct tcmulib_context *ctx, char *dev_name, int *index)
 	*index = 0;
 
 	darray_foreach(dev_ptr, ctx->devices) {
+		size_t len;
+
 		dev = *dev_ptr;
-		size_t len = strnlen(dev->dev_name, sizeof(dev->dev_name));
+		len = strnlen(dev->dev_name, sizeof(dev->dev_name));
 
 		if (!strncmp(dev->dev_name, dev_name, len)) {
 			*index = i;

--- a/qcow.c
+++ b/qcow.c
@@ -1136,12 +1136,13 @@ static uint64_t get_cluster_offset(struct qcow_state *s, const uint64_t offset, 
 		l2_table_update(s, l2_table, l2_offset, l2_index, cluster_offset | s->cluster_copied);
 		s->set_refcount(s, cluster_offset, 1);
 	} else if (!(cluster_offset & s->cluster_copied) && allocate) {
-		tcmu_err("re-allocating shared cluster for writing\n");
-		/* refcount > 1 (the copied bit means refcount == 1)
-		 * need to make a new copy if this is for a write */
 		uint64_t old_offset = cluster_offset & s->cluster_mask;
 		// TODO what if this is compressed?
 		uint8_t *cow_buffer;
+
+		tcmu_err("re-allocating shared cluster for writing\n");
+		/* refcount > 1 (the copied bit means refcount == 1)
+		 * need to make a new copy if this is for a write */
 		if (!(cow_buffer = malloc(s->cluster_size)))
 			goto fail;
 		if (!(cluster_offset = qcow_cluster_alloc(s)))


### PR DESCRIPTION
Warn about C99 declaration after statement to make the code tidy and
more readable.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>