### PR TITLE
tcmur: add handle_try_passthrough helper support

### DIFF
--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -1889,10 +1889,27 @@ static bool command_is_generic(struct tcmulib_cmd *cmd)
 	}
 }
 
+static int handle_try_passthrough(struct tcmu_device *dev,
+				  struct tcmulib_cmd *cmd)
+{
+	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
+	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);
+	int ret;
+
+	if (!rhandler->handle_cmd)
+		return TCMU_NOT_HANDLED;
+
+	track_aio_request_start(rdev);
+	ret = rhandler->handle_cmd(dev, cmd);
+	if (ret != TCMU_ASYNC_HANDLED)
+		track_aio_request_finish(rdev, NULL);
+
+	return ret;
+}
+
 int tcmur_generic_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 {
 	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);
-	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
 	int ret;
 
 	if (rdev->flags & TCMUR_DEV_FORMATTING && cmd->cdb[0] != INQUIRY)
@@ -1904,11 +1921,9 @@ int tcmur_generic_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	 * The handler want to handle some commands by itself,
 	 * try to passthrough it first
 	 */
-	if (rhandler->handle_cmd) {
-		ret = rhandler->handle_cmd(dev, cmd);
-		if (ret != TCMU_NOT_HANDLED)
-			return ret;
-	}
+	ret = handle_try_passthrough(dev, cmd);
+	if (ret != TCMU_NOT_HANDLED)
+		return ret;
 
 	/* Falls back to the runner's generic handle callout */
 	if (command_is_generic(cmd))


### PR DESCRIPTION
For the passthrough partially type handlers, likes the rbd handler,
will only passthrough some commands like XCOPY/CAW/WS..., the
.handle_cmd will be support in rbd's handler.

Sipmlify the code to let the developers wouldn't have to worry about
the handler is async or sync.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>