### PR TITLE
fix compiling error for gcc 5.3.1.

### DIFF
--- a/file_zbc.c
+++ b/file_zbc.c
@@ -442,7 +442,7 @@ static bool zbc_parse_config(const char *cfgstring, struct zbc_dev_config *cfg,
 err:
 	msg = "Invalid configuration string format";
 failed:
-	if (!msg || asprintf(reason, msg) == -1)
+	if (!msg || asprintf(reason, "%s", msg) == -1)
 		*reason = NULL;
 	return false;
 }


### PR DESCRIPTION
error: format not a string literal and no format arguments [-Werror=format-security]

Signed-off-by: zhenwei.pi <zhenwei.pi@youruncloud.com>