### PR TITLE
tcmu:fix return data length of rtpg response data

### DIFF
--- a/alua.c
+++ b/alua.c
@@ -374,7 +374,7 @@ int tcmu_emulate_report_tgt_port_grps(struct tcmu_device *dev,
 		int next_off = off + 8 + (group->num_tgt_ports * 4);
 
 		if (next_off > alloc_len) {
-			ret_data_len += next_off;
+			ret_data_len += 8 + (group->num_tgt_ports * 4);
 			continue;
 		}
 


### PR DESCRIPTION
When the actual length is greater than the allocation length，the return data length filed of the rtpg response data is incorrect。

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>