### PR TITLE
tcmu:fix the vpd00 inquiry response buffer length

### DIFF
--- a/api.c
+++ b/api.c
@@ -337,7 +337,7 @@ int tcmu_emulate_evpd_inquiry(
 	switch (cdb[2]) {
 	case 0x0: /* Supported VPD pages */
 	{
-		char data[9];
+		char data[16];
 
 		memset(data, 0, sizeof(data));
 


### PR DESCRIPTION
The current buffer length 9 is too small， add pagecode 0x00 has been 10，so the initiator sends the vpd00 command to return the last byte to a random value。Taking into account the future expansion modified to 16.

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>