### PR TITLE
libtcmu: add tcmu_is_ring_reset_support support

### DIFF
--- a/configfs.c
+++ b/configfs.c
@@ -247,6 +247,19 @@ int tcmu_set_cfgfs_ul(const char *path, unsigned long val)
 	return tcmu_set_cfgfs_str(path, buf, strlen(buf) + 1);
 }
 
+bool tcmu_cfgfs_file_is_supported(struct tcmu_device *dev, const char *name)
+{
+	char path[PATH_MAX];
+
+	snprintf(path, sizeof(path), CFGFS_CORE"/%s/%s/%s",
+		 dev->tcm_hba_name, dev->tcm_dev_name, name);
+
+	if (access(path, F_OK) == -1)
+		return false;
+
+	return true;
+}
+
 int tcmu_exec_cfgfs_dev_action(struct tcmu_device *dev, const char *name,
 			       unsigned long val)
 {

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -122,6 +122,7 @@ int tcmu_set_cfgfs_str(const char *path, const char *val, int val_len);
 int tcmu_get_cfgfs_int(const char *path);
 int tcmu_set_cfgfs_ul(const char *path, unsigned long val);
 int tcmu_get_attribute(struct tcmu_device *dev, const char *name);
+bool tcmu_cfgfs_file_is_supported(struct tcmu_device *dev, const char *name);
 int tcmu_exec_cfgfs_dev_action(struct tcmu_device *dev, const char *name,
 			       unsigned long val);
 long long tcmu_get_device_size(struct tcmu_device *dev);


### PR DESCRIPTION
This will compatible with the old kernel version which could
not support the ring reset operations.

Signed-off-by: Xiubo Li <xiubli@redhat.com>