### PR TITLE
libtcmu:fixed conf file parse error

### DIFF
--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -265,7 +265,8 @@ static void tcmu_parse_option(char **cur, const char *end)
 
 		return;
 	}
-
+	/* skip character '='  */
+	s++;
 	while (isblank(*r) || *r == '=')
 		r--;
 	r++;
@@ -282,7 +283,7 @@ static void tcmu_parse_option(char **cur, const char *end)
 		} else if (isdigit(*r)) {
 			type = TCMU_OPT_INT;
 		} else {
-			tcmu_err("option type %d not supported!\n");
+			tcmu_err("option type not supported!\n");
 			return;
 		}
 


### PR DESCRIPTION
     If there is no space betwwen the option and the character '=',
     after the following while loop, the charactor '=' may be replace by '\0'
     and therefore can not be parsed correctly.

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>