### PR TITLE
runner/rbd: do not reopen device if blacklisted

### DIFF
--- a/rbd.c
+++ b/rbd.c
@@ -641,12 +641,19 @@ static int tcmu_rbd_lock(struct tcmu_device *dev)
 	if (orig_owner)
 		free(orig_owner);
 
-	if (ret == -ETIMEDOUT || ret == -ESHUTDOWN)
-		ret = TCMUR_LOCK_NOTCONN;
-	else if (ret)
-		ret = TCMUR_LOCK_FAILED;
-	else
+	switch (ret) {
+	case 0:
 		ret = TCMUR_LOCK_SUCCESS;
+		break;
+	case -ETIMEDOUT:
+		ret = TCMUR_LOCK_NOTCONN;
+		break;
+	case -ESHUTDOWN:
+		ret = TCMUR_LOCK_BLACKLISTED;
+		break;
+	default:
+		ret = TCMUR_LOCK_FAILED;
+	}
 
 	tcmu_rbd_service_status_update(dev, ret == TCMUR_LOCK_SUCCESS ?
 				       true : false);

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -47,6 +47,7 @@ enum {
 	TCMUR_LOCK_SUCCESS,
 	TCMUR_LOCK_FAILED,
 	TCMUR_LOCK_NOTCONN,
+	TCMUR_LOCK_BLACKLISTED,
 };
 
 struct tcmur_handler {

--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -299,7 +299,8 @@ retry:
 			retries++;
 			goto retry;
 		}
-
+		/* fall through */
+	case TCMUR_LOCK_BLACKLISTED:
 		tcmu_dev_dbg(dev, "Fail handler device connection.\n");
 		tcmu_notify_conn_lost(dev);
 		new_state = TCMUR_DEV_LOCK_UNLOCKED;


### PR DESCRIPTION
tcmu_acquire_dev_lock() must not skip tcmu_notify_conn_lost()
if handler told us explicitly that we are blaclisted.

Otherwise, kernel lio won't be flushed, and a stale request
sitting somewhere in kernel queues may come to us later, when
we have reacquired the lock.

Signed-off-by: Maxim Patlasov <mpatlasov@skytap.com>