### PR TITLE
fix restarts from unclean shutdowns

### DIFF
--- a/configfs.c
+++ b/configfs.c
@@ -228,3 +228,13 @@ int tcmu_set_cfgfs_ul(const char *path, unsigned long val)
 	sprintf(buf, "%lu", val);
 	return tcmu_set_cfgfs_str(path, buf, strlen(buf) + 1);
 }
+
+int tcmu_exec_cfgfs_dev_action(struct tcmu_device *dev, const char *name,
+			       unsigned long val)
+{
+	char path[PATH_MAX];
+
+	snprintf(path, sizeof(path), CFGFS_CORE"/%s/%s/action/%s",
+		 dev->tcm_hba_name, dev->tcm_dev_name, name);
+	return tcmu_set_cfgfs_ul(path, val);
+}

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -588,7 +588,7 @@ static void close_devices(struct tcmulib_context *ctx)
 	struct tcmu_device *dev;
 	char *cfgstring = "";
 
-	darray_foreach(dev_ptr, ctx->devices) {
+	darray_foreach_reverse(dev_ptr, ctx->devices) {
 		dev = *dev_ptr;
 		remove_device(ctx, dev->dev_name, cfgstring, true);
 	}

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -1077,13 +1077,3 @@ void tcmulib_processing_complete(struct tcmu_device *dev)
 		tcmu_err("failed to write device /dev/%s, %d\n",
 			 dev->dev_name, errno);
 }
-
-void _cleanup_mutex_lock(void *arg)
-{
-	pthread_mutex_unlock(arg);
-}
-
-void _cleanup_spin_lock(void *arg)
-{
-	pthread_spin_unlock(arg);
-}

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -132,16 +132,6 @@ void tcmulib_processing_complete(struct tcmu_device *dev);
 /* Clean up loose ends when exiting */
 void tcmulib_close(struct tcmulib_context *ctx);
 
-/* kick start command processing thread */
-int tcmulib_start_cmdproc_thread(struct tcmu_device *dev,
-				 void *(*thread_fn)(void *));
-
-/* cleanup command processing thread for a given device */
-void tcmulib_cleanup_cmdproc_thread(struct tcmu_device *dev);
-
-/* cleanup all (devices) command processing threads */
-void tcmulib_cleanup_all_cmdproc_threads();
-
 #ifdef __cplusplus
 }
 #endif

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -112,6 +112,8 @@ void tcmu_set_dev_solid_state_media(struct tcmu_device *dev, bool solid_state);
 bool tcmu_get_dev_solid_state_media(struct tcmu_device *dev);
 struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev);
 struct tcmur_handler *tcmu_get_runner_handler(struct tcmu_device *dev);
+void tcmu_block_device(struct tcmu_device *dev);
+void tcmu_unblock_device(struct tcmu_device *dev);
 
 /* Helper routines for processing commands */
 char *tcmu_get_cfgfs_str(const char *path);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -119,6 +119,8 @@ int tcmu_set_cfgfs_str(const char *path, const char *val, int val_len);
 int tcmu_get_cfgfs_int(const char *path);
 int tcmu_set_cfgfs_ul(const char *path, unsigned long val);
 int tcmu_get_attribute(struct tcmu_device *dev, const char *name);
+int tcmu_exec_cfgfs_dev_action(struct tcmu_device *dev, const char *name,
+			       unsigned long val);
 long long tcmu_get_device_size(struct tcmu_device *dev);
 char *tcmu_get_wwn(struct tcmu_device *dev);
 int tcmu_get_cdb_length(uint8_t *cdb);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -114,6 +114,7 @@ struct tcmulib_handler *tcmu_get_dev_handler(struct tcmu_device *dev);
 struct tcmur_handler *tcmu_get_runner_handler(struct tcmu_device *dev);
 void tcmu_block_device(struct tcmu_device *dev);
 void tcmu_unblock_device(struct tcmu_device *dev);
+void tcmu_flush_device(struct tcmu_device *dev);
 
 /* Helper routines for processing commands */
 char *tcmu_get_cfgfs_str(const char *path);

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -76,11 +76,4 @@ struct tcmu_device {
 	void *hm_private; /* private ptr for handler module */
 };
 
