### PR TITLE
Mode sense

### DIFF
--- a/api.c
+++ b/api.c
@@ -740,34 +740,52 @@ int tcmu_emulate_read_capacity_16(
 	return SAM_STAT_GOOD;
 }
 
-int handle_rwrecovery_page(uint8_t *buf, size_t buf_len)
+static void copy_to_response_buf(uint8_t *to_buf, size_t to_len,
+				 uint8_t *from_buf, size_t from_len)
 {
-	if (buf_len < 12)
-		return -1;
+	if (!to_buf)
+		return;
+	/*
+	 * SPC 4r37: 4.3.5.6 Allocation length:
+	 *
+	 * The device server shall terminate transfers to the Data-In Buffer
+	 * when the number of bytes or blocks specified by the ALLOCATION
+	 * LENGTH field have been transferred or when all available data
+	 * have been transferred, whichever is less.
+	 */
+	memcpy(to_buf, from_buf, to_len > from_len ? from_len : to_len);
+}
 
+int handle_rwrecovery_page(uint8_t *ret_buf, size_t ret_buf_len)
+{
+	uint8_t buf[12];
+
+	memset(buf, 0, sizeof(buf));
 	buf[0] = 0x1;
 	buf[1] = 0xa;
 
+	copy_to_response_buf(ret_buf, ret_buf_len, buf, 12);
 	return 12;
 }
 
-int handle_cache_page(uint8_t *buf, size_t buf_len)
+int handle_cache_page(uint8_t *ret_buf, size_t ret_buf_len)
 {
-	if (buf_len < 20)
-		return -1;
+	uint8_t buf[20];
 
+	memset(buf, 0, sizeof(buf));
 	buf[0] = 0x8;
 	buf[1] = 0x12;
 	buf[2] = 0x4; // WCE=1
 
+	copy_to_response_buf(ret_buf, ret_buf_len, buf, 20);
 	return 20;
 }
 
-static int handle_control_page(uint8_t *buf, size_t buf_len)
+static int handle_control_page(uint8_t *ret_buf, size_t ret_buf_len)
 {
-	if (buf_len < 12)
-		return -1;
+	uint8_t buf[12];
 
+	memset(buf, 0, sizeof(buf));
 	buf[0] = 0x0a;
 	buf[1] = 0x0a;
 
@@ -814,11 +832,12 @@ static int handle_control_page(uint8_t *buf, size_t buf_len)
 	buf[8] = 0xff;
 	buf[9] = 0xff;
 
+	copy_to_response_buf(ret_buf, ret_buf_len, buf, 12);
 	return 12;
 }
 
 
