### PR TITLE
rbd: new optional for specifying location of Ceph config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ Created user-backed storage object rbd0 size 1073741824.
 
 Note that the cfgstring is handler specific. The format is:
 
-- **rbd**: /pool_name/image_name[;osd_op_timeout=N]  
+- **rbd**: /pool_name/image_name[;osd_op_timeout=N;conf=N]
 (osd_op_timeout is optional and N is in seconds)
+(conf is optional and N is the path to the conf file)
 - **qcow**: /path_to_file
 - **glfs**: /volume@hostname/filename
 - **file**: /path_to_file

--- a/rbd.c
+++ b/rbd.c
@@ -277,7 +277,7 @@ static int tcmu_rbd_image_open(struct tcmu_device *dev)
 	if (ret < 0) {
 		tcmu_dev_err(dev, "Could not connect to cluster. (Err %d)\n",
 			     ret);
-		goto set_cluster_null;
+		goto rados_shutdown;
 	}
 
 	ret = tcmu_rbd_service_register(dev);
@@ -305,7 +305,6 @@ rados_destroy:
 	state->io_ctx = NULL;
 rados_shutdown:
 	rados_shutdown(state->cluster);
-set_cluster_null:
 	state->cluster = NULL;
 	return ret;
 }


### PR DESCRIPTION
A custom Ceph config file can now be specified via a
"conf=/path/to/ceph.conf" optional within the cfgstring.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>