### PR TITLE
rbd: don't override the user requested max sectors

### DIFF
--- a/rbd.c
+++ b/rbd.c
@@ -769,8 +769,6 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 		tcmu_dev_err(dev, "Could not stat image.\n");
 		goto stop_image;
 	}
-	tcmu_set_dev_max_xfer_len(dev, image_info.obj_size /
-				  tcmu_get_dev_block_size(dev));
 
 	tcmu_set_dev_write_cache_enabled(dev, 0);
 


### PR DESCRIPTION
At the ceph/rbd side object sized IOs are best, but for iSCSI
it is normally going to be too large. In newer linux kernels
the initiator will try to size IOs based on the optimal
size vpd info, and so with the default object size we are
getting 4MB IOs. Even with 10 gig ethernet we can see latencies
in the 1000s of ms and there are no improvements in throughput
with these larger IOs.

This patch just lets the user configure the IO size with the
hw_max_sectors setting.