### PR TITLE
tcmulib dbus registration changes

### DIFF
--- a/libtcmu.h
+++ b/libtcmu.h
@@ -77,6 +77,7 @@ struct tcmulib_handler {
 	void (*removed)(struct tcmu_device *dev);
 
 	void *hm_private; /* private ptr for handler module */
+	void *connection; /* private, dbus connection for this subtype */
 };
 
 /*

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -45,8 +45,6 @@ struct tcmulib_context {
 
 	struct nl_sock *nl_sock;
 
-	unsigned reg_count_down;
-
 	GDBusConnection *connection;
 };
 

--- a/tcmu-handler.xml
+++ b/tcmu-handler.xml
@@ -24,10 +24,5 @@ that the configstring is valid before the device has been created.
       <arg type="b" name="succeeded" direction="out"/>
       <arg type="s" name="message" direction="out"/>
     </method>
-    <method name="UnregisterHandler">
-      <arg type="s" name="subtype" direction="in"/>
-      <arg type="b" name="succeeded" direction="out"/>
-      <arg type="s" name="message" direction="out"/>
-    </method>
   </interface>
 </node>


### PR DESCRIPTION
Fixes issues with dbus registration of tcmulib handlers.
tcmu-runner can now handle tcmulib processes that are killed or release
the dbus name for a specific subtype.
tcmulib daemon processes can now handle situations where the tcmu-runner
service becomes unavailable.

Signed-off-by: Bryant G. Ly bryantly@linux.vnet.ibm.com
Signed-off-by: Brad Warrum <bwarrum@us.ibm.com>

Prior to this change, the TCMUService1.HandlerManager1 DBus interface exposed two methods - RegisterHandler and UnregisterHandler.  The UnregisterHandler method did not have a corresponding tcmulib function.  When a tcmulib process died without calling the UnregisterHandler method, tcmu-runner would continue watching the bus name for all subtypes registered by the tcmulib process (on_register_handler() in main.c).  When the tcmulib process restarted, tcmu-runner watched the same bus name again.  This caused all of the watch_name callbacks (on_handler_vanished, on_handler_appeared) to be called more than once for each corresponding dbus event.  This caused an assortment of problems - one of which caused tcmu-runner to segfault in glib due to a null pointer dereference with the following error messages after restarting the tcmulib daemon process 3 times in a row:
```
Aug 15 18:56:32 systemd[1]: Started LIO Userspace-passthrough daemon.
Aug 15 18:57:04 tcmu-runner[39324]: (process:39324): GLib-GIO-CRITICAL **: g_dbus_object_manager_server_unexport_unlocked: assertion 'g_variant_is_object_path (object_path)' failed
Aug 15 18:57:12 tcmu-runner[39324]: (process:39324): GLib-GIO-CRITICAL **: g_dbus_object_skeleton_new: assertion 'g_variant_is_object_path (object_path)' failed
Aug 15 18:57:12 tcmu-runner[39324]: (process:39324): GLib-GIO-CRITICAL **: g_dbus_object_skeleton_add_interface: assertion 'G_IS_DBUS_OBJECT_SKELETON (object)' failed
Aug 15 18:57:12 systemd[1]: tcmu-runner.service: Main process exited, code=dumped, status=11/SEGV
Aug 15 18:57:12 systemd[1]: tcmu-runner.service: Unit entered failed state.
Aug 15 18:57:12 systemd[1]: tcmu-runner.service: Failed with result 'core-dump'.
```
Additionally, tcmulib-register was incapable of handling situations where tcmu-runner was not running when the tcmulib process was started, or where tcmu-runner was restarted while the tcmulib process was running (causing the TCMUService name to vanish and reappear).  The result was that the subtypes for the tcmulib process would not reappear in targetcli until the tcmulib process was restarted.

This change drops the UnregisterHandler method from the HandlerManager DBus interface.  tcmu-runner now stops watching the DBus name for a tcmulib subtype when the name vanishes. The RegisterHandler call is now triggered every time the TCMUService name becomes available and a subtype bus name becomes owned by the tcmulib process.

I was unsure of whether or not this would require a version number change to HandlerManager1.  Since the UnregisterHandler method was never used, I assumed it was not necessary.  I'm also not entirely sure how to handle/report DBus errors during the registration process.