### PR TITLE
libtcmu: fix name check for nl commands

### DIFF
--- a/libtcmu.c
+++ b/libtcmu.c
@@ -136,12 +136,9 @@ lookup_dev_by_name(struct tcmulib_context *ctx, char *dev_name, int *index)
 	*index = 0;
 
 	darray_foreach(dev_ptr, ctx->devices) {
-		size_t len;
-
 		dev = *dev_ptr;
-		len = strnlen(dev->dev_name, sizeof(dev->dev_name));
 
-		if (!strncmp(dev->dev_name, dev_name, len)) {
+		if (!strcmp(dev->dev_name, dev_name)) {
 			*index = i;
 			return dev;
 		}


### PR DESCRIPTION
If dev->dev_name is uio1 but dev_name is uio10 we would
match it and return the dev for uio1.

This would cause problems for device removal because we would
leave the cmdproc running and accessing the uio device for
the device we wanted to shutdown (we shutdown the cmdproc
for uio1 instead of uio10). The kernel would then do
uio_unregister_device and free the uio device, but runner
could still be doing uio read/poll calls and cause crashes.