### PR TITLE
tcmu-runner: rlimit openfile support via prarmeter

### DIFF
--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -152,7 +152,7 @@ log_internal(int pri, struct tcmu_device *dev, const char *funcname,
 	if (!fmt)
 		return;
 
-	if (!logbuf) {
+	if (!logbuf || !logbuf->finish_initialize) {
 		/* handle early log calls by config and deamon setup */
 		vfprintf(stderr, fmt, args);
 		return;
@@ -500,21 +500,21 @@ int tcmu_setup_log(void)
 
 	ret = create_syslog_output(TCMU_LOG_INFO, NULL);
 	if (ret < 0)
-		fprintf(stderr, "create syslog output error \n");
+		tcmu_err("create syslog output error \n");
 
 	ret = create_stdout_output(TCMU_LOG_DEBUG_SCSI_CMD);
 	if (ret < 0)
-		fprintf(stderr, "create stdout output error \n");
-
-	ret = tcmu_make_absolute_logfile(logfilepath, TCMU_LOG_FILENAME);
-	if (ret < 0) {
-		fprintf(stderr, "tcmu_make_absolute_logfile failed\n");
-		goto cleanup_log;
-	}
+		tcmu_err("create stdout output error \n");
 
 	ret = create_file_output(TCMU_LOG_DEBUG, logfilepath);
 	if (ret < 0)
-		fprintf(stderr, "create file output error \n");
+		tcmu_err("create file output error \n");
+
+	ret = tcmu_make_absolute_logfile(logfilepath, TCMU_LOG_FILENAME);
+	if (ret < 0) {
+		tcmu_err("tcmu_make_absolute_logfile failed\n");
+		goto cleanup_log;
+	}
 
 	ret = pthread_create(&logbuf->thread_id, NULL, log_thread_start, logbuf);
 	if (ret)

--- a/main.c
+++ b/main.c
@@ -948,8 +948,9 @@ int main(int argc, char **argv)
 			break;
 		case 'l':
 			if (strlen(optarg) > PATH_MAX - TCMU_LOG_FILENAME_MAX) {
-				fprintf(stderr, "--tcmu-log-dir='%s' cannot exceed %d characters\n",
+				tcmu_err("--tcmu-log-dir='%s' cannot exceed %d characters\n",
 				         optarg, PATH_MAX - TCMU_LOG_FILENAME_MAX);
+				goto free_opt;
 			}
 
 			if (!tcmu_logdir_create(optarg))
@@ -974,7 +975,7 @@ int main(int argc, char **argv)
 			tcmu_set_log_level(TCMU_CONF_LOG_DEBUG_SCSI_CMD);
 			break;
 		case 'V':
-			printf("tcmu-runner %s\n", TCMUR_VERSION);
+			tcmu_info("tcmu-runner %s\n", TCMUR_VERSION);
 			goto free_opt;
 		default:
 		case 'h':
@@ -983,12 +984,12 @@ int main(int argc, char **argv)
 		}
 	}
 
+	if (tcmu_setup_log())
+		goto destroy_config;
+
 	tcmu_cfg = tcmu_setup_config(NULL);
 	if (!tcmu_cfg)
 		goto free_opt;
-
-	if (tcmu_setup_log())
-		goto destroy_config;
 
 	tcmu_dbg("handler path: %s\n", handler_path);
 

--- a/main.c
+++ b/main.c
@@ -934,7 +934,7 @@ int main(int argc, char **argv)
 		int option_index = 0;
 		int c, nr_files;
 
-		c = getopt_long(argc, argv, "df:hlV",
+		c = getopt_long(argc, argv, "df:hl:V",
 				long_options, &option_index);
 		if (c == -1)
 			break;

--- a/main.c
+++ b/main.c
@@ -39,6 +39,8 @@
 #include <getopt.h>
 #include <poll.h>
 #include <scsi/scsi.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 
 #include <libkmod.h>
 #include <sys/utsname.h>
@@ -53,6 +55,9 @@
 #include "version.h"
 #include "libtcmu_config.h"
 #include "libtcmu_log.h"
+
+#define TCMUR_MIN_OPEN_FD 65536
+#define TCMUR_MAX_OPEN_FD 1048576
 
 static char *handler_path = DEFAULT_HANDLER_PATH;
 /* tcmu log dir path */
@@ -848,6 +853,63 @@ static bool tcmu_logdir_create(const char *path)
 	return TRUE;
 }
 
+static void tcmu_set_max_fd_limit(void)
+{
+	struct rlimit old_rlim, new_rlim;
+	bool set = 0;
+
+	if (getrlimit(RLIMIT_NOFILE, &old_rlim) == -1) {
+		tcmu_err("failed to get max open fd limit: %m\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (old_rlim.rlim_cur < TCMUR_MAX_OPEN_FD) {
+		new_rlim.rlim_cur = TCMUR_MAX_OPEN_FD;
+		if (old_rlim.rlim_max < TCMUR_MAX_OPEN_FD) {
+			new_rlim.rlim_max = TCMUR_MAX_OPEN_FD;
+		} else {
+			new_rlim.rlim_max = old_rlim.rlim_max;
+		}
+
+		set = 1;
+		if (setrlimit(RLIMIT_NOFILE, &new_rlim) == -1) {
+			tcmu_warn("failed to set max open fd to [soft: %lld hard: %lld] %m\n",
+				  (long long int)new_rlim.rlim_cur,
+				  (long long int)new_rlim.rlim_max);
+			set = 0;
+			if (old_rlim.rlim_cur < TCMUR_MIN_OPEN_FD ) {
+				new_rlim.rlim_cur = TCMUR_MIN_OPEN_FD;
+				if (old_rlim.rlim_max < TCMUR_MIN_OPEN_FD) {
+					new_rlim.rlim_max = TCMUR_MIN_OPEN_FD;
+				} else {
+					new_rlim.rlim_max = old_rlim.rlim_max;
+				}
+
+				set = 1;
+				if (setrlimit(RLIMIT_NOFILE, &new_rlim) == -1) {
+					tcmu_err("failed to set max open fd to [soft: %lld hard: %lld] %m\n",
+					         (long long int)new_rlim.rlim_cur,
+					         (long long int)new_rlim.rlim_max);
+
+					exit(EXIT_FAILURE);
+				}
+			}
+		}
+	}
+
+	if (set) {
+		tcmu_info("max open fd set to [soft: %lld hard: %lld]\n",
+	                  (long long int)new_rlim.rlim_cur,
+	                  (long long int)new_rlim.rlim_max);
+	} else {
+		tcmu_info("max open fd remain [soft: %lld hard: %lld]\n",
+		          (long long int)old_rlim.rlim_cur,
+		          (long long int)old_rlim.rlim_max);
+	}
+
+	return;
+}
+
 static void usage(void) {
 	printf("\nusage:\n");
 	printf("\ttcmu-runner [options]\n");
@@ -974,6 +1036,8 @@ int main(int argc, char **argv)
 		tcmu_err("tcmulib_initialize failed\n");
 		goto err_free_handlers;
 	}
+
+	tcmu_set_max_fd_limit();
 
 	loop = g_main_loop_new(NULL, FALSE);
 	if (g_unix_signal_add(SIGINT, sighandler, loop) <= 0 ||


### PR DESCRIPTION
@mikechristie @pkalever 

This is based on @pkalever's #178 PRs and then make this only configurable via the tcmu-runner's parameter.

1, @pkalever's #178 patch
2, make the rlimit openfile as one parameter
3, fix --tcmu-log-dir crash 
[EDIT]4, convert printf/fprintf to tcmu_xxx
Thanks,

Please review.