### PR TITLE
log_internal: append device subtype if available

### DIFF
--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -161,6 +161,7 @@ log_internal(int pri, struct tcmu_device *dev, const char *funcname,
 	unsigned int head;
 	char *msg;
 	int n;
+	struct tcmur_handler *rhandler;
 
 	if (pri > tcmu_log_level)
 		return;
@@ -179,8 +180,16 @@ log_internal(int pri, struct tcmu_device *dev, const char *funcname,
 	head = logbuf->head;
 	rb_set_pri(logbuf, head, pri);
 	msg = rb_get_msg(logbuf, head);
-	n = sprintf(msg, "%s:%d %s: ", funcname, linenr,
-		    dev ? dev->tcm_dev_name: "");
+
+	if (dev) {
+		rhandler = tcmu_get_runner_handler(dev);
+		n = sprintf(msg, "%s:%d %s/%s: ", funcname, linenr,
+		            rhandler ? rhandler->subtype: "",
+		            dev ? dev->tcm_dev_name: "");
+	} else {
+		n = sprintf(msg, "%s:%d: ", funcname, linenr);
+	}
+
 	vsnprintf(msg + n, LOG_MSG_LEN - n, fmt, args);
 
 	rb_update_head(logbuf);


### PR DESCRIPTION

example:
[DEBUG_SCSI_CMD] tcmu_cdb_debug_info:1061 glfs/abc: 35 0 0 0 0 0 0 0 0 0
[...]
[DEBUG_SCSI_CMD] tcmu_cdb_debug_info:1061 rbd/xyz: 12 0 0 0 24 0
[...]