### PR TITLE
Fix alua

### DIFF
--- a/alua.c
+++ b/alua.c
@@ -416,6 +416,13 @@ int tcmu_emulate_report_tgt_port_grps(struct tcmu_device *dev,
 	return SAM_STAT_GOOD;
 }
 
+bool failover_is_supported(struct tcmu_device *dev)
+{
+	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
+
+	return !!rhandler->lock;
+}
+
 static void *alua_lock_thread_fn(void *arg)
 {
 	/* TODO: set UA based on bgly's patches */

--- a/alua.c
+++ b/alua.c
@@ -197,6 +197,11 @@ tcmu_get_alua_grp(struct tcmu_device *dev, const char *name)
 
 		group->tpgs = TPGS_ALUA_IMPLICIT;
 	} else if (!strcmp(str_val, "Implicit")) {
+		if (!failover_is_supported(dev)) {
+			tcmu_dev_err(dev, "device failover is not supported with the alua access type: Implicit\n");
+			goto free_str_val;
+		}
+
 		rdev->failover_type = TMCUR_DEV_FAILOVER_IMPLICIT;
 
 		group->tpgs = TPGS_ALUA_IMPLICIT;

--- a/alua.h
+++ b/alua.h
@@ -51,5 +51,6 @@ struct tgt_port *tcmu_get_enabled_port(struct list_head *);
 int tcmu_get_alua_grps(struct tcmu_device *, struct list_head *);
 void tcmu_release_alua_grps(struct list_head *);
 int alua_implicit_transition(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
+bool failover_is_supported(struct tcmu_device *dev);
 
 #endif

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -805,18 +805,33 @@ static int tcmur_writesame_work_fn(struct tcmu_device *dev,
 	return write_same_fn(dev, cmd, off, len, cmd->iovec, cmd->iov_cnt);
 }
 
-int tcmur_handle_writesame(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
-			   tcmur_writesame_fn_t write_same_fn)
+static inline int tcmur_alua_implicit_transition(struct tcmu_device *dev,
+					  struct tcmulib_cmd *cmd)
 {
 	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);
-	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
 	int ret;
+
+	if (!failover_is_supported(dev))
+		return 0;
 
 	if (rdev->failover_type == TMCUR_DEV_FAILOVER_IMPLICIT) {
 		ret = alua_implicit_transition(dev, cmd);
 		if (ret)
 			return ret;
 	}
+
+	return 0;
+}
+
+int tcmur_handle_writesame(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+			   tcmur_writesame_fn_t write_same_fn)
+{
+	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
+	int ret;
+
+	ret = tcmur_alua_implicit_transition(dev, cmd);
+	if (ret)
+		return ret;
 
 	ret = handle_writesame_check(dev, cmd);
 	if (ret)
@@ -2214,11 +2229,9 @@ static int tcmur_cmd_handler(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		goto untrack;
 	}
 
-	if (rdev->failover_type == TMCUR_DEV_FAILOVER_IMPLICIT) {
-		ret = alua_implicit_transition(dev, cmd);
-		if (ret)
-			goto untrack;
-	}
+	ret = tcmur_alua_implicit_transition(dev, cmd);
+	if (ret)
+		return ret;
 
 	switch(cdb[0]) {
 	case READ_6:


### PR DESCRIPTION
tcmur: fix rhandler->lock NULL pointer dereference

Using host libthread_db library "/lib64/libthread_db.so.1".
Core was generated by `./tcmu-runner -d --handler-path .'.
Program terminated with signal 11, Segmentation fault.
 (gdb) where
 #0  0x0000000000000000 in  ()
 #1  0x000000000040da3d in tcmu_acquire_dev_lock ()
 #2  0x000000000040f830 in alua_lock_thread_fn ()
 #3  0x00007fe59bca2dc5 in start_thread () at /lib64/libpthread.so.0
 #4  0x00007fe59b18f21d in clone () at /lib64/libc.so.6