### PR TITLE
main: set TCMUR_DEV_FLAG_IS_OPEN on successfully added devices

### DIFF
--- a/main.c
+++ b/main.c
@@ -760,6 +760,7 @@ static int dev_added(struct tcmu_device *dev)
 	ret = rhandler->open(dev);
 	if (ret)
 		goto cleanup_aio_tracking;
+	rdev->flags |= TCMUR_DEV_FLAG_IS_OPEN;
 
 	/*
 	 * Set the optimal unmap granularity and the alignment to


### PR DESCRIPTION
Otherwise the device will not properly be closed when removed.