### PR TITLE
rbd: Add write same support

### DIFF
--- a/api.c
+++ b/api.c
@@ -637,7 +637,10 @@ finish_page83:
 		}
 
 		/* MAXIMUM WRITE SAME LENGTH */
-		val64 = htobe64(VPD_MAX_WRITE_SAME_LENGTH);
+		if (rhandler->unmap)
+			val64 = htobe64(max_xfer_length);
+		else
+			val64 = htobe64(VPD_MAX_WRITE_SAME_LENGTH);
 		memcpy(&data[36], &val64, 8);
 
 		tcmu_memcpy_into_iovec(iovec, iov_cnt, data, sizeof(data));

--- a/api.c
+++ b/api.c
@@ -703,12 +703,13 @@ finish_page83:
 		data[5] = 0x04;
 
 		/*
-		 * The logical block provisioning unmap (LBPU) field.
+		 * The logical block provisioning unmap (LBPU|LBPWS|LBPWS10) fields.
 		 *
-		 * This will enable the UNMAP command for the device server.
+		 * This will enable the UNMAP command for the device server and write
+		 * same(10|16) command.
 		 */
 		if (rhandler->unmap)
-			data[5] |= 0x80;
+			data[5] |= 0xe0;
 
 		tcmu_memcpy_into_iovec(iovec, iov_cnt, data, sizeof(data));
 		return SAM_STAT_GOOD;

