### PR TITLE
Fix possible ring broken

### DIFF
--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -73,6 +73,7 @@ typedef void (*cmd_done_t)(struct tcmu_device *, struct tcmulib_cmd *, int);
 
 struct tcmulib_cmd {
 	uint16_t cmd_id;
+	struct tcmu_cmd_entry *entry;
 	uint8_t *cdb;
 	struct iovec *iovec;
 	size_t iov_cnt;

--- a/target_core_user_local.h
+++ b/target_core_user_local.h
@@ -69,6 +69,7 @@ struct tcmu_cmd_entry_hdr {
 	__u16 cmd_id;
 	__u8 kflags;
 #define TCMU_UFLAG_UNKNOWN_OP 0x1
+#define TCMU_UFLAG_COMPLETED  0x2
 	__u8 uflags;
 
 } __attribute__((packed));


### PR DESCRIPTION
   /* cmd_id could be different in async case */
   if (cmd->cmd_id != ent->hdr.cmd_id) {
          ent->hdr.cmd_id = cmd->cmd_id;
   }

There is no place changing and shouldn't change the cmd_id, or
this could cause the ring broken.

The old code changing the entry's cmd_id is to deal with the
async type IOs. Which will always update the first entry from the
tail, but the first entry from the tail maybe not belonged
to the current cmd, so it in order to simplify the code here just
used a trick.

If the runner has bug like handle the completion more than once,
the TCMU will find cmd_id in idr more than once too, the ring
should be flaged as broken.

Maybe there has other bugs could cause the ring broken too.
