### PR TITLE
rbd: fix build error for rados_service_update_status()

### DIFF
--- a/rbd.c
+++ b/rbd.c
@@ -82,8 +82,10 @@ struct rbd_aio_cb {
 static void tcmu_rbd_service_status_update(struct tcmu_device *dev,
 					   bool has_lock)
 {
-	int ret;
+	struct tcmu_rbd_state *state = tcmu_get_dev_private(dev);
 	char *status_buf = NULL;
+	int ret;
+
 	ret = asprintf(&status_buf, "%s%c%s%c", "lock_owner", '\0',
 		       has_lock ? "true" : "false", '\0');
 	if (ret < 0) {


### PR DESCRIPTION
/data/tcmu-runner/rbd.c: In function ‘tcmu_rbd_service_status_update’:
/data/tcmu-runner/rbd.c:94:36: error: ‘state’ undeclared (first use in
		this function)
ret = rados_service_update_status(state->cluster, status_buf);
                                      ^

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>