### PR TITLE
file_zbc: Do not implicitly open conventional zones

### DIFF
--- a/file_zbc.c
+++ b/file_zbc.c
@@ -2074,7 +2074,7 @@ static int zbc_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	}
 
 	/* If the zone is not open, implicitly open it */
-	if (!zbc_zone_is_open(zone)) {
+	if (zbc_zone_seq(zone) && !zbc_zone_is_open(zone)) {
 
 		/* Too many explicit open ? */
 		if (zdev->nr_exp_open >= zdev->nr_open_zones)


### PR DESCRIPTION
Writes to conventional zones must not change the zone condition to
implicitly opened. Before calling __zbc_open_zone(), make sure that the
write target is a sequential zone.

Reported-by: Masato Suzuki <masato.suzuki@wdc.com>
Signed-off-by: Damien Le Moal <damien.lemoal@wdc.com>