### PR TITLE
 tcmu-runner: return the correct scsi proto status to kernel

### DIFF
--- a/api.c
+++ b/api.c
@@ -1169,7 +1169,9 @@ int tcmu_emulate_start_stop(struct tcmu_device *dev, uint8_t *cdb)
 #define CDB_TO_BUF_SIZE(bytes) ((bytes) * 3 + 1)
 #define CDB_FIX_BYTES 64 /* 64 bytes for default */
 #define CDB_FIX_SIZE CDB_TO_BUF_SIZE(CDB_FIX_BYTES)
-void tcmu_cdb_debug_info(struct tcmu_device *dev, const struct tcmulib_cmd *cmd)
+void tcmu_print_cdb_info(struct tcmu_device *dev,
+			 const struct tcmulib_cmd *cmd,
+			 const char *info)
 {
 	int i, n, bytes;
 	char fix[CDB_FIX_SIZE], *buf;
@@ -1191,9 +1193,17 @@ void tcmu_cdb_debug_info(struct tcmu_device *dev, const struct tcmulib_cmd *cmd)
 	for (i = 0, n = 0; i < bytes; i++) {
 		n += sprintf(buf + n, "%x ", cmd->cdb[i]);
 	}
+
+	if (info)
+		n += sprintf(buf + n, "%s", info);
+
 	sprintf(buf + n, "\n");
 
-	tcmu_dev_dbg_scsi_cmd(dev, buf);
+	if (info) {
+		tcmu_dev_warn(dev, buf);
+	} else {
+		tcmu_dev_dbg_scsi_cmd(dev, buf);
+	}
 
 	if (bytes > CDB_FIX_SIZE)
 		free(buf);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -192,7 +192,7 @@ int tcmu_emulate_mode_sense(struct tcmu_device *dev, uint8_t *cdb,
 int tcmu_emulate_mode_select(struct tcmu_device *dev, uint8_t *cdb,
 			     struct iovec *iovec, size_t iov_cnt);
 /* SCSI helpers */
-void tcmu_cdb_debug_info(struct tcmu_device *dev, const struct tcmulib_cmd *cmd);
+void tcmu_print_cdb_info(struct tcmu_device *dev, const struct tcmulib_cmd *cmd, const char *info);
 
 #ifdef __cplusplus
 }

--- a/main.c
+++ b/main.c
@@ -624,7 +624,7 @@ static void *tcmur_cmdproc_thread(void *arg)
 		while (!dev_stopping && (cmd = tcmulib_get_next_command(dev)) != NULL) {
 
 			if (tcmu_get_log_level() == TCMU_LOG_DEBUG_SCSI_CMD)
-				tcmu_cdb_debug_info(dev, cmd);
+				tcmu_print_cdb_info(dev, cmd, NULL);
 
 			if (tcmur_handler_is_passthrough_only(rhandler))
 				ret = tcmur_cmd_passthrough_handler(dev, cmd);
@@ -632,7 +632,7 @@ static void *tcmur_cmdproc_thread(void *arg)
 				ret = tcmur_generic_handle_cmd(dev, cmd);
 
 			if (ret == TCMU_STS_NOT_HANDLED)
-				tcmu_dev_warn(dev, "Command 0x%x not supported\n", cmd->cdb[0]);
+				tcmu_print_cdb_info(dev, cmd, "is not supported");
 
 			/*
 			 * command (processing) completion is called in the following


### PR DESCRIPTION
The SAM_STAT_TASK_SET_FULL status code is returned when the logical
unit lacks the resources to accept a received task from an I_T nexus.

For the other errors of the backend storage, we will return NOT READY
status instead of ILLEGAL REQUEST, because returning ILLEGAL REQUEST
would cause immediate IO errors on some initiators, Returning NOT
READY instead means the operations will be retried a finite number of
times and we can survive intermittent errors.