### PR TITLE
alua: fix enabled_port NULL pointer dereference

### DIFF
--- a/alua.c
+++ b/alua.c
@@ -279,7 +279,7 @@ int tcmu_get_alua_grps(struct tcmu_device *dev,
 	struct alua_grp *group;
 	struct dirent **namelist;
 	char path[PATH_MAX];
-	int i, n, ret = 0;
+	int i, n;
 
 	snprintf(path, sizeof(path), CFGFS_CORE"/%s/%s/alua",
 		 dev->tcm_hba_name, dev->tcm_dev_name);
@@ -306,7 +306,7 @@ free_names:
 	for (i = 0; i < n; i++)
 		free(namelist[i]);
 	free(namelist);
-	return ret;
+	return 0;
 }
 
 /*

--- a/target.c
+++ b/target.c
@@ -288,7 +288,7 @@ int tcmu_add_dev_to_recovery_list(struct tcmu_device *dev)
 	struct list_head alua_list;
 	struct alua_grp *group;
 	struct tgt_port_grp *tpg;
-	struct tgt_port *port, *enabled_port;
+	struct tgt_port *port, *enabled_port = NULL;
 	int ret;
 
 	pthread_mutex_lock(&tpg_recovery_lock);


### PR DESCRIPTION
[ERROR] tcmu_rbd_handle_timedout_cmd:582 block12: Timing out cmd.
[ERROR] tcmu_notify_conn_lost:163 block12: Handler connection
lost (lock state 0)
Segmentation fault

From GDB:

Core was generated by `./tcmu-runner -d --handler-path .'.
Program terminated with signal 11, Segmentation fault.

gdb where
   /data/tcmu-runner/target.c:202
   at /data/tcmu-runner/target.c:330
   /data/tcmu-runner/tcmur_device.c:165
	cmd=0x2af5dc056de0) at /data/tcmu-runner/rbd.c:583
   (completion=0x2af5dc07c3d0, aio_cb=0x2af5dc07bdb0) at
   /data/tcmu-runner/rbd.c:699
[snap]

At the same time remove useless code.

Signed-off-by: Zhuoyu Zhang <zhangzhuoyu@cmss.chinamobile.com>
Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>