### PR TITLE
fix the condition of sleep in _tcmu_reopen_dev

### DIFF
--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -92,7 +92,7 @@ int __tcmu_reopen_dev(struct tcmu_device *dev, bool in_lock_thread)
 
 		tcmu_dev_dbg(dev, "Opening device.\n");
 		ret = rhandler->open(dev, true);
-		if (!ret) {
+		if (ret) {
 			/* Avoid busy loop ? */
 			sleep(1);
 		}


### PR DESCRIPTION
when open device failed，after sleep 1S try to open device again。
Signed-off-by: tangwenji <tang.wenji@zte.com.cn>