### PR TITLE
rbd/write_same: make it compatible with lower version of librbd

### DIFF
--- a/rbd.c
+++ b/rbd.c
@@ -53,7 +53,7 @@
 /*
  * rbd_aio_writesame support was added in librbd 1.12.0
  */
-#if LIBRBD_VERSION_CODE >= LIBRBD_VERSION(1, 12, 0)
+#if LIBRBD_VERSION_CODE >= LIBRBD_VERSION(1, 12, 0) || LIBRBD_SUPPORTS_WRITESAME
 #define RBD_WRITE_SAME_SUPPORT
 #endif
 


### PR DESCRIPTION
More detail please see: https://github.com/ceph/ceph/pull/16583

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>