### PR TITLE
[RFC] libtcmu: do not install headers and drop libtcmu stable API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(tcmu
   )
 set_target_properties(tcmu
   PROPERTIES
-  SOVERSION "1"
+  SOVERSION "2"
   )
 target_include_directories(tcmu
   PUBLIC ${LIBNL_INCLUDE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,8 +256,6 @@ configure_file (
   )
 install(SCRIPT tcmu.conf_install.cmake)
 
-install(FILES libtcmu.h libtcmu_common.h tcmu-runner.h
-  DESTINATION include)
 install(FILES org.kernel.TCMUService1.service
   DESTINATION /usr/share/dbus-1/system-services)
 install(FILES tcmu-runner.conf DESTINATION /etc/dbus-1/system.d)


### PR DESCRIPTION
When libtcmu was created it was really early in the project and
missing lots of features. It is now difficult to maintain that API
and there may not be any users considering how many things
it was missing and we have not got any patches from non
tcmu-runner users in a long time.

The project will of course not change license and remain Apache
Version 2.0, so any one can just use the code in their own
project, but in future versions the stable libtcmu will not be
maintained.

If there are users, please speak up. It is a RFC patch, so I am open
to working something out. Are you using the netlink and uio ib functions,
but not the scsi and iovec ones in api.c?