### PR TITLE
runner: make the usage visible without intalling tcmu.conf

### DIFF
--- a/main.c
+++ b/main.c
@@ -847,10 +847,6 @@ int main(int argc, char **argv)
 	guint reg_id;
 	int ret;
 
-	tcmu_cfg = tcmu_setup_config(NULL);
-	if (!tcmu_cfg)
-		exit(1);
-
 	while (1) {
 		int option_index = 0;
 		int c;
@@ -887,6 +883,10 @@ int main(int argc, char **argv)
 			goto destroy_config;
 		}
 	}
+
+	tcmu_cfg = tcmu_setup_config(NULL);
+	if (!tcmu_cfg)
+		exit(1);
 
 	if (tcmu_setup_log())
 		goto destroy_config;


### PR DESCRIPTION
When new user who are not very familiar about the tcmu-runner,
his/her mostly will print the usage of this like:

./tcmu-runner -h
Failed to open file '/etc/tcmu/tcmu.conf', No such file or directory

This patch will make the usage visible even without intalling
the tcmu.conf file.

Signed-off-by: Zhuoyu Zhang <zhangzhuoyu@cmss.chinamobile.com>
Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>