### PR TITLE
Logdir misc fix

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -37,9 +37,6 @@
 #define TCMU_GLFS_LOG_FILENAME "tcmu-runner-glfs.log"  /* MAX 32 CHAR */
 #define TCMU_GLFS_DEBUG_LEVEL  4
 
-/* tcmu log dir path */
-extern char *tcmu_log_dir;
-
 /* cache protection */
 pthread_mutex_t glfs_lock;
 

--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -156,8 +156,9 @@ static void tcmu_conf_set_options(struct tcmu_config *cfg, bool reloading)
 		/*
 		 * The priority of the logdir setting is:
 		 * 1, --tcmu_log_dir/-l LOG_DIR_PATH
-		 * 2, tcmu.conf
-		 * 3, default /var/log/
+		 * 2, export TCMU_LOGDIR="/var/log/mychoice/"
+		 * 3, tcmu.conf
+		 * 4, default /var/log/
 		 */
 		if (!tcmu_get_logdir())
 			tcmu_logdir_create(cfg->log_dir_path);

--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -143,12 +143,29 @@ do { \
 	} \
 } while (0);
 
-static void tcmu_conf_set_options(struct tcmu_config *cfg)
+static void tcmu_conf_set_options(struct tcmu_config *cfg, bool reloading)
 {
 	/* set log_level option */
 	TCMU_PARSE_CFG_INT(cfg, log_level);
 	TCMU_CONF_CHECK_LOG_LEVEL(log_level);
 	tcmu_set_log_level(cfg->log_level);
+
+	if (!reloading) {
+		/* set log_dir path option */
+		TCMU_PARSE_CFG_STR(cfg, log_dir_path);
+		/*
+		 * The priority of the logdir setting is:
+		 * 1, --tcmu_log_dir/-l LOG_DIR_PATH
+		 * 2, tcmu.conf
+		 * 3, default /var/log/
+		 */
+		if (!tcmu_get_logdir())
+			tcmu_logdir_create(cfg->log_dir_path);
+		else
+			tcmu_warn("The logdir option from the tcmu.conf will be ignored\n");
+	} else {
+		tcmu_warn("The logdir option is not supported by dynamic reloading for now!\n");
+	}
 
 	/* add your new config options */
 }
@@ -322,7 +339,7 @@ static void tcmu_parse_option(char **cur, const char *end)
 	}
 }
 
-static void tcmu_parse_options(struct tcmu_config *cfg, char *buf, int len)
+static void tcmu_parse_options(struct tcmu_config *cfg, char *buf, int len, bool reloading)
 {
 	char *cur = buf, *end = buf + len;
 
@@ -344,10 +361,10 @@ static void tcmu_parse_options(struct tcmu_config *cfg, char *buf, int len)
 	}
 
 	/* parse the options from tcmu_options[] to struct tcmu_config */
-	tcmu_conf_set_options(cfg);
+	tcmu_conf_set_options(cfg, reloading);
 }
 
-static int tcmu_load_config(struct tcmu_config *cfg)
+static int tcmu_load_config(struct tcmu_config *cfg, bool reloading)
 {
 	int ret = -1;
 	int fd, len;
@@ -372,7 +389,7 @@ static int tcmu_load_config(struct tcmu_config *cfg)
 
 	buf[len] = '\0';
 
-	tcmu_parse_options(cfg, buf, len);
+	tcmu_parse_options(cfg, buf, len, reloading);
 
 	ret = 0;
 free_buf:
@@ -431,7 +448,7 @@ static void *dyn_config_start(void *arg)
 
 			/* Try to reload the config file */
 			if (event->mask & IN_MODIFY || event->mask & IN_IGNORED)
-				tcmu_load_config(cfg);
+				tcmu_load_config(cfg, true);
 
 			p += sizeof(struct inotify_event) + event->len;
 		}
@@ -459,7 +476,7 @@ struct tcmu_config *tcmu_setup_config(const char *path)
 		goto free_cfg;
 	}
 
