### PR TITLE
rbd: Add the header explicitly when needed

### DIFF
--- a/rbd.c
+++ b/rbd.c
@@ -39,6 +39,7 @@
 #include "tcmur_device.h"
 
 #include <rbd/librbd.h>
+#include <rados/librados.h>
 
 /*
  * rbd_lock_acquire exclusive lock support was added in librbd 0.1.11


### PR DESCRIPTION
This will be very helpful when generating the cscope database, or
the cscope couldn't create the correct jump database for some function
like: rados_service_register().

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>