### PR TITLE
tcmur/unmap_split: reduce the unmap split logs output

### DIFF
--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -327,8 +327,17 @@ static int align_and_split_unmap(struct tcmu_device *dev,
 		desc->length = lbas * block_size;
 		ucmd->cmdstate = desc;
 
-		tcmu_dev_dbg(dev, "Split %d: start lba: %llu, end lba: %llu, lbas: %u\n",
-			     j++, lba, lba + lbas - 1, lbas);
+		/* The first one */
+		if (j++ == 0)
+			tcmu_dev_dbg(dev, "The first split: start lba: %llu, end lba: %llu, lbas: %u\n",
+				     lba, lba + lbas - 1, lbas);
+
+		/* The last one */
+		if (nlbas == lbas) {
+			tcmu_dev_dbg(dev, "The last split: start lba: %llu, end lba: %llu, lbas: %u\n",
+				     lba, lba + lbas - 1, lbas);
+			tcmu_dev_dbg(dev, "There are totally %d splits\n", j);
+		}
 
 		ret = async_handle_cmd(dev, ucmd, unmap_work_fn);
 		if (ret != TCMU_ASYNC_HANDLED) {


### PR DESCRIPTION
When the target device is large enough, there will be too many noisy
split logs output.

These days I am testing the runner in large scale, there are to much
noisy log of this.


Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>