### PR TITLE
libtcmu: handle error when netlink family group is not found

### DIFF
--- a/libtcmu.c
+++ b/libtcmu.c
@@ -317,6 +317,10 @@ static struct nl_sock *setup_netlink(struct tcmulib_context *ctx)
 	}
 
 	ret = genl_ctrl_resolve_grp(sock, "TCM-USER", "config");
+	if (ret < 0) {
+		tcmu_err("couldn't resolve netlink family group, is target_core_user.ko loaded?\n");
+		goto err_unregister;
+	}
 
 	ret = nl_socket_add_membership(sock, ret);
 	if (ret < 0) {


### PR DESCRIPTION
genl_ctrl_resolve_grp returns a negative error code[1] when failed to
look up the family object. This patch handles the negative error code.

[1] http://www.infradead.org/~tgr/libnl/doc/api/group__genl__ctrl.html
>    Numeric group identifier or a negative error code. 