### PR TITLE
alua:fix untrack when implicit transition not success

### DIFF
--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -2231,7 +2231,7 @@ static int tcmur_cmd_handler(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 
 	ret = tcmur_alua_implicit_transition(dev, cmd);
 	if (ret)
-		return ret;
+		goto untrack;
 
 	switch(cdb[0]) {
 	case READ_6:


### PR DESCRIPTION
when client login, alua_implicit_transition always return with lock state 2
this patch just fix it.

Signed-off-by: Zhang Zhuoyu <zhangzhuoyu@cmss.chinamobile.com>