### PR TITLE
runner: fail commands with unsupported CDBs.

### DIFF
--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -51,6 +51,7 @@ struct tcmulib_context {
 struct tcmu_device {
 	int fd;
 
+	pthread_spinlock_t lock; /* protects concurrent updates to mailbox */
 	struct tcmu_mailbox *map;
 	size_t map_len;
 

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -35,32 +35,13 @@
 #include "tcmu-runner.h"
 #include "alua.h"
 
-static void _cleanup_spin_lock(void *arg)
-{
-	pthread_spin_unlock(arg);
-}
-
-void tcmur_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
-			    int rc)
-{
-	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);
-
-	pthread_cleanup_push(_cleanup_spin_lock, (void *)&rdev->lock);
-	pthread_spin_lock(&rdev->lock);
-
-	tcmulib_command_complete(dev, cmd, rc);
-
-	pthread_spin_unlock(&rdev->lock);
-	pthread_cleanup_pop(0);
-}
-
 static void aio_command_finish(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 			       int rc)
 {
 	int wakeup;
 
 	track_aio_request_finish(tcmu_get_daemon_dev_private(dev), &wakeup);
-	tcmur_command_complete(dev, cmd, rc);
+	tcmulib_command_complete(dev, cmd, rc);
 	if (wakeup)
 		tcmulib_processing_complete(dev);
 }

--- a/tcmur_cmd_handler.h
+++ b/tcmur_cmd_handler.h
@@ -26,8 +26,6 @@ void tcmur_set_pending_ua(struct tcmu_device *dev, int ua);
 int tcmur_generic_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
 int tcmur_cmd_passthrough_handler(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
 bool tcmur_handler_is_passthrough_only(struct tcmur_handler *rhandler);
-void tcmur_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
-			    int ret);
 typedef int (*tcmur_writesame_fn_t)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 			   uint64_t off, uint64_t len, struct iovec *iov, size_t iov_cnt);
 int tcmur_handle_writesame(struct tcmu_device *dev, struct tcmulib_cmd *cmd,

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -71,7 +71,6 @@ struct tcmur_device {
         struct tcmu_io_queue work_queue;
         struct tcmu_track_aio track_queue;
 
-	pthread_spinlock_t lock; /* protects concurrent updates to mailbox */
 	pthread_mutex_t caw_lock; /* for atomic CAW operation */
 
 	uint32_t format_progress;


### PR DESCRIPTION
This patch just properly handles unsupported CDBs by failing
them instead of hanging the entire device.