-/* internal (private) helpers */
-
-/* pthread cleanup handler: unlock a mutex */
-void _cleanup_mutex_lock(void *);
-/* pthread cleanup handler: unlock a spinlock */
-void _cleanup_spin_lock(void *);
-
 #endif

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -76,19 +76,11 @@ struct tcmu_device {
 	void *hm_private; /* private ptr for handler module */
 };
 
-struct tcmu_thread {
-	pthread_t thread_id;
-	struct tcmu_device *dev;
-};
-
 /* internal (private) helpers */
 
 /* pthread cleanup handler: unlock a mutex */
 void _cleanup_mutex_lock(void *);
 /* pthread cleanup handler: unlock a spinlock */
 void _cleanup_spin_lock(void *);
-
-/* cancel (+join) a thread */
-void cancel_thread(pthread_t);
 
 #endif

--- a/main-syms.txt
+++ b/main-syms.txt
@@ -4,4 +4,5 @@
 	tcmur_handle_writesame;
 	tcmu_notify_lock_lost;
 	tcmu_notify_conn_lost;
+	tcmu_cancel_thread;
 };

--- a/main.c
+++ b/main.c
@@ -190,12 +190,6 @@ static int open_handlers(void)
 
 static gboolean sighandler(gpointer user_data)
 {
-	/*
-	 * FIXME: this is broken if IO is running in runner when called.
-	 * IO could be running in the handler or runner and we could free
-	 * resources while in use.
-	 */
-	tcmulib_cleanup_all_cmdproc_threads();
 	g_main_loop_quit((GMainLoop*)user_data);
 
 	return G_SOURCE_CONTINUE;
@@ -872,6 +866,8 @@ static void dev_removed(struct tcmu_device *dev)
 		tcmu_err("could not cleanup mailbox lock %d\n", ret);
 
 	free(rdev);
+
+	tcmu_dev_dbg(dev, "removed from tcmu-runner\n");
 }
 
 #define TCMUR_MIN_OPEN_FD 65536

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -151,6 +151,11 @@ struct tcmur_handler {
 int tcmur_register_handler(struct tcmur_handler *handler);
 bool tcmur_unregister_handler(struct tcmur_handler *handler);
 
+/*
+ * Misc
+ */
+void tcmu_cancel_thread(pthread_t thread);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tcmur_aio.c
+++ b/tcmur_aio.c
@@ -35,6 +35,11 @@ struct tcmu_work {
 	struct list_node entry;
 };
 
+static void _cleanup_mutex_lock(void *arg)
+{
+	pthread_mutex_unlock(arg);
+}
+
 void track_aio_request_start(struct tcmur_device *rdev)
 {
 	struct tcmu_track_aio *aio_track = &rdev->track_queue;

--- a/tcmur_aio.c
+++ b/tcmur_aio.c
@@ -244,7 +244,7 @@ void cleanup_io_work_queue_threads(struct tcmu_device *dev)
 
 	for (i = 0; i < nr_threads; i++) {
 		if (io_wq->io_wq_threads[i]) {
-			cancel_thread(io_wq->io_wq_threads[i]);
+			tcmu_cancel_thread(io_wq->io_wq_threads[i]);
 		}
 	}
 }

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -35,6 +35,11 @@
 #include "tcmu-runner.h"
 #include "alua.h"
 
+static void _cleanup_spin_lock(void *arg)
+{
+	pthread_spin_unlock(arg);
+}
+
 void tcmur_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 			    int rc)
 {

--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -140,6 +140,7 @@ void tcmu_cancel_recovery(struct tcmu_device *dev)
 		pthread_mutex_lock(&rdev->state_lock);
 	}
 	pthread_mutex_unlock(&rdev->state_lock);
+	tcmu_dev_dbg(dev, "Recovery thread wait done\n");
 }
 
 /**

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -45,6 +45,8 @@ enum {
 struct tcmur_device {
 	struct tcmu_device *dev;
 
+	pthread_t cmdproc_thread;
+
 	/* TCMUR_DEV flags */
 	uint32_t flags;
 	uint8_t failover_type;


### PR DESCRIPTION
The following patches allow us to restart runner after it has crashed. They require the tcmu restart patches posted to target-devel (no link yet as spinics has not updated).