### PR TITLE
handler: do not perform implicit transition if command not supported

### DIFF
--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -2299,9 +2299,33 @@ static int tcmur_cmd_handler(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		goto untrack;
 	}
 
-	ret = tcmur_alua_implicit_transition(dev, cmd);
-	if (ret)
-		goto untrack;
+	/* Don't perform alua implicit transition if command is not supported */
+	switch(cdb[0]) {
+	case READ_6:
+	case READ_10:
+	case READ_12:
+	case READ_16:
+	case WRITE_6:
+	case WRITE_10:
+	case WRITE_12:
+	case WRITE_16:
+	case UNMAP:
+	case SYNCHRONIZE_CACHE:
+	case SYNCHRONIZE_CACHE_16:
+	case EXTENDED_COPY:
+	case COMPARE_AND_WRITE:
+	case WRITE_VERIFY:
+	case WRITE_VERIFY_16:
+	case WRITE_SAME:
+	case WRITE_SAME_16:
+	case FORMAT_UNIT:
+		ret = tcmur_alua_implicit_transition(dev, cmd);
+		if (ret)
+			goto untrack;
+		break;
+	default:
+		break;
+	}
 
 	switch(cdb[0]) {
 	case READ_6:


### PR DESCRIPTION
If unsupported command was handled by tcmur_cmd_handler, alua implicit
transition have a chance to cause image exclusive-lock threshing between
runners, so do not perform implicit transition if command not supported

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>
Signed-off-by: Zhang Zhuoyu <zhangzhuoyu@cmss.chinamobile.com>