### PR TITLE
tcmu:double free tgt_port in tcmu_get_alua_grp

### DIFF
--- a/alua.c
+++ b/alua.c
@@ -219,7 +219,7 @@ tcmu_get_alua_grp(struct tcmu_device *dev, const char *name)
 			port = tcmu_get_tgt_port(member);
 			if (!port) {
 				free(orig_str_val);
-				goto free_ports;
+				goto free_group;
 			}
 			port->grp = group;
 			group->num_tgt_ports++;
@@ -232,8 +232,6 @@ tcmu_get_alua_grp(struct tcmu_device *dev, const char *name)
 
 free_str_val:
 	free(str_val);
-free_ports:
-	tcmu_release_tgt_ports(group);
 free_group:
 	tcmu_free_alua_grp(group);
 	return NULL;


### PR DESCRIPTION
The function tcmu_release_tgt_ports is called by function tcmu_free_alua_grp，so there is no need for explicit call tcmu_release_tgt_ports in tcmu_get_alua_grp()。

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>