### PR TITLE
rbd:fix parse cfgstring optional options

### DIFF
--- a/rbd.c
+++ b/rbd.c
@@ -775,7 +775,7 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 
 	/* The next options are optional */
 	next_opt = strtok(NULL, ";");
-	if (next_opt) {
+	while (next_opt) {
 		if (!strncmp(next_opt, "osd_op_timeout=", 15)) {
 			state->osd_op_timeout = strdup(next_opt + 15);
 			if (!state->osd_op_timeout ||
@@ -792,6 +792,7 @@ static int tcmu_rbd_open(struct tcmu_device *dev)
 				goto free_config;
 			}
 		}
+		next_opt = strtok(NULL, ";");
 	}
 
 	ret = tcmu_rbd_image_open(dev);


### PR DESCRIPTION
When cfg two optional options exist at the same time, only the first option can resolve correctly。

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>