### PR TITLE
libtcmu:fixed memory leaks of log_dir_path

### DIFF
--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -531,6 +531,8 @@ void tcmu_destroy_config(struct tcmu_config *cfg)
 	}
 
 	tcmu_conf_free_str_keys(cfg);
+	if (cfg->log_dir_path)
+		free(cfg->log_dir_path);
 	free(cfg->path);
 	free(cfg);
 }


### PR DESCRIPTION
If the user has configured log_dir_path in tcmu.conf file,there will be a memory leak.

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>