### PR TITLE
Re-install libtcmu API and header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,7 +271,7 @@ configure_file (
   )
 install(SCRIPT tcmu.conf_install.cmake)
 
-install(FILES libtcmu.h libtcmu_common.h tcmu-runner.h
+install(FILES libtcmu.h libtcmu_common.h libtcmu_priv.h darray.h
   DESTINATION include)
 install(FILES org.kernel.TCMUService1.service
   DESTINATION /usr/share/dbus-1/system-services)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ target_link_libraries(tcmu
   ${LIBNL_GENL_LIB}
   ${GLIB_LIBRARIES}
   )
-install(TARGETS tcmu LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} NAMELINK_SKIP)
+install(TARGETS tcmu LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Stuff for building the static library
 add_library(tcmu_static

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,8 @@ configure_file (
   )
 install(SCRIPT tcmu.conf_install.cmake)
 
+install(FILES libtcmu.h libtcmu_common.h tcmu-runner.h
+  DESTINATION include)
 install(FILES org.kernel.TCMUService1.service
   DESTINATION /usr/share/dbus-1/system-services)
 install(FILES tcmu-runner.conf DESTINATION /etc/dbus-1/system.d)

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -20,11 +20,7 @@
 #include <gio/gio.h>
 #include <pthread.h>
 
-#include "scsi_defs.h"
 #include "darray.h"
-#include "ccan/list/list.h"
-#include "tcmur_aio.h"
-#include "tcmu-runner.h"
 
 #define KERN_IFACE_VER 2
 


### PR DESCRIPTION
Thanks to Mike and other persons' great efforts on re-licenseing tcmu-runner/libtcmu now we can link qemu-tcmu and libtcmu. It's time to bring libtcmu API back. This patchset reverts two commits to re-install libtcmu API and tunes header files for dependence. Now when we compile tcmu-runner, libtcmu API and four headers(libtcmu.h, libtcmu_common.h, libtcmu_priv.h, darray.h) will be installed. With this patchset qemu-tcmu can be successfully compiled and works pretty properly. @amarts @lxbsz 
We also can base on these patches to tune libtcmu further and make libtcmu more suitable for different  TCMU daemons.