### PR TITLE
tcmu-runner:fix the exception return value for function tcmu_get_alua_grps()

### DIFF
--- a/alua.c
+++ b/alua.c
@@ -280,6 +280,7 @@ int tcmu_get_alua_grps(struct tcmu_device *dev,
 	struct dirent **namelist;
 	char path[PATH_MAX];
 	int i, n;
+	int ret = 0;
 
 	snprintf(path, sizeof(path), CFGFS_CORE"/%s/%s/alua",
 		 dev->tcm_hba_name, dev->tcm_dev_name);
@@ -294,10 +295,14 @@ int tcmu_get_alua_grps(struct tcmu_device *dev,
 			continue;
 
 		group = tcmu_get_alua_grp(dev, namelist[i]->d_name);
-		if (!group)
+		if (!group) {
+			tcmu_dev_err(dev, "Could not get alua group %s.\n", namelist[i]->d_name);
+			ret = -1;
 			goto free_groups;
+		}
 		list_add_tail(group_list, &group->entry);
 	}
+	ret = 0;
 	goto free_names;
 
 free_groups:
@@ -306,7 +311,7 @@ free_names:
 	for (i = 0; i < n; i++)
 		free(namelist[i]);
 	free(namelist);
-	return 0;
+	return ret;
 }
 
 /*


### PR DESCRIPTION
When the function tcmu_get_alua_grp() return NULL,the function tcmu_get_alua_grps should return exception value ,that can avoid the upper call function re-release grp list。

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>