### PR TITLE
zbc: fix write emulation, change returned sense codes, add install step and more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ set_target_properties(handler_file_zbc
 target_include_directories(handler_file_zbc
   PUBLIC ${PROJECT_SOURCE_DIR}/ccan
   )
-
+install(TARGETS handler_file_zbc DESTINATION ${CMAKE_INSTALL_LIBDIR}/tcmu-runner)
 
 # The minimal library consumer
 add_executable(consumer

--- a/file_zbc.c
+++ b/file_zbc.c
@@ -627,6 +627,7 @@ static int zbc_format_meta(struct zbc_dev *zdev)
 	struct zbc_dev_config *cfg = &zdev->cfg;
 	struct zbc_meta *meta;
 	struct zbc_zone *zone;
+	unsigned int nr_seq_zones;
 	__u64 lba = 0;
 	unsigned int i;
 	int ret;
@@ -653,8 +654,12 @@ static int zbc_format_meta(struct zbc_dev *zdev)
 	}
 
 	zdev->nr_open_zones = cfg->open_num;
-	if (zdev->nr_open_zones >= zdev->nr_zones)
-		zdev->nr_open_zones = zdev->nr_zones;
+	nr_seq_zones = zdev->nr_zones - zdev->nr_conv_zones;
+	if (zdev->nr_open_zones >= nr_seq_zones / 2) {
+		zdev->nr_open_zones = nr_seq_zones / 2;
+		if (!zdev->nr_open_zones)
+			zdev->nr_open_zones = 1;
+	}
 
 	tcmu_dev_dbg(zdev->dev, "Formatting...\n");
 	tcmu_dev_dbg(zdev->dev, "  Model: %s\n",


### PR DESCRIPTION
Hello,

I'd like to publish a few commits to ZBC file handler. Most of these are fixes that came about as a result of our internal testing.

Besides the changes listed in the title, this PR contains some minor fixes to tcmu-runner core.
One commit is a fix for a compile error (see the comment attached to the commit). Not sure if anyone else has seen this, but both Damien and me get this error on a fresh install of Fedora 27 unless a specific include is commented out.

Cheers,
Dmitry
