### PR TITLE
systemd: setup the tcmu-runner in multi-user.target

### DIFF
--- a/tcmu-runner.service
+++ b/tcmu-runner.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=LIO Userspace-passthrough daemon
+After=network.target
 
 [Service]
 LimitNOFILE=1000000
@@ -7,3 +8,6 @@ Type=dbus
 BusName=org.kernel.TCMUService1
 KillMode=process
 ExecStart=/usr/bin/tcmu-runner
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This will enable the tcmu-runner service booted when the system
is up.

More detail please see:
https://www.freedesktop.org/software/systemd/man/bootup.html#

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>