-static struct {
+static struct mode_sense_handler {
 	uint8_t page;
 	uint8_t subpage;
 	int (*get)(uint8_t *buf, size_t buf_len);
@@ -827,6 +846,42 @@ static struct {
 	{0x8, 0, handle_cache_page},
 	{0xa, 0, handle_control_page},
 };
+
+static ssize_t handle_mode_sense(struct mode_sense_handler *handler,
+				 uint8_t **buf, size_t alloc_len,
+				 size_t *used_len, bool sense_ten)
+{
+	int ret;
+
+	ret = handler->get(*buf, alloc_len - *used_len);
+
+	if  (!sense_ten && (*used_len + ret >= 255))
+		return -EINVAL;
+
+	/*
+	 * SPC 4r37: 4.3.5.6 Allocation length:
+	 *
+	 * If the information being transferred to the Data-In Buffer includes
+	 * fields containing counts of the number of bytes in some or all of
+	 * the data (e.g., the PARAMETER DATA LENGTH field, the PAGE LENGTH
+	 * field, the DESCRIPTOR LENGTH field, the AVAILABLE DATA field),
+	 * then the contents of these fields shall not be altered to reflect
+	 * the truncation, if any, that results from an insufficient
+	 * ALLOCATION LENGTH value
+	 */
+	/*
+	 * Setup the buffer so to still loop over the handlers, but just
+	 * increment the used_len so we can return the
+	 * final value.
+	 */
+	if (*buf && (*used_len + ret >= alloc_len))
+		*buf = NULL;
+
+	*used_len += ret;
+	if (*buf)
+		*buf += ret;
+	return ret;
+}
 
 /*
  * Handle MODE_SENSE(6) and MODE_SENSE(10).
@@ -846,13 +901,23 @@ int tcmu_emulate_mode_sense(
 	int i;
 	int ret;
 	size_t used_len;
-	uint8_t buf[512];
-	bool got_sense = false;
+	uint8_t *buf;
+	uint8_t *orig_buf = NULL;
 
-	memset(buf, 0, sizeof(buf));
+	if (!alloc_len)
+		return SAM_STAT_GOOD;
 
 	/* Mode parameter header. Mode data length filled in at the end. */
 	used_len = sense_ten ? 8 : 4;
+	if (used_len > alloc_len)
+		goto fail;
+
+	buf = calloc(1, alloc_len);
+	if (!buf)
+		return tcmu_set_sense_data(sense, HARDWARE_ERROR,
+					   ASC_INTERNAL_TARGET_FAILURE, NULL);
+	orig_buf = buf;
+	buf += used_len;
 
 	/* Don't fill in device-specific parameter */
 	/* This helper fn doesn't support sw write protect (SWP) */
@@ -860,58 +925,47 @@ int tcmu_emulate_mode_sense(
 	/* Don't report block descriptors */
 
 	if (page_code == 0x3f) {
-		got_sense = true;
 		for (i = 0; i < ARRAY_SIZE(modesense_handlers); i++) {
-			ret = modesense_handlers[i].get(&buf[used_len], sizeof(buf) - used_len);
-			if (ret <= 0)
-				break;
-
-			if  (sense_ten && (used_len + ret >= 255))
-				break;
-
-			if (used_len + ret > alloc_len)
-				break;
-
-			used_len += ret;
+			ret = handle_mode_sense(&modesense_handlers[i],
+						&buf, alloc_len, &used_len,
+						sense_ten);
+			if (ret < 0)
+				goto free_buf;
 		}
-	}
-	else {
+	} else {
+		ret = 0;
+
 		for (i = 0; i < ARRAY_SIZE(modesense_handlers); i++) {
-			if (page_code == modesense_handlers[i].page
-			    && subpage_code == modesense_handlers[i].subpage) {
-				ret = modesense_handlers[i].get(&buf[used_len],
-								sizeof(buf) - used_len);
-				if (ret <= 0)
-					break;
-
-				if  (!sense_ten && (used_len + ret >= 255))
-					break;
-
-				if (used_len + ret > alloc_len)
-					break;
-
-				used_len += ret;
-				got_sense = true;
+			if (page_code == modesense_handlers[i].page &&
+			    subpage_code == modesense_handlers[i].subpage) {
+				ret = handle_mode_sense(&modesense_handlers[i],
+							&buf, alloc_len,
+							&used_len, sense_ten);
 				break;
 			}
 		}
+
+		if (ret <= 0)
+			goto free_buf;
 	}
 
-	if (!got_sense)
-		return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
-				    ASC_INVALID_FIELD_IN_CDB, NULL);
-
 	if (sense_ten) {
-		uint16_t *ptr = (uint16_t*) buf;
+		uint16_t *ptr = (uint16_t*) orig_buf;
 		*ptr = htobe16(used_len - 2);
 	}
 	else {
-		buf[0] = used_len - 1;
+		orig_buf[0] = used_len - 1;
 	}
 
-	tcmu_memcpy_into_iovec(iovec, iov_cnt, buf, sizeof(buf));
-
+	tcmu_memcpy_into_iovec(iovec, iov_cnt, orig_buf, alloc_len);
+	free(orig_buf);
 	return SAM_STAT_GOOD;
+
+free_buf:
+	free(orig_buf);
+fail:
+	return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
+				   ASC_INVALID_FIELD_IN_CDB, NULL);
 }
 
 /*

--- a/consumer.c
+++ b/consumer.c
@@ -103,11 +103,11 @@ static int foo_handle_cmd(
 		break;
 	case MODE_SENSE:
 	case MODE_SENSE_10:
-		return tcmu_emulate_mode_sense(cdb, iovec, iov_cnt, sense);
+		return tcmu_emulate_mode_sense(dev, cdb, iovec, iov_cnt, sense);
 		break;
 	case MODE_SELECT:
 	case MODE_SELECT_10:
-		return tcmu_emulate_mode_select(cdb, iovec, iov_cnt, sense);
+		return tcmu_emulate_mode_select(dev, cdb, iovec, iov_cnt, sense);
 		break;
 	case READ_6:
 	case READ_10:

--- a/file_example.c
+++ b/file_example.c
@@ -66,6 +66,8 @@ static int file_open(struct tcmu_device *dev)
 	}
 	config += 1; /* get past '/' */
 
+	tcmu_set_dev_write_cache_enabled(dev, 1);
+
 	state->fd = open(config, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
 	if (state->fd == -1) {
 		tcmu_err("could not open %s: %m\n", config);

--- a/glfs.c
+++ b/glfs.c
@@ -489,6 +489,7 @@ static int tcmu_glfs_open(struct tcmu_device *dev)
 		return -ENOMEM;
 
 	tcmu_set_dev_private(dev, gfsp);
+	tcmu_set_dev_write_cache_enabled(dev, 1);
 
 	config = tcmu_get_path(dev);
 	if (!config) {

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -763,6 +763,16 @@ uint32_t tcmu_get_dev_max_xfer_len(struct tcmu_device *dev)
 	return dev->max_xfer_len;
 }
 
+void tcmu_set_dev_write_cache_enabled(struct tcmu_device *dev, bool enabled)
+{
+	dev->write_cache_enabled = enabled;
+}
+
+bool tcmu_get_dev_write_cache_enabled(struct tcmu_device *dev)
+{
+	return dev->write_cache_enabled;
+}
+
 int tcmu_get_dev_fd(struct tcmu_device *dev)
 {
 	return dev->fd;

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -98,6 +98,8 @@ void tcmu_set_dev_block_size(struct tcmu_device *dev, uint32_t block_size);
 uint32_t tcmu_get_dev_block_size(struct tcmu_device *dev);
 void tcmu_set_dev_max_xfer_len(struct tcmu_device *dev, uint32_t len);
 uint32_t tcmu_get_dev_max_xfer_len(struct tcmu_device *dev);
+void tcmu_set_dev_write_cache_enabled(struct tcmu_device *dev, bool enabled);
+bool tcmu_get_dev_write_cache_enabled(struct tcmu_device *dev);
 struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev);
 struct tcmur_handler *tcmu_get_runner_handler(struct tcmu_device *dev);
 
@@ -128,8 +130,11 @@ int tcmu_emulate_read_capacity_10(uint64_t num_lbas, uint32_t block_size, uint8_
 				  struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
 int tcmu_emulate_read_capacity_16(uint64_t num_lbas, uint32_t block_size, uint8_t *cdb,
 				  struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
-int tcmu_emulate_mode_sense(uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
-int tcmu_emulate_mode_select(uint8_t *cdb, struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+int tcmu_emulate_mode_sense(struct tcmu_device *dev, uint8_t *cdb,
+			    struct iovec *iovec, size_t iov_cnt, uint8_t *sense);
+int tcmu_emulate_mode_select(struct tcmu_device *dev, uint8_t *cdb,
+			     struct iovec *iovec, size_t iov_cnt,
+			     uint8_t *sense);
 /* SCSI helpers */
 void tcmu_cdb_debug_info(const struct tcmulib_cmd *cmd);
 

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -61,6 +61,7 @@ struct tcmu_device {
 	uint64_t num_lbas;
 	uint32_t block_size;
 	uint32_t max_xfer_len;
+	unsigned int  write_cache_enabled:1;
 
 	char dev_name[16]; /* e.g. "uio14" */
 	char tcm_hba_name[16]; /* e.g. "user_8" */

--- a/qcow.c
+++ b/qcow.c
@@ -1405,7 +1405,12 @@ static int qcow_open(struct tcmu_device *dev)
 	tcmu_dbg("%s\n", tcmu_get_dev_cfgstring(dev));
 	tcmu_dbg("%s\n", config);
 
-	if (bdev_open(bdev, AT_FDCWD, config, O_RDWR) == -1)
+	/*
+	 * We do not implement flush, so set WCE=0 and do sync IO.
+	 */
+	tcmu_set_dev_write_cache_enabled(dev, 0);
+
+	if (bdev_open(bdev, AT_FDCWD, config, O_RDWR | O_SYNC) == -1)
 		goto err;
 	return 0;
 err:

--- a/rbd.c
+++ b/rbd.c
@@ -438,6 +438,8 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 	tcmu_set_dev_max_xfer_len(dev, image_info.obj_size /
 				  tcmu_get_dev_block_size(dev));
 
+	tcmu_set_dev_write_cache_enabled(dev, 0);
+
 	tcmu_dev_dbg(dev, "config %s, size %lld\n", tcmu_get_dev_cfgstring(dev),
 		     rbd_size);
 	free(dev_cfg_dup);

--- a/tcmu-synthesizer.c
+++ b/tcmu-synthesizer.c
@@ -64,11 +64,11 @@ static int syn_handle_cmd(struct tcmu_device *dev, uint8_t *cdb,
 		break;
 	case MODE_SENSE:
 	case MODE_SENSE_10:
-		return tcmu_emulate_mode_sense(cdb, iovec, iov_cnt, sense);
+		return tcmu_emulate_mode_sense(dev, cdb, iovec, iov_cnt, sense);
 		break;
 	case MODE_SELECT:
 	case MODE_SELECT_10:
-		return tcmu_emulate_mode_select(cdb, iovec, iov_cnt, sense);
+		return tcmu_emulate_mode_select(dev, cdb, iovec, iov_cnt, sense);
 		break;
 	case READ_6:
 	case READ_10:

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -1855,12 +1855,12 @@ static int handle_generic_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 							     iov_cnt, sense);
 	case MODE_SENSE:
 	case MODE_SENSE_10:
-		return tcmu_emulate_mode_sense(cdb, iovec, iov_cnt, sense);
+		return tcmu_emulate_mode_sense(dev, cdb, iovec, iov_cnt, sense);
 	case START_STOP:
 		return tcmu_emulate_start_stop(dev, cdb, sense);
 	case MODE_SELECT:
 	case MODE_SELECT_10:
-		return tcmu_emulate_mode_select(cdb, iovec, iov_cnt, sense);
+		return tcmu_emulate_mode_select(dev, cdb, iovec, iov_cnt, sense);
 	default:
 		return TCMU_NOT_HANDLED;
 	}


### PR DESCRIPTION
Fixes for mode sense and the cache page:

1. Patch 1 fixes several issues in the mode sense handling of the allocation length field and short buffers.
2. Patch 2 allows handlers to report different WCE values.
3. The rest of the patches covert handlers to #2 so they report a WCE value they support. 