--- a/main-syms.txt
+++ b/main-syms.txt
@@ -1,3 +1,4 @@
 {
 	tcmur_register_handler;
+	tcmur_handle_writesame;
 };

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -229,12 +229,14 @@ finish_err:
 
 static int handle_writesame_check(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 {
+	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
 	uint8_t *cdb = cmd->cdb;
 	uint8_t *sense = cmd->sense_buf;
 	uint32_t lba_cnt = tcmu_get_xfer_length(cdb);
 	uint32_t block_size = tcmu_get_dev_block_size(dev);
 	uint64_t start_lba = tcmu_get_lba(cdb);
 	uint64_t dev_last_lba = tcmu_get_dev_num_lbas(dev);
+	uint32_t max_ws_len;
 
 	if (cmd->iov_cnt != 1 || cmd->iovec->iov_len != block_size) {
 		tcmu_dev_err(dev, "Illegal Data-Out: iov_cnt %u length: %u\n",
@@ -261,9 +263,14 @@ static int handle_writesame_check(struct tcmu_device *dev, struct tcmulib_cmd *c
 	 * The MAXIMUM WRITE SAME LENGTH field in Block Limits VPD page (B0h)
 	 * limit the maximum block number for the WRITE SAME.
 	 */
-	if (lba_cnt > VPD_MAX_WRITE_SAME_LENGTH) {
+	if (rhandler->unmap)
+		max_ws_len = tcmu_get_dev_max_xfer_len(dev);
+	else
+		max_ws_len = VPD_MAX_WRITE_SAME_LENGTH;
+
+	if (lba_cnt > max_ws_len) {
 		tcmu_dev_err(dev, "blocks: %u exceeds MAXIMUM WRITE SAME LENGTH: %u\n",
-			     lba_cnt, VPD_MAX_WRITE_SAME_LENGTH);
+			     lba_cnt, max_ws_len);
 		return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
 					   ASC_INVALID_FIELD_IN_CDB,
 					   NULL);

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -158,7 +158,7 @@ struct write_same {
 	size_t iov_len;
 };
 
-static int write_same_work_fn(struct tcmu_device *dev,
+static int writesame_work_fn(struct tcmu_device *dev,
 				 struct tcmulib_cmd *cmd)
 {
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
@@ -178,7 +178,7 @@ static int write_same_work_fn(struct tcmu_device *dev,
 			       block_size * cur_lba);
 }
 
-static void handle_write_same_cbk(struct tcmu_device *dev,
+static void handle_writesame_cbk(struct tcmu_device *dev,
 				  struct tcmulib_cmd *cmd,
 				  int ret)
 {
@@ -210,7 +210,7 @@ static void handle_write_same_cbk(struct tcmu_device *dev,
 			     write_same->cur_lba, write_lbas);
 	}
 
-	rc = async_handle_cmd(dev, cmd, write_same_work_fn);
+	rc = async_handle_cmd(dev, cmd, writesame_work_fn);
 	if (rc != TCMU_ASYNC_HANDLED) {
 		tcmu_dev_err(dev, "Write same async handle cmd failure\n");
 		ret = tcmu_set_sense_data(sense, MEDIUM_ERROR,
@@ -227,7 +227,7 @@ finish_err:
 	aio_command_finish(dev, cmd, ret);
 }
 
-static int handle_write_same(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+static int handle_writesame_check(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 {
 	uint8_t *cdb = cmd->cdb;
 	uint8_t *sense = cmd->sense_buf;
@@ -235,10 +235,6 @@ static int handle_write_same(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	uint32_t block_size = tcmu_get_dev_block_size(dev);
 	uint64_t start_lba = tcmu_get_lba(cdb);
 	uint64_t dev_last_lba = tcmu_get_dev_num_lbas(dev);
-	uint64_t write_lbas;
-	size_t max_xfer_length, length = 1024 * 1024;
-	struct write_same *write_same;
-	int i;
 
 	if (cmd->iov_cnt != 1 || cmd->iovec->iov_len != block_size) {
 		tcmu_dev_err(dev, "Illegal Data-Out: iov_cnt %u length: %u\n",
@@ -288,15 +284,24 @@ static int handle_write_same(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	tcmu_dev_dbg(dev, "Start lba: %llu, number of lba:: %hu, last lba: %llu\n",
 		     start_lba, lba_cnt, start_lba + lba_cnt - 1);
 
-	/*
-	 * For now not support UNMAP bit and ANCHOR bit.
-	 */
-	if (cdb[1] & 0x10 || cdb[1] & 0x08) {
-		tcmu_dev_err(dev, "The ANCHOR or UNMAP bit is set not support!\n");
-		return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
-					   ASC_INVALID_FIELD_IN_CDB,
-					   NULL);
-	}
+	return 0;
+}
+
+static int handle_writesame(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+{
+	uint8_t *cdb = cmd->cdb;
+	uint8_t *sense = cmd->sense_buf;
+	uint32_t lba_cnt = tcmu_get_xfer_length(cdb);
+	uint32_t block_size = tcmu_get_dev_block_size(dev);
+	uint64_t start_lba = tcmu_get_lba(cdb);
+	uint64_t write_lbas;
+	size_t max_xfer_length, length = 1024 * 1024;
+	struct write_same *write_same;
+	int i, ret;
+
+	ret = handle_writesame_check(dev, cmd);
+	if (ret)
+		return ret;
 
 	write_same = calloc(1, sizeof(struct write_same));
 	if (!write_same) {
@@ -330,12 +335,44 @@ static int handle_write_same(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	write_same->iov_cnt = 1;
 	cmd->cmdstate = write_same;
 
-	cmd->done = handle_write_same_cbk;
+	cmd->done = handle_writesame_cbk;
 
 	tcmu_dev_dbg(dev, "First lba: %llu, write lbas: %llu\n",
 		     start_lba, write_lbas);
 
-	return async_handle_cmd(dev, cmd, write_same_work_fn);
+	return async_handle_cmd(dev, cmd, writesame_work_fn);
+}
+
+static int tcmur_writesame_work_fn(struct tcmu_device *dev,
+				 struct tcmulib_cmd *cmd)
+{
+	tcmur_writesame_fn_t write_same_fn = cmd->cmdstate;
+	uint32_t block_size = tcmu_get_dev_block_size(dev);
+	uint8_t *cdb = cmd->cdb;
+	uint64_t off = block_size * tcmu_get_lba(cdb);
+	uint32_t len = block_size * tcmu_get_xfer_length(cdb);
+
+	cmd->done = handle_generic_cbk;
+
+	/*
+	 * Write contents of the logical block data(from the Data-Out Buffer)
+	 * to each LBA in the specified LBA range.
+	 */
+	return write_same_fn(dev, cmd, off, len, cmd->iovec, cmd->iov_cnt);
+}
+
+int tcmur_handle_writesame(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+			   tcmur_writesame_fn_t write_same_fn)
+{
+	int ret;
+
+	ret = handle_writesame_check(dev, cmd);
+	if (ret)
+		return ret;
+
+	cmd->cmdstate = write_same_fn;
+
+	return async_handle_cmd(dev, cmd, tcmur_writesame_work_fn);
 }
 
 /* async write verify */
@@ -2060,7 +2097,7 @@ static int tcmur_cmd_handler(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		break;
 	case WRITE_SAME:
 	case WRITE_SAME_16:
-		ret = handle_write_same(dev, cmd);
+		ret = handle_writesame(dev, cmd);
 		break;
 	case FORMAT_UNIT:
 		ret = handle_format_unit(dev, cmd);

--- a/tcmur_cmd_handler.h
+++ b/tcmur_cmd_handler.h
@@ -27,5 +27,10 @@ int tcmur_cmd_passthrough_handler(struct tcmu_device *dev, struct tcmulib_cmd *c
 bool tcmur_handler_is_passthrough_only(struct tcmur_handler *rhandler);
 void tcmur_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 			    int ret);
+typedef int (*tcmur_writesame_fn_t)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+			   uint64_t off, uint64_t len, struct iovec *iov, size_t iov_cnt);
+int tcmur_handle_writesame(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+			   tcmur_writesame_fn_t write_same_fn);
+
 
 #endif /* __TCMUR_CMD_HANDLER_H */


### PR DESCRIPTION
1, rbd add write same support and with the UNMAP bit support.
2, write same emulator add UNMAP bit support.
3, limit the MAX WRITE SAME LENGTH to "hw_max_sectors" when both the unmap and write same are supported.
