### PR TITLE
alua: fix memory leakage when doing the alua implicit transition

### DIFF
--- a/main.c
+++ b/main.c
@@ -805,6 +805,10 @@ static int dev_added(struct tcmu_device *dev)
 
 	rdev->flags |= TCMUR_DEV_FLAG_IS_OPEN;
 
+	ret = pthread_cond_init(&rdev->lock_cond, NULL);
+	if (ret < 0)
+		goto cleanup_lock_cond;
+
 	/*
 	 * Set the optimal unmap granularity to max xfer len. Optimal unmap
 	 * alignment starts at the begining of the device.
@@ -821,6 +825,8 @@ static int dev_added(struct tcmu_device *dev)
 
 close_dev:
 	rhandler->close(dev);
+cleanup_lock_cond:
+	pthread_cond_destroy(&rdev->lock_cond);
 cleanup_aio_tracking:
 	cleanup_aio_tracking(rdev);
 cleanup_io_work_queue:
@@ -863,6 +869,10 @@ static void dev_removed(struct tcmu_device *dev)
 
 	cleanup_io_work_queue(dev, false);
 	cleanup_aio_tracking(rdev);
+
+	ret = pthread_cond_destroy(&rdev->lock_cond);
+	if (ret != 0)
+		tcmu_err("could not cleanup lock cond %d\n", ret);
 
 	ret = pthread_mutex_destroy(&rdev->state_lock);
 	if (ret != 0)

--- a/target.c
+++ b/target.c
@@ -258,7 +258,7 @@ done:
 	 * cmdproc thread to reopen all these in parallel.
 	 */
 	list_for_each_safe(&tpg->devs, rdev, tmp_rdev, recovery_entry) {
-		ret = __tcmu_reopen_dev(rdev->dev);
+		ret = __tcmu_reopen_dev(rdev->dev, false);
 		if (ret) {
 			tcmu_dev_err(rdev->dev, "Could not reinitialize device. (err %d).\n",
 				     ret);

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -46,7 +46,6 @@ struct tcmulib_cfg_info;
 enum {
 	TCMUR_LOCK_SUCCESS,
 	TCMUR_LOCK_FAILED,
-	TCMUR_LOCK_BUSY,
 	TCMUR_LOCK_NOTCONN,
 };
 

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -55,6 +55,7 @@ struct tcmur_device {
 
 	uint8_t lock_state;
 	pthread_t lock_thread;
+	pthread_cond_t lock_cond;
 
 	/* General lock for lock state, thread, dev state, etc */
 	pthread_mutex_t state_lock;
@@ -82,7 +83,7 @@ int tcmu_cancel_lock_thread(struct tcmu_device *dev);
 void tcmu_notify_conn_lost(struct tcmu_device *dev);
 void tcmu_notify_lock_lost(struct tcmu_device *dev);
 
-int __tcmu_reopen_dev(struct tcmu_device *dev);
+int __tcmu_reopen_dev(struct tcmu_device *dev, bool in_lock_thread);
 int tcmu_reopen_dev(struct tcmu_device *dev);
 
 int tcmu_acquire_dev_lock(struct tcmu_device *dev);


### PR DESCRIPTION
The error log as:
"Could not start implicit transition thread:Cannot allocate memory"

When a joinable thread terminates, its memory resources (thread
descriptor and stack) are not deallocated until another thread
performs pthread_join on it. Therefore, pthread_join must be
called once for each joinable thread created to avoid memory leaks.

Here we will make the lock pthread as detached to avoid this.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>
Signed-off-by: Zhang Zhuoyu <zhangzhuoyu@cmss.chinamobile.com>