### PR TITLE
README: update for supporting install_dep.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,15 @@ We encourage pull requests and issues tracking via Github, and the [target-devel
 
 ##### Building tcmu-runner
 
-1. Install cmake.
 1. Clone this repo.
-1. Install development packages for dependencies, usually ending with "-devel" or "-dev": libnl3, libglib2 (or glib2-devel on Fedora), libpthread, libdl, libkmod, libgfapi (Gluster), librbd1 (Ceph), zlib.
-1. Type `cmake .`.
+1. Type `./install_dep.sh` to install development packages for dependencies, or you can do it manually:
+   * *Note:* Install cmake and other packages which usually ending with "-devel" or "-dev": libnl3, libglib2 (or glib2-devel on Fedora), libpthread, libdl, libkmod, libgfapi (Gluster), librbd1 (Ceph), zlib.
+1. Type `cd tcmu-runner/`
+1. Type `cmake .`
    * *Note:* tcmu-runner can be compiled without the Gluster or qcow handlers using the `-Dwith-glfs=false` and `-Dwith-qcow=false` cmake parameters respectively.
-   * *Note:*  If using systemd, `-DSUPPORT_SYSTEMD=ON -DCMAKE_INSTALL_PREFIX=/usr` should be passed to cmake, so files are installed to the correct location.
-1. Type `make`.
-1. Type `make install`.
+   * *Note:* If using systemd, `-DSUPPORT_SYSTEMD=ON -DCMAKE_INSTALL_PREFIX=/usr` should be passed to cmake, so files are installed to the correct location.
+1. Type `make`
+1. Type `make install`
 
 
 ##### Running tcmu-runner


### PR DESCRIPTION
remove '.' after `cmake .`, which will be looks like `cmake ..` and will be confusing.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>