### PR TITLE
runner/rbd: update lock state on RTPG/INQUIRY

### DIFF
--- a/alua.c
+++ b/alua.c
@@ -358,6 +358,8 @@ int tcmu_emulate_report_tgt_port_grps(struct tcmu_device *dev,
 	if (!tcmu_get_enabled_port(group_list))
 		return TCMU_NOT_HANDLED;
 
+	tcmu_update_dev_lock_state(dev);
+
 	if (alloc_len < 4)
 		return tcmu_set_sense_data(cmd->sense_buf, ILLEGAL_REQUEST,
 					   ASC_INVALID_FIELD_IN_CDB, NULL);

--- a/rbd.c
+++ b/rbd.c
@@ -490,6 +490,19 @@ static int tcmu_rbd_has_lock(struct tcmu_device *dev)
 	return 0;
 }
 
+static int tcmu_rbd_get_lock_state(struct tcmu_device *dev)
+{
+	int ret;
+
+	ret = tcmu_rbd_has_lock(dev);
+	if (ret == 1)
+		return TCMUR_DEV_LOCK_LOCKED;
+	else if (ret == 0 || ret == -ESHUTDOWN)
+		return TCMUR_DEV_LOCK_UNLOCKED;
+	else
+		return TCMUR_DEV_LOCK_UNKNOWN;
+}
+
 /**
  * tcmu_rbd_lock_break - break rbd exclusive lock if needed
  * @dev: device to break the lock for.
@@ -1241,6 +1254,7 @@ struct tcmur_handler tcmu_rbd_handler = {
 	.handle_cmd    = tcmu_rbd_handle_cmd,
 #ifdef RBD_LOCK_ACQUIRE_SUPPORT
 	.lock          = tcmu_rbd_lock,
+	.get_lock_state = tcmu_rbd_get_lock_state,
 #endif
 };
 

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -127,6 +127,10 @@ struct tcmur_handler {
 	 * Must return a TCMUR_LOCK return value.
 	 */
 	int (*lock)(struct tcmu_device *dev);
+	/*
+	 * Must return TCMUR_DEV_LOCK state value.
+	 */
+	int (*get_lock_state)(struct tcmu_device *dev);
 
 	/*
 	 * internal field, don't touch this

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -2299,8 +2299,11 @@ static int handle_inquiry(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 					   ASC_INTERNAL_TARGET_FAILURE, NULL);
 
 	port = tcmu_get_enabled_port(&group_list);
-	if (!port)
+	if (!port) {
 		tcmu_dev_dbg(dev, "no enabled ports found. Skipping ALUA support\n");
+	} else {
+		tcmu_update_dev_lock_state(dev);
+	}
 
 	ret = tcmu_emulate_inquiry(dev, port, cmd->cdb, cmd->iovec,
 				   cmd->iov_cnt, cmd->sense_buf);

--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -230,6 +230,31 @@ int tcmu_cancel_lock_thread(struct tcmu_device *dev)
 	return ret;
 }
 
+/*
+ * The initiator could have done FO/FB while no IO was
+ * in flight so we did not get notified about losing the
+ * lock. Update lock state now to avoid firing the error
+ * handler later.
+ */
+void tcmu_update_dev_lock_state(struct tcmu_device *dev)
+{
+	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
+	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);
+	int state;
+
+	if (!rhandler->get_lock_state)
+		return;
+
+	state = rhandler->get_lock_state(dev);
+	pthread_mutex_lock(&rdev->state_lock);
+	if (rdev->lock_state == TCMUR_DEV_LOCK_LOCKED &&
+	    state != TCMUR_DEV_LOCK_LOCKED) {
+		tcmu_dev_dbg(dev, "Updated out of sync lock state.\n");
+		rdev->lock_state = TCMUR_DEV_LOCK_UNLOCKED;
+	}
+	pthread_mutex_unlock(&rdev->state_lock);
+}
+
 int tcmu_acquire_dev_lock(struct tcmu_device *dev)
 {
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -40,6 +40,7 @@ enum {
 	TCMUR_DEV_LOCK_UNLOCKED,
 	TCMUR_DEV_LOCK_LOCKED,
 	TCMUR_DEV_LOCK_LOCKING,
+	TCMUR_DEV_LOCK_UNKNOWN,
 };
 
 struct tcmur_device {
@@ -85,5 +86,6 @@ int __tcmu_reopen_dev(struct tcmu_device *dev);
 int tcmu_reopen_dev(struct tcmu_device *dev);
 
 int tcmu_acquire_dev_lock(struct tcmu_device *dev);
+void tcmu_update_dev_lock_state(struct tcmu_device *dev);
 
 #endif


### PR DESCRIPTION
If there is no IO in flight or sent when the lock is taken from
from a node, then rbd will not discover the lock has been taken
until it gets IO errors from being blacklisted later. This
will fire off the error handler and force retries.

To avoid that, this patch just updates our lock state when
there is a RTPG or INQUIRY. Normally this would be sent
before switching paths so we can catch the state change then
and prevent the extra retries.