### PR TITLE
tcmu:fix error using the return value of function  tcmu_get_dev_max_xfer_length

### DIFF
--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -759,7 +759,7 @@ static int handle_writesame(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 					   NULL);
 	}
 
-	max_xfer_length = tcmu_get_dev_max_xfer_len(dev);
+	max_xfer_length = tcmu_get_dev_max_xfer_len(dev) * block_size;
 	length = round_up(length, max_xfer_length);
 	length = min(length, (size_t)lba_cnt * block_size);
 
@@ -2110,7 +2110,7 @@ static int handle_format_unit(struct tcmu_device *dev, struct tcmulib_cmd *cmd) 
 	cmd->cmdstate = state;
 	state->done_blocks = 0;
 
-	max_xfer_length = tcmu_get_dev_max_xfer_len(dev);
+	max_xfer_length = tcmu_get_dev_max_xfer_len(dev) * block_size;
 	length = round_up(length, max_xfer_length);
 	state->length = length;
 


### PR DESCRIPTION
The return value of fuction tcmu_get_dev_max_xfer_len is number of sector, but some functions used it as data size, for example handle_writesam and handle_format_unit functions.

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>