### PR TITLE
extra: fix RPM build error

### DIFF
--- a/tcmu-runner.spec
+++ b/tcmu-runner.spec
@@ -48,6 +48,8 @@ userspace libraries they like.
 
 %install
 %{__make} DESTDIR=%{buildroot} install
+%{__mkdir} -p %{buildroot}/etc/tcmu/
+%{__install} -m 644 tcmu.conf %{buildroot}/etc/tcmu/
 
 %clean
 %{__rm} -rf ${buldroot}


### PR DESCRIPTION
```
RPM build errors:
    Directory not found:
/root/tcmu-runner-orig/extra/rpmbuild/BUILDROOT/tcmu-runner-1.3.0.54.g6684a21-0.el7.centos.x86_64/etc/tcmu
    File not found:
/root/tcmu-runner-orig/extra/rpmbuild/BUILDROOT/tcmu-runner-1.3.0.54.g6684a21-0.el7.centos.x86_64/etc/tcmu/tcmu.conf
-----
```

Signed-off-by: Xiubo Li <xiubli@redhat.com>