### PR TITLE
tcmu-runner: add reset netlink support

### DIFF
--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -66,6 +66,7 @@ enum {
 #define CFGFS_CORE CFGFS_ROOT"/core"
 
 #define CFGFS_TARGET_MOD "/sys/module/target_core_user"
+#define CFGFS_MOD_PARAM CFGFS_TARGET_MOD"/parameters"
 
 /* Temporarily limit this to 32M */
 #define VPD_MAX_UNMAP_LBA_COUNT            (32 * 1024 * 1024)
@@ -157,6 +158,9 @@ int tcmu_set_dev_size(struct tcmu_device *dev);
 long long tcmu_get_dev_size(struct tcmu_device *dev);
 char *tcmu_get_wwn(struct tcmu_device *dev);
 int tcmu_set_control(struct tcmu_device *dev, const char *key, unsigned long val);
+void tcmu_reset_netlink(void);
+void tcmu_block_netlink(void);
+void tcmu_unblock_netlink(void);
 int tcmu_get_cdb_length(uint8_t *cdb);
 uint64_t tcmu_get_lba(uint8_t *cdb);
 uint32_t tcmu_get_xfer_length(uint8_t *cdb);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -65,6 +65,8 @@ enum {
 #define CFGFS_ROOT "/sys/kernel/config/target"
 #define CFGFS_CORE CFGFS_ROOT"/core"
 
+#define CFGFS_TARGET_MOD "/sys/module/target_core_user"
+
 /* Temporarily limit this to 32M */
 #define VPD_MAX_UNMAP_LBA_COUNT            (32 * 1024 * 1024)
 #define VPD_MAX_UNMAP_BLOCK_DESC_COUNT     0x04

--- a/main.c
+++ b/main.c
@@ -486,11 +486,12 @@ static int load_our_module(void)
 			} else {
 				tcmu_info("no modules directory '/lib/modules/%s', checking module target_core_user entry in '/sys/modules/'\n",
 					  u.release);
-				ret = stat("/sys/module/target_core_user", &sb);
+				ret = stat(CFGFS_TARGET_MOD, &sb);
 				if (!ret) {
 					tcmu_dbg("Module target_core_user already loaded\n");
 				} else {
-					tcmu_err("stat() on '/sys/module/target_core_user' failed: %m\n");
+					tcmu_err("stat() on '%s' failed: %m\n",
+						 CFGFS_TARGET_MOD);
 				}
 			}
 		} else {

--- a/main.c
+++ b/main.c
@@ -1078,6 +1078,10 @@ int main(int argc, char **argv)
 	}
 
 	tcmu_dbg("handler path: %s\n", handler_path);
+
+	tcmu_block_netlink();
+	tcmu_reset_netlink();
+
 	ret = open_handlers();
 	if (ret < 0) {
 		tcmu_err("couldn't open handlers\n");
@@ -1141,6 +1145,7 @@ int main(int argc, char **argv)
 				NULL  // user date free func
 		);
 
+	tcmu_unblock_netlink();
 	g_main_loop_run(loop);
 
 	tcmu_info("Exiting...\n");
@@ -1167,6 +1172,7 @@ err_tcmulib_close:
 err_free_handlers:
 	darray_free(handlers);
 close_fd:
+	tcmu_unblock_netlink();
 	lock_fd.l_type = F_UNLCK;
 	if (fcntl(fd, F_SETLK, &lock_fd) == -1) {
 		tcmu_err("fcntl(UNLCK) on lockfile %s failed: [%m]\n",


### PR DESCRIPTION
Will do the netlink reset when starting and just before it could
receive and handle the netlink requests from kernel space.

Signed-off-by: Xiubo Li <xiubli@redhat.com>