### PR TITLE
unmap: Align start lba and split large num blocks into optimal ones.

### DIFF
--- a/api.c
+++ b/api.c
@@ -570,6 +570,7 @@ finish_page83:
 	{
 		char data[64];
 		int max_xfer_length;
+		int opt_unmap_gran;
 		uint16_t val16;
 		uint32_t val32;
 		uint64_t val64;
@@ -622,7 +623,8 @@ finish_page83:
 			memcpy(&data[24], &val32, 4);
 
 			/* OPTIMAL UNMAP GRANULARITY */
-			val32 = htobe32(max_xfer_length);
+			opt_unmap_gran = tcmu_get_dev_opt_unmap_gran(dev);
+			val32 = htobe32(opt_unmap_gran);
 			memcpy(&data[28], &val32, 4);
 
 			/* UNMAP GRANULARITY ALIGNMENT */

--- a/api.c
+++ b/api.c
@@ -616,7 +616,7 @@ finish_page83:
 
 		if (rhandler->unmap) {
 			/* MAXIMUM UNMAP LBA COUNT */
-			val32 = htobe32(max_xfer_length);
+			val32 = htobe32(VPD_MAX_UNMAP_LBA_COUNT);
 			memcpy(&data[20], &val32, 4);
 
 			/* MAXIMUM UNMAP BLOCK DESCRIPTOR COUNT */

--- a/api.c
+++ b/api.c
@@ -310,7 +310,7 @@ int tcmu_emulate_std_inquiry(
 }
 
 /* This func from CCAN str/hex/hex.c. Public Domain */
-static bool char_to_hex(unsigned char *val, char c)
+bool char_to_hex(unsigned char *val, char c)
 {
 	if (c >= '0' && c <= '9') {
 		*val = c - '0';

--- a/api.c
+++ b/api.c
@@ -569,8 +569,9 @@ finish_page83:
 	case 0xb0: /* Block Limits */
 	{
 		char data[64];
-		int max_xfer_length;
-		int opt_unmap_gran;
+		uint32_t max_xfer_length;
+		uint32_t opt_unmap_gran;
+		uint32_t unmap_gran_align;
 		uint16_t val16;
 		uint32_t val32;
 		uint64_t val64;
@@ -628,7 +629,8 @@ finish_page83:
 			memcpy(&data[28], &val32, 4);
 
 			/* UNMAP GRANULARITY ALIGNMENT */
-			val32 = htobe32(max_xfer_length);
+			unmap_gran_align = tcmu_get_dev_unmap_gran_align(dev);
+			val32 = htobe32(unmap_gran_align);
 			memcpy(&data[32], &val32, 4);
 
 			/* UGAVALID: An unmap granularity alignment valid bit */

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -780,6 +780,21 @@ uint32_t tcmu_get_dev_opt_unmap_gran(struct tcmu_device *dev)
 	return dev->opt_unmap_gran;
 }
 
+/**
+ * tcmu_set/get_dev_unmap_gran_align - set/get device's unmap granularity alignment
+ * @dev: tcmu device
+ * @len: unmap granularity alignment length in block_size sectors
+ */
+void tcmu_set_dev_unmap_gran_align(struct tcmu_device *dev, uint32_t len)
+{
+	dev->unmap_gran_align = len;
+}
+
+uint32_t tcmu_get_dev_unmap_gran_align(struct tcmu_device *dev)
+{
+	return dev->unmap_gran_align;
+}
+
 void tcmu_set_dev_write_cache_enabled(struct tcmu_device *dev, bool enabled)
 {
 	dev->write_cache_enabled = enabled;

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -765,6 +765,21 @@ uint32_t tcmu_get_dev_max_xfer_len(struct tcmu_device *dev)
 	return dev->max_xfer_len;
 }
 
+/**
+ * tcmu_set/get_dev_opt_unmap_gran - set/get device's optimal unmap granularity
+ * @dev: tcmu device
+ * @len: optimal unmap granularity length in block_size sectors
+ */
+void tcmu_set_dev_opt_unmap_gran(struct tcmu_device *dev, uint32_t len)
+{
+	dev->opt_unmap_gran = len;
+}
+
+uint32_t tcmu_get_dev_opt_unmap_gran(struct tcmu_device *dev)
+{
+	return dev->opt_unmap_gran;
+}
+
 void tcmu_set_dev_write_cache_enabled(struct tcmu_device *dev, bool enabled)
 {
 	dev->write_cache_enabled = enabled;

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -100,6 +100,8 @@ void tcmu_set_dev_block_size(struct tcmu_device *dev, uint32_t block_size);
 uint32_t tcmu_get_dev_block_size(struct tcmu_device *dev);
 void tcmu_set_dev_max_xfer_len(struct tcmu_device *dev, uint32_t len);
 uint32_t tcmu_get_dev_max_xfer_len(struct tcmu_device *dev);
+void tcmu_set_dev_opt_unmap_gran(struct tcmu_device *dev, uint32_t len);
+uint32_t tcmu_get_dev_opt_unmap_gran(struct tcmu_device *dev);
 void tcmu_set_dev_write_cache_enabled(struct tcmu_device *dev, bool enabled);
 bool tcmu_get_dev_write_cache_enabled(struct tcmu_device *dev);
 struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -102,6 +102,8 @@ void tcmu_set_dev_max_xfer_len(struct tcmu_device *dev, uint32_t len);
 uint32_t tcmu_get_dev_max_xfer_len(struct tcmu_device *dev);
 void tcmu_set_dev_opt_unmap_gran(struct tcmu_device *dev, uint32_t len);
 uint32_t tcmu_get_dev_opt_unmap_gran(struct tcmu_device *dev);
+void tcmu_set_dev_unmap_gran_align(struct tcmu_device *dev, uint32_t len);
+uint32_t tcmu_get_dev_unmap_gran_align(struct tcmu_device *dev);
 void tcmu_set_dev_write_cache_enabled(struct tcmu_device *dev, bool enabled);
 bool tcmu_get_dev_write_cache_enabled(struct tcmu_device *dev);
 struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -39,6 +39,8 @@ struct tcmulib_cmd;
 #define CFGFS_ROOT "/sys/kernel/config/target"
 #define CFGFS_CORE CFGFS_ROOT"/core"
 
+/* Temporarily limit this to 32M */
+#define VPD_MAX_UNMAP_LBA_COUNT            (32 * 1024 * 1024)
 #define VPD_MAX_UNMAP_BLOCK_DESC_COUNT     0x04
 
 #define max(a, b) ({			\

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -128,6 +128,7 @@ void tcmu_zero_iovec(struct iovec *iovec, size_t iov_cnt);
 size_t tcmu_memcpy_into_iovec(struct iovec *iovec, size_t iov_cnt, void *src, size_t len);
 size_t tcmu_memcpy_from_iovec(void *dest, size_t len, struct iovec *iovec, size_t iov_cnt);
 size_t tcmu_iovec_length(struct iovec *iovec, size_t iov_cnt);
+bool char_to_hex(unsigned char *val, char c);
 
 /* Basic implementations of mandatory SCSI commands */
 int tcmu_set_sense_data(uint8_t *sense_buf, uint8_t key, uint16_t asc_ascq, uint32_t *info);

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -62,6 +62,7 @@ struct tcmu_device {
 	uint32_t block_size;
 	uint32_t max_xfer_len;
 	uint32_t opt_unmap_gran;
+	uint32_t unmap_gran_align;
 	unsigned int  write_cache_enabled:1;
 
 	char dev_name[16]; /* e.g. "uio14" */

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -61,6 +61,7 @@ struct tcmu_device {
 	uint64_t num_lbas;
 	uint32_t block_size;
 	uint32_t max_xfer_len;
+	uint32_t opt_unmap_gran;
 	unsigned int  write_cache_enabled:1;
 
 	char dev_name[16]; /* e.g. "uio14" */

--- a/main.c
+++ b/main.c
@@ -675,6 +675,7 @@ static int dev_added(struct tcmu_device *dev)
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
 	struct tcmur_device *rdev;
 	int32_t block_size, max_sectors;
+	uint32_t max_xfer_length;
 	int64_t dev_size;
 	int ret;
 
@@ -730,8 +731,13 @@ static int dev_added(struct tcmu_device *dev)
 	if (ret)
 		goto cleanup_aio_tracking;
 
-	/* Set the optimal unmap granularity to max xfer len */
-	tcmu_set_dev_opt_unmap_gran(dev, tcmu_get_dev_max_xfer_len(dev));
+	/*
+	 * Set the optimal unmap granularity and the alignment to
+	 * max xfer len
+	 */
+	max_xfer_length = tcmu_get_dev_max_xfer_len(dev);
+	tcmu_set_dev_opt_unmap_gran(dev, max_xfer_length);
+	tcmu_set_dev_unmap_gran_align(dev, max_xfer_length);
 
 	ret = tcmulib_start_cmdproc_thread(dev, tcmur_cmdproc_thread);
 	if (ret < 0)

--- a/main.c
+++ b/main.c
@@ -730,6 +730,9 @@ static int dev_added(struct tcmu_device *dev)
 	if (ret)
 		goto cleanup_aio_tracking;
 
+	/* Set the optimal unmap granularity to max xfer len */
+	tcmu_set_dev_opt_unmap_gran(dev, tcmu_get_dev_max_xfer_len(dev));
+
 	ret = tcmulib_start_cmdproc_thread(dev, tcmur_cmdproc_thread);
 	if (ret < 0)
 		goto close_dev;

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -702,7 +702,7 @@ static int xcopy_parse_segment_descs(uint8_t *seg_descs, struct xcopy *xcopy,
 
 static int xcopy_gen_naa_ieee(struct tcmu_device *udev, uint8_t *wwn)
 {
-	char *buf, *p, ch;
+	char *buf, *p;
 	bool next = true;
 	int ind = 0;
 
@@ -727,16 +727,9 @@ static int xcopy_gen_naa_ieee(struct tcmu_device *udev, uint8_t *wwn)
 	 * per device uniqeness.
 	 */
 	for (; *p && ind < XCOPY_NAA_IEEE_REGEX_LEN; p++) {
-		int val;
+		uint8_t val;
 
-		ch = *p;
-		if ((ch >= '0') && (ch <= '9'))
-			val = ch - '0';
-		else if ((ch >= 'a') && (ch <= 'f'))
-			val = ch - 'a' + 10;
-		else if ((ch >= 'A') && (ch <= 'F'))
-			val = ch - 'A' + 10;
-		else
+		if (!char_to_hex(&val, *p))
 			continue;
 
 		if (next) {


### PR DESCRIPTION
NOTE: here we always asumme the OPTIMAL UNMAP GRANULARITY equals to UNMAP GRANULARITY ALIGNMENT, if not in feature and the align and split algorithm should be changed.
    
The next will add the alignment support in Write Same UNMAP.