### PR TITLE
runner: config fix and code clean up

### DIFF
--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -23,6 +23,8 @@
 #include "libtcmu_config.h"
 #include "libtcmu_log.h"
 
+#include "ccan/list/list.h"
+
 /*
  * System config for TCMU, for now there are only 3 option types supported:
  * 1, The "int type" option, for example:
@@ -75,7 +77,6 @@
  * system config reload thread daemon will try to update them for all the
  * tcmu-runner, consumer and tcmu-synthesizer daemons.
  */
-#include "ccan/list/list.h"
 
 static LIST_HEAD(tcmu_options);
 
@@ -337,7 +338,7 @@ static void tcmu_parse_option(char **cur, const char *end)
 		option->opt_str = strdup(s);
 		break;
 	default:
-		tcmu_err("option type %d not supported!\n");
+		tcmu_err("option type %d not supported!\n", option->type);
 		break;
 	}
 }

--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -25,6 +25,26 @@
 
 #include "ccan/list/list.h"
 
+typedef enum {
+	TCMU_OPT_NONE = 0,
+	TCMU_OPT_INT, /* type int */
+	TCMU_OPT_STR, /* type string */
+	TCMU_OPT_BOOL, /* type boolean */
+	TCMU_OPT_MAX,
+} tcmu_option_type;
+
+struct tcmu_conf_option {
+	struct list_node list;
+
+	char *key;
+	tcmu_option_type type;
+	union {
+		int opt_int;
+		bool opt_bool;
+		char *opt_str;
+	};
+};
+
 /*
  * System config for TCMU, for now there are only 3 option types supported:
  * 1, The "int type" option, for example:

--- a/libtcmu_config.h
+++ b/libtcmu_config.h
@@ -31,7 +31,6 @@ struct tcmu_config {
  *    4: DEBUG
  *    5: DEBUG SCSI CMD
  */
-
 enum {
 	TCMU_CONF_LOG_LEVEL_MIN = 1,
 	TCMU_CONF_LOG_ERROR = 1,
@@ -40,26 +39,6 @@ enum {
 	TCMU_CONF_LOG_DEBUG,
 	TCMU_CONF_LOG_DEBUG_SCSI_CMD,
 	TCMU_CONF_LOG_LEVEL_MAX = TCMU_CONF_LOG_DEBUG_SCSI_CMD,
-};
-
-typedef enum {
-	TCMU_OPT_NONE = 0,
-	TCMU_OPT_INT, /* type int */
-	TCMU_OPT_STR, /* type string */
-	TCMU_OPT_BOOL, /* type boolean */
-	TCMU_OPT_MAX,
-} tcmu_option_type;
-
-struct tcmu_conf_option {
-	struct list_node list;
-
-	char *key;
-	tcmu_option_type type;
-	union {
-		int opt_int;
-		bool opt_bool;
-		char *opt_str;
-	};
 };
 
 void tcmu_destroy_config(struct tcmu_config *cfg);


### PR DESCRIPTION
make the struct data invisible and fix the log message and clean up the code

Signed-off-by: Xiubo Li <xiubli@redhat.com>

