### PR TITLE
runner: zero default unmap granularity alignment

### DIFF
--- a/main.c
+++ b/main.c
@@ -797,12 +797,12 @@ static int dev_added(struct tcmu_device *dev)
 	rdev->flags |= TCMUR_DEV_FLAG_IS_OPEN;
 
 	/*
-	 * Set the optimal unmap granularity and the alignment to
-	 * max xfer len
+	 * Set the optimal unmap granularity to max xfer len. Optimal unmap
+	 * alignment starts at the begining of the device.
 	 */
 	max_xfer_length = tcmu_get_dev_max_xfer_len(dev);
 	tcmu_set_dev_opt_unmap_gran(dev, max_xfer_length);
-	tcmu_set_dev_unmap_gran_align(dev, max_xfer_length);
+	tcmu_set_dev_unmap_gran_align(dev, 0);
 
 	ret = tcmulib_start_cmdproc_thread(dev, tcmur_cmdproc_thread);
 	if (ret < 0)


### PR DESCRIPTION
The unmap granularity alignment is advertised to initiators via the
Block Limits INQUIRY VPD, which is specified as follows (sbc3r25):

  The UNMAP GRANULARITY ALIGNMENT field indicates the LBA of the first
  logical block to which the OPTIMAL UNMAP GRANULARITY field applies.
  The unmap granularity alignment is used to calculate an optimal unmap
  request starting LBA as follows:
  optimal unmap request starting LBA = (n × optimal unmap granularity)
                                       + unmap granularity alignment

Using a default unmap granularity alignment of max_xfer_length, which
is currently the case, means that the optimal unmap request starting LBA
is incorrectly staggered.

Signed-off-by: David Disseldorp <ddiss@suse.de>