### PR TITLE
runner: scsi debug info convert to tcmu_dev_dbg_scsi_cmd()

### DIFF
--- a/api.c
+++ b/api.c
@@ -1175,7 +1175,7 @@ int tcmu_emulate_start_stop(struct tcmu_device *dev, uint8_t *cdb,
 #define CDB_TO_BUF_SIZE(bytes) ((bytes) * 3 + 1)
 #define CDB_FIX_BYTES 64 /* 64 bytes for default */
 #define CDB_FIX_SIZE CDB_TO_BUF_SIZE(CDB_FIX_BYTES)
-void tcmu_cdb_debug_info(const struct tcmulib_cmd *cmd)
+void tcmu_cdb_debug_info(struct tcmu_device *dev, const struct tcmulib_cmd *cmd)
 {
 	int i, n, bytes;
 	char fix[CDB_FIX_SIZE], *buf;
@@ -1186,7 +1186,7 @@ void tcmu_cdb_debug_info(const struct tcmulib_cmd *cmd)
 	if (bytes > CDB_FIX_SIZE) {
 		buf = malloc(CDB_TO_BUF_SIZE(bytes));
 		if (!buf) {
-			tcmu_err("out of memory\n");
+			tcmu_dev_err(dev, "out of memory\n");
 			return;
 		}
 	}
@@ -1196,7 +1196,7 @@ void tcmu_cdb_debug_info(const struct tcmulib_cmd *cmd)
 	}
 	sprintf(buf + n, "\n");
 
-	tcmu_dbg_scsi_cmd(buf);
+	tcmu_dev_dbg_scsi_cmd(dev, buf);
 
 	if (bytes > CDB_FIX_SIZE)
 		free(buf);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -146,7 +146,7 @@ int tcmu_emulate_mode_select(struct tcmu_device *dev, uint8_t *cdb,
 			     struct iovec *iovec, size_t iov_cnt,
 			     uint8_t *sense);
 /* SCSI helpers */
-void tcmu_cdb_debug_info(const struct tcmulib_cmd *cmd);
+void tcmu_cdb_debug_info(struct tcmu_device *dev, const struct tcmulib_cmd *cmd);
 
 #ifdef __cplusplus
 }

--- a/main.c
+++ b/main.c
@@ -639,7 +639,7 @@ static void *tcmur_cmdproc_thread(void *arg)
 
 		while ((cmd = tcmulib_get_next_command(dev)) != NULL) {
 			if (tcmu_get_log_level() == TCMU_LOG_DEBUG_SCSI_CMD)
-				tcmu_cdb_debug_info(cmd);
+				tcmu_cdb_debug_info(dev, cmd);
 
 			if (tcmur_handler_is_passthrough_only(rhandler))
 				ret = tcmur_cmd_passthrough_handler(dev, cmd);
@@ -647,7 +647,7 @@ static void *tcmur_cmdproc_thread(void *arg)
 				ret = tcmur_generic_handle_cmd(dev, cmd);
 
 			if (ret == TCMU_NOT_HANDLED)
-				tcmu_warn("Command 0x%x not supported\n", cmd->cdb[0]);
+				tcmu_dev_warn(dev, "Command 0x%x not supported\n", cmd->cdb[0]);
 
 			/*
 			 * command (processing) completion is called in the following


### PR DESCRIPTION
Make the code more easy to debug.
    
Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>