-	if (tcmu_load_config(cfg)) {
+	if (tcmu_load_config(cfg, false)) {
 		tcmu_err("Loading TCMU config failed!\n");
 		goto free_path;
 	}

--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -130,25 +130,13 @@ do { \
 	free(cfg->key); \
 } while (0);
 
-#define TCMU_CONF_CHECK_LOG_LEVEL(key) \
-do { \
-	struct tcmu_conf_option *option; \
-	option = tcmu_get_option(#key); \
-	if (!option) \
-		return; \
-	if (option->opt_int > TCMU_CONF_LOG_LEVEL_MAX) { \
-		option->opt_int = TCMU_CONF_LOG_LEVEL_MAX; \
-	} else if (option->opt_int < TCMU_CONF_LOG_LEVEL_MIN) { \
-		option->opt_int = TCMU_CONF_LOG_LEVEL_MIN; \
-	} \
-} while (0);
-
 static void tcmu_conf_set_options(struct tcmu_config *cfg, bool reloading)
 {
 	/* set log_level option */
 	TCMU_PARSE_CFG_INT(cfg, log_level);
-	TCMU_CONF_CHECK_LOG_LEVEL(log_level);
-	tcmu_set_log_level(cfg->log_level);
+	if (cfg->log_level) {
+		tcmu_set_log_level(cfg->log_level);
+	}
 
 	if (!reloading) {
 		/* set log_dir path option */

--- a/libtcmu_config.h
+++ b/libtcmu_config.h
@@ -28,6 +28,7 @@ struct tcmu_config {
 
 	bool is_dynamic;
 	int log_level;
+	char *log_dir_path;
 };
 
 /*

--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -88,6 +88,23 @@ unsigned int tcmu_get_log_level(void)
 	return tcmu_log_level;
 }
 
+bool tcmu_logdir_getenv(void)
+{
+	char *log_path;
+
+	if (tcmu_get_logdir())
+		return true;
+
+	log_path = getenv("TCMU_LOGDIR");
+	if (!log_path)
+		return true;
+
+	if (!tcmu_logdir_create(log_path))
+		return false;
+
+	return true;
+}
+
 void tcmu_set_log_level(int level)
 {
 	/* set the default log level to info */

--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -107,9 +107,10 @@ bool tcmu_logdir_getenv(void)
 
 void tcmu_set_log_level(int level)
 {
-	/* set the default log level to info */
-	if (!level)
-		level = TCMU_CONF_LOG_INFO;
+	if (level > TCMU_CONF_LOG_LEVEL_MAX)
+		level = TCMU_CONF_LOG_LEVEL_MAX;
+	else if (level < TCMU_CONF_LOG_LEVEL_MIN)
+		level = TCMU_CONF_LOG_LEVEL_MIN;
 
 	tcmu_log_level = to_syslog_level(level);
 }

--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -36,9 +36,6 @@
 #define LOG_MSG_LEN (LOG_ENTRY_LEN - 1) /* the length of the log message */
 #define LOG_ENTRYS (1024 * 32)
 
-/* tcmu log dir path */
-char *tcmu_log_dir = NULL;
-
 struct log_buf {
 	pthread_cond_t cond;
 	pthread_mutex_t lock;
@@ -62,6 +59,36 @@ struct log_output {
 	void *data;
 	tcmu_log_destination dest;
 };
+
+/* tcmu log dir path */
+static char *tcmu_log_dir = NULL;
+
+/* get the log dir of tcmu-runner */
+char *tcmu_get_log_dir(void)
+{
+	return tcmu_log_dir;
+}
+
+char *tcmu_alloc_and_set_log_dir(const char *log_dir)
+{
+	/*
+	 * Do nothing here and will use the /var/log/
+	 * as the default log dir
+	 */
+	if (!log_dir)
+		return NULL;
+
+	tcmu_log_dir = strdup(log_dir);
+	if (!tcmu_log_dir)
+		tcmu_err("Failed to copy log dir: %s\n", log_dir);
+
+	return tcmu_log_dir;
+}
+
+void tcmu_logdir_destroy(void)
+{
+	free(tcmu_log_dir);
+}
 
 static int tcmu_log_level = TCMU_LOG_INFO;
 static struct log_buf *logbuf = NULL;

--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <limits.h>
 
 #include "darray.h"
 #include "libtcmu_log.h"
@@ -469,6 +470,20 @@ static void *log_thread_start(void *arg)
 
 	pthread_cleanup_pop(1);
 	return NULL;
+}
+
+bool tcmu_logdir_check(const char *path)
+{
+	if (!path)
+		return false;
+
+	if (strlen(path) > PATH_MAX - TCMU_LOG_FILENAME_MAX) {
+		tcmu_err("--tcmu-log-dir='%s' cannot exceed %d characters\n",
+			 path, PATH_MAX - TCMU_LOG_FILENAME_MAX);
+		return false;
+	}
+
+	return true;
 }
 
 int tcmu_make_absolute_logfile(char *path, const char *filename)

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <stdbool.h>
 
 #define TCMU_IDENT "tcmu"
 #define TCMU_RUNNER "tcmu-runner"
@@ -60,6 +61,7 @@ void tcmu_info_message(struct tcmu_device *dev, const char *funcname, int linenr
 void tcmu_dbg_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
 void tcmu_dbg_scsi_cmd_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
 
+bool tcmu_logdir_check(const char *path);
 int tcmu_make_absolute_logfile(char *path, const char *filename);
 
 #define tcmu_dev_err(dev, ...)  {tcmu_err_message(dev, __func__, __LINE__, __VA_ARGS__);}

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -63,6 +63,7 @@ void tcmu_dbg_scsi_cmd_message(struct tcmu_device *dev, const char *funcname, in
 
 char *tcmu_get_logdir(void);
 void tcmu_logdir_destroy(void);
+bool tcmu_logdir_getenv(void);
 bool tcmu_logdir_create(const char *path);
 int tcmu_make_absolute_logfile(char *path, const char *filename);
 

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -50,10 +50,6 @@ typedef void (*log_close_fn_t) (void *data);
 
 struct tcmu_device;
 
-char *tcmu_get_log_dir(void);
-char *tcmu_alloc_and_set_log_dir(const char *log_dir);
-void tcmu_logdir_destroy(void);
-
 void tcmu_set_log_level(int level);
 unsigned int tcmu_get_log_level(void);
 int tcmu_setup_log(void);
@@ -65,8 +61,11 @@ void tcmu_info_message(struct tcmu_device *dev, const char *funcname, int linenr
 void tcmu_dbg_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
 void tcmu_dbg_scsi_cmd_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
 
-bool tcmu_logdir_check(const char *path);
+char *tcmu_get_logdir(void);
+void tcmu_logdir_destroy(void);
+bool tcmu_logdir_create(const char *path);
 int tcmu_make_absolute_logfile(char *path, const char *filename);
+
 
 #define tcmu_dev_err(dev, ...)  {tcmu_err_message(dev, __func__, __LINE__, __VA_ARGS__);}
 #define tcmu_dev_warn(dev, ...) {tcmu_warn_message(dev, __func__, __LINE__, __VA_ARGS__);}

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -50,6 +50,10 @@ typedef void (*log_close_fn_t) (void *data);
 
 struct tcmu_device;
 
+char *tcmu_get_log_dir(void);
+char *tcmu_alloc_and_set_log_dir(const char *log_dir);
+void tcmu_logdir_destroy(void);
+
 void tcmu_set_log_level(int level);
 unsigned int tcmu_get_log_level(void);
 int tcmu_setup_log(void);

--- a/main.c
+++ b/main.c
@@ -955,6 +955,9 @@ int main(int argc, char **argv)
 		}
 	}
 
+	if (!tcmu_logdir_getenv())
+		goto free_opt;
+
 	/*
 	 * The order of setting up config and logger is important, because
 	 * the log directory may be configured via the system config file

--- a/main.c
+++ b/main.c
@@ -829,29 +829,6 @@ static void dev_removed(struct tcmu_device *dev)
 	free(rdev);
 }
 
-static bool tcmu_logdir_create(const char *path)
-{
-	DIR* dir;
-
-	if (!tcmu_logdir_check(path))
-		return FALSE;
-
-	dir = opendir(path);
-	if (dir) {
-		closedir(dir);
-	} else if (errno == ENOENT) {
-		if (mkdir(path, 0755) == -1) {
-			tcmu_err("mkdir(%s) failed: %m\n", path);
-			return FALSE;
-		}
-	} else {
-		tcmu_err("opendir(%s) failed: %m\n", path);
-		return FALSE;
-	}
-
-	return !!tcmu_alloc_and_set_log_dir(path);
-}
-
 #define TCMUR_MIN_OPEN_FD 65536
 #define TCMUR_MAX_OPEN_FD 1048576
 static int tcmu_set_max_fd_limit(const int nr_files)

--- a/main.c
+++ b/main.c
@@ -947,11 +947,8 @@ int main(int argc, char **argv)
 			}
 			break;
 		case 'l':
-			if (strlen(optarg) > PATH_MAX - TCMU_LOG_FILENAME_MAX) {
-				tcmu_err("--tcmu-log-dir='%s' cannot exceed %d characters\n",
-				         optarg, PATH_MAX - TCMU_LOG_FILENAME_MAX);
+			if (!tcmu_logdir_check(optarg))
 				goto free_opt;
-			}
 
 			if (!tcmu_logdir_create(optarg))
 				goto free_opt;

--- a/main.c
+++ b/main.c
@@ -955,12 +955,17 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (tcmu_setup_log())
-		goto destroy_config;
-
+	/*
+	 * The order of setting up config and logger is important, because
+	 * the log directory may be configured via the system config file
+	 * which will be used in logger setting up.
+	 */
 	tcmu_cfg = tcmu_setup_config(NULL);
 	if (!tcmu_cfg)
 		goto free_opt;
+
+	if (tcmu_setup_log())
+		goto destroy_config;
 
 	tcmu_dbg("handler path: %s\n", handler_path);
 

--- a/tcmu.conf
+++ b/tcmu.conf
@@ -7,9 +7,9 @@
 #    3: INFO
 #    4: DEBUG
 #    5: DEBUG SCSI CMD
-# And the default logging level is 2, if you want to change the
+# And the default logging level is 3, if you want to change the
 # default level, uncomment it and set your level number:
-# log_level = 2
+# log_level = 3
 #
 # Logging Directory Path
 # The default logging Directory path is /var/log/, uncomment it

--- a/tcmu.conf
+++ b/tcmu.conf
@@ -10,3 +10,8 @@
 # And the default logging level is 2, if you want to change the
 # default level, uncomment it and set your level number:
 # log_level = 2
+#
+# Logging Directory Path
+# The default logging Directory path is /var/log/, uncomment it
+# and set your own path:
+# log_dir_path = "/var/log/"


### PR DESCRIPTION
1, add tcmu_logdir_check helper support 
2, fix and clean up the file output callout 
3, make tcmu_log_dir as static
4, move tcmu_logdir_create to log file and make it globally 
5,  fix error when making recursion directories 
6,  fix tcmu_conf_set_options 
7, make log dir configurable in tcmu.conf  