### PR TITLE
tcmur: improve batch kernel wake up notifications

### DIFF
--- a/tcmur_aio.h
+++ b/tcmur_aio.h
@@ -26,6 +26,7 @@ struct tcmu_device;
 struct tcmulib_cmd;
 
 struct tcmu_track_aio {
+	unsigned int pending_wakeups;
 	unsigned int tracked_aio_ops;
 	pthread_mutex_t track_lock;
 	pthread_cond_t *is_empty_cond;
@@ -55,6 +56,7 @@ int async_handle_cmd(struct tcmu_device *, struct tcmulib_cmd *,
 /* aio request tracking */
 void track_aio_request_start(struct tcmur_device *);
 void track_aio_request_finish(struct tcmur_device *, int *);
+void track_aio_wakeup_finish(struct tcmur_device *, int *);
 int aio_wait_for_empty_queue(struct tcmur_device *rdev);
 
 #endif /* __TCMUR_AIO_H */

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -57,12 +57,15 @@ void tcmur_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 static void aio_command_finish(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 			       int rc)
 {
-	int wakeup;
+	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);
+	int wake_up;
 
-	track_aio_request_finish(tcmu_get_daemon_dev_private(dev), &wakeup);
 	tcmur_command_complete(dev, cmd, rc);
-	if (wakeup)
+	track_aio_request_finish(rdev, &wake_up);
+	while (wake_up) {
 		tcmulib_processing_complete(dev);
+		track_aio_wakeup_finish(rdev, &wake_up);
+	}
 }
 
 static int alloc_iovec(struct tcmulib_cmd *cmd, size_t length)


### PR DESCRIPTION
Only fire a single wake up concurrently. If additional AIO
completions arrive while the kernel is being woken up, the
wake up will fire again.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>