### PR TITLE
Remove COPIED flag from qcow refcount table entry

### DIFF
--- a/qcow.c
+++ b/qcow.c
@@ -958,7 +958,7 @@ static int qcow2_set_refcount(struct qcow_state *s, uint64_t cluster_offset, uin
 			tcmu_err("refblock allocation failure\n");
 			return -1;
 		}
-		rc_table_update(s, rc_index, refblock_offset | s->cluster_copied);
+		rc_table_update(s, rc_index, refblock_offset);
 		qcow2_set_refcount(s, refblock_offset, 1);
 	}
 


### PR DESCRIPTION
The QCOW2_OFLAG_COPIED flag was being set on refcount
table entries allocated by tcmu-runner.  This caused
refcount lookups to fail for all clusters whose corresponding
refcount block was allocated by tcmu-runner.

Reviewed-by: Chris Leech <cleech@redhat.com>
Signed-off-by: Bryant G. Ly <bryantly@linux.vnet.ibm.com>
Signed-off-by: Brad Warrum <bwarrum@us.ibm.com>