### PR TITLE
config: fix parse error when there has no space after '='

### DIFF
--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -280,7 +280,8 @@ static void tcmu_parse_option(char **cur, const char *end)
 	}
 	/* skip character '='  */
 	s++;
-	while (isblank(*r) || *r == '=')
+	r--;
+	while (isblank(*r))
 		r--;
 	r++;
 	*r = '\0';
@@ -288,17 +289,13 @@ static void tcmu_parse_option(char **cur, const char *end)
 	option = tcmu_get_option(p);
 	if (!option) {
 		r = s;
-		while (isblank(*r) || *r == '=')
+		while (isblank(*r))
 			r++;
 
-		if (*r == '"' || *r == '\'') {
-			type = TCMU_OPT_STR;
-		} else if (isdigit(*r)) {
+		if (isdigit(*r))
 			type = TCMU_OPT_INT;
-		} else {
-			tcmu_err("option type not supported!\n");
-			return;
-		}
+		else
+			type = TCMU_OPT_STR;
 
 		option = tcmu_register_option(p, type);
 		if (!option)
@@ -318,7 +315,6 @@ static void tcmu_parse_option(char **cur, const char *end)
 		option->opt_int = atoi(s);
 		break;
 	case TCMU_OPT_STR:
-		s++;
 		while (isblank(*s))
 			s++;
 		/* skip first " or ' if exist */


### PR DESCRIPTION
Signed-off-by: Xiubo Li <xiubli@redhat.com>