### PR TITLE
Fix ceph install deps to support [librbd1 librbd]-devel

### DIFF
--- a/install_dep.sh
+++ b/install_dep.sh
@@ -19,7 +19,9 @@ if [ y`uname`y = yLinuxy ]; then
 		# for glusterfs
 		$SUDO yum install -y glusterfs-api glusterfs-api-devel
 		# for ceph
-		$SUDO yum install -y librados2 librados2-devel librbd1 librbd-devel
+		$SUDO yum install -y librados2 librados2-devel librbd1
+		yum search librbd-devel | grep -q "N/S matched" && LIBRBD=librbd || LIBRBD=librbd1
+	        $DUDO yum install -y $LIBRBD-devel
 		;;
 	*)
 		echo "TODO: only fedora/rhel/centos are supported for now!"


### PR DESCRIPTION
https://download.ceph.com/rpm-jewel/rhel7/x86_64/
Before and Jewel Version, should be librbd1-devel.

https://download.ceph.com/rpm-kraken/el7/x86_64/
After and Kraken Version, should be librbd-devel.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>