### PR TITLE
libtcmu: fix cfgstring len

### DIFF
--- a/libtcmu.c
+++ b/libtcmu.c
@@ -545,7 +545,7 @@ static int is_uio(const struct dirent *dirent)
 {
 	int fd;
 	char *tmp_path;
-	char buf[256] = {'\0'};
+	char buf[CFGSTRING_MAX] = {'\0'};
 	ssize_t ret = 0;
 
 	if (strncmp(dirent->d_name, "uio", 3))
@@ -591,7 +591,7 @@ static int open_devices(struct tcmulib_context *ctx)
 
 	for (i = 0; i < num_devs; i++) {
 		char *tmp_path;
-		char buf[256] = {'\0'};
+		char buf[CFGSTRING_MAX] = {'\0'};
 		int fd;
 		int ret;
 

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -65,7 +65,7 @@ struct tcmu_device {
 	char dev_name[16]; /* e.g. "uio14" */
 	char tcm_hba_name[16]; /* e.g. "user_8" */
 	char tcm_dev_name[128]; /* e.g. "backup2" */
-	char cfgstring[256];
+	char cfgstring[CFGSTRING_MAX];
 
 	struct tcmulib_handler *handler;
 	struct tcmulib_context *ctx;

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -34,6 +34,8 @@ extern "C" {
 #include "libtcmu_common.h"
 #include "alua.h"
 
+#define CFGSTRING_MAX  (256 + 1 + 256 + PATH_MAX) /* glfs cfg ex: VOLNAME@HOSTNAME/PATH */
+
 typedef int (*rw_fn_t)(struct tcmu_device *, struct tcmulib_cmd *,
 		       struct iovec *, size_t, size_t, off_t);
 typedef int (*flush_fn_t)(struct tcmu_device *, struct tcmulib_cmd *);


### PR DESCRIPTION
cfgstring will look like,
test@192.168.124.208/block-store/c2d55250-9d9d-4965-bfa1-43ce1b3aa5fc (glfs)

The string can exceed 256 characters.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>