### PR TITLE
libtcmu: fix traverse darray for remove_device

### DIFF
--- a/libtcmu.c
+++ b/libtcmu.c
@@ -517,7 +517,7 @@ static void close_devices(struct tcmulib_context *ctx)
 	struct tcmu_device *dev;
 	char *cfgstring = "";
 
-	darray_foreach(dev_ptr, ctx->devices) {
+	darray_foreach_reverse(dev_ptr, ctx->devices) {
 		dev = *dev_ptr;
 		remove_device(ctx, dev->dev_name, cfgstring);
 	}


### PR DESCRIPTION
Otherwise some devices will not be removed when the devices more than 1.

Signed-off-by: peng.liang <peng.liang5@zte.com.cn>
  