### PR TITLE
Fix file optical strict aliasing rules errors

### DIFF
--- a/be_byteshift.h
+++ b/be_byteshift.h
@@ -1,0 +1,48 @@
+#ifndef _TCMU_BE_BYTESHIFT_H
+#define _TCMU_BE_BYTESHIFT_H
+
+static inline void __put_unaligned_be32(uint32_t val, uint8_t *p)
+{
+	*p++ = val >> 24;
+	*p++ = val >> 16;
+	*p++ = val >> 8;
+	*p++ = val;
+}
+
+static inline void put_unaligned_be32(uint32_t val, void *p)
+{
+	__put_unaligned_be32(val, p);
+}
+
+static inline void __put_unaligned_be16(uint16_t val, uint8_t *p)
+{
+	*p++ = val >> 8;
+	*p++ = val;
+}
+
+static inline void put_unaligned_be16(uint16_t val, void *p)
+{
+	__put_unaligned_be16(val, p);
+}
+
+static inline uint16_t __get_unaligned_be16(const uint8_t *p)
+{
+	return p[0] << 8 | p[1];
+}
+
+static inline uint16_t get_unaligned_be16(const void *p)
+{
+	return __get_unaligned_be16(p);
+}
+
+static inline uint32_t __get_unaligned_be32(const uint8_t *p)
+{
+	return p[0] << 24 | p[1] << 16 | p[2] << 8 | p[3];
+}
+
+static inline uint16_t get_unaligned_be32(const void *p)
+{
+	return __get_unaligned_be32(p);
+}
+
+#endif

--- a/file_optical.c
+++ b/file_optical.c
@@ -1389,9 +1389,6 @@ static int fbo_emulate_format_unit(struct tcmu_device *dev, uint8_t *cdb,
 	struct fbo_state *state = tcmu_get_dev_private(dev);
 	pthread_t thr;
 	uint8_t param_list[12];
-	uint16_t temp;
-	uint32_t num_lbas;
-	uint16_t block_size;
 
 	// TBD: If we simulate start/stop, then fail if stopped
 	if (state->flags & FBO_READ_ONLY)
@@ -1420,8 +1417,7 @@ static int fbo_emulate_format_unit(struct tcmu_device *dev, uint8_t *cdb,
 					   ASC_INVALID_FIELD_IN_PARAMETER_LIST,
 					   NULL);
 
-	memcpy(&temp, &param_list[2], 2);
-	if (be16toh(temp) != 8)
+	if (get_unaligned_be16(&param_list[2]) != 8)
 		return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
 					   ASC_INVALID_FIELD_IN_PARAMETER_LIST,
 					   NULL);
@@ -1432,17 +1428,15 @@ static int fbo_emulate_format_unit(struct tcmu_device *dev, uint8_t *cdb,
 					   ASC_INVALID_FIELD_IN_PARAMETER_LIST,
 					   NULL);
 
-	memcpy(&num_lbas, &param_list[4], 4);
 	if ((cdb[1] & 0x08 || !(param_list[1] & 0x20)) &&
-	    be32toh(num_lbas) != state->num_lbas)
+	    get_unaligned_be16(&param_list[4])  != state->num_lbas)
 		/* Number of Blocks doesn't match */
 		return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
 					   ASC_INVALID_FIELD_IN_PARAMETER_LIST,
 					   NULL);
 
-	memcpy(&block_size, &param_list[10], 2);
 	if ((((uint32_t)param_list[9] << 16) +
-	     be16toh(block_size)) != state->block_size)
+	     get_unaligned_be16(&param_list[10])) != state->block_size)
 		/* Block Size is wrong */
 		return tcmu_set_sense_data(sense, ILLEGAL_REQUEST,
 					   ASC_INVALID_FIELD_IN_PARAMETER_LIST,


### PR DESCRIPTION
Fixes for compile errors when strict aliasing is on. Based on @bgly's patches in PR

https://github.com/open-iscsi/tcmu-runner/pull/273
