### PR TITLE
Possible "duplicate struct iovec" fix

### DIFF
--- a/libtcmu.c
+++ b/libtcmu.c
@@ -17,7 +17,6 @@
 #include <memory.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 #include <unistd.h>
 #include <limits.h>
 #include <sys/mman.h>
@@ -28,12 +27,18 @@
 #include <dirent.h>
 #include <scsi/scsi.h>
 
+/*
+ * fcntl.h must be included *after* target_core_user_local.h is included, to
+ * avoid duplicate "struct iovec" compilation error, since the structure is
+ * defined differently in struct_iovec.h and linux/uio.h
+ */
+#include "target_core_user_local.h"
+#include <fcntl.h>
 
 #include <libnl3/netlink/genl/genl.h>
 #include <libnl3/netlink/genl/mngt.h>
 #include <libnl3/netlink/genl/ctrl.h>
 
-#include "target_core_user_local.h"
 #include "libtcmu.h"
 #include "libtcmu_log.h"
 #include "libtcmu_priv.h"

--- a/target_core_user_local.h
+++ b/target_core_user_local.h
@@ -4,7 +4,7 @@
 /* This header will be used by application too */
 
 #include <linux/types.h>
-#include <linux/uio.h>
+#include <sys/uio.h>
 
 #define TCMU_VERSION "2.0"
 


### PR DESCRIPTION
This pull request fixes an issue I raised where compilation of tcmu-runner under a 4.13 kernel leads to a compilation error message stating that "struct iovec" is multiply defined:

```
> [   88s] /usr/bin/cc -Dtcmu_static_EXPORTS -I/usr/include/libnl3 -I/usr/include/gio-unix-2.0 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include  -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -g -DNDEBUG -Wall -std=c99 -O2 -g -DNDEBUG -fPIC   -o CMakeFiles/tcmu_static.dir/libtcmu-register.c.o   -c /home/abuild/rpmbuild/BUILD/tcmu-runner-1.2.0/libtcmu-register.c
> [   88s] In file included from /usr/include/linux/target_core_user.h:7:0,
> [   88s]                  from /home/abuild/rpmbuild/BUILD/tcmu-runner-1.2.0/libtcmu.c:31:
> [   88s] /usr/include/linux/uio.h:16:8: error: redefinition of 'struct iovec'
> [   88s]  struct iovec
> [   88s]         ^~~~~
> [   88s] In file included from /usr/include/bits/fcntl-linux.h:38:0,
> [   88s]                  from /usr/include/bits/fcntl.h:61,
> [   88s]                  from /usr/include/fcntl.h:35,
> [   88s]                  from /home/abuild/rpmbuild/BUILD/tcmu-runner-1.2.0/libtcmu.c:20:
> [   88s] /usr/include/bits/types/struct_iovec.h:26:8: note: originally defined here
> [   88s]  struct iovec
> [   88s]         ^~~~~
> [   88s] make[2]: *** [CMakeFiles/tcmu_static.dir/build.make:97: CMakeFiles/tcmu_static.dir/libtcmu.c.o] Error 1
```
Please consider this fix, or comment on it if it's the wrong approach or would cause any functional change.