### PR TITLE
api: VPD 0xB0 add UNMAP GRANULARITY ALIGNMENT support

### DIFF
--- a/api.c
+++ b/api.c
@@ -634,6 +634,13 @@ finish_page83:
 			/* OPTIMAL UNMAP GRANULARITY */
 			val32 = htobe32(max_xfer_length);
 			memcpy(&data[28], &val32, 4);
+
+			/* UNMAP GRANULARITY ALIGNMENT */
+			val32 = htobe32(max_xfer_length);
+			memcpy(&data[32], &val32, 4);
+
+			/* UGAVALID: An unmap granularity alignment valid bit */
+			data[32] |= 0x80;
 		}
 
 		/* MAXIMUM WRITE SAME LENGTH */


### PR DESCRIPTION
Here let assume hw_max_sectors == device's max discard sectors.

Till now we set the both OPTIMAL UNMAP GRANULARITY and GRANULARITY
ALIGNMENT to hw_max_sectors of the device.

The following example shows why we need the granularity alignment
in near feature:

If the unmap granularity == 64 and hw_max_sectors == 128. A request
that is submitted for 256 sectors 2...257 will be split in two: 2..129,
130..257. However, only 2 aligned blocks out of 3 are included in the
request, 128..191 may be left intact and not discarded. And here needs
one way to truncate to ensure good alignment to split into 2..127,
128..255, 256..257.

And for some case, maybe the initiators could use the alignment to
do the alignment just before submitting the request.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>