### PR TITLE
Reinstall libtcmu API and header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ target_link_libraries(tcmu
   ${LIBNL_GENL_LIB}
   ${GLIB_LIBRARIES}
   )
-install(TARGETS tcmu LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} NAMELINK_SKIP)
+install(TARGETS tcmu LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Stuff for building the static library
 add_library(tcmu_static

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ configure_file (
   )
 install(SCRIPT tcmu.conf_install.cmake)
 
-install(FILES libtcmu.h libtcmu_common.h tcmu-runner.h
+install(FILES libtcmu.h libtcmu_common.h libtcmu_priv.h darray.h
   DESTINATION include)
 install(FILES org.kernel.TCMUService1.service
   DESTINATION /usr/share/dbus-1/system-services)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,8 @@ configure_file (
   )
 install(SCRIPT tcmu.conf_install.cmake)
 
+install(FILES libtcmu.h libtcmu_common.h tcmu-runner.h
+  DESTINATION include)
 install(FILES org.kernel.TCMUService1.service
   DESTINATION /usr/share/dbus-1/system-services)
 install(FILES tcmu-runner.conf DESTINATION /etc/dbus-1/system.d)

--- a/alua.c
+++ b/alua.c
@@ -23,6 +23,7 @@
 #include "libtcmu_log.h"
 #include "libtcmu_common.h"
 #include "libtcmu_priv.h"
+#include "tcmu-runner.h"
 #include "tcmur_device.h"
 #include "target.h"
 #include "alua.h"

--- a/api.c
+++ b/api.c
@@ -25,6 +25,7 @@
 #include "libtcmu_log.h"
 #include "libtcmu_common.h"
 #include "libtcmu_priv.h"
+#include "tcmu-runner.h"
 #include "target.h"
 #include "alua.h"
 #include "be_byteshift.h"

--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -22,6 +22,7 @@
 #include "libtcmu_config.h"
 #include "libtcmu_time.h"
 #include "libtcmu_priv.h"
+#include "tcmu-runner.h"
 #include "string_priv.h"
 
 /* tcmu ring buffer for log */

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -20,10 +20,7 @@
 #include <gio/gio.h>
 #include <pthread.h>
 
-#include "scsi_defs.h"
 #include "darray.h"
-#include "ccan/list/list.h"
-#include "tcmur_aio.h"
 
 #define KERN_IFACE_VER 2
 

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -24,7 +24,6 @@
 #include "darray.h"
 #include "ccan/list/list.h"
 #include "tcmur_aio.h"
-#include "tcmu-runner.h"
 
 #define KERN_IFACE_VER 2
 


### PR DESCRIPTION
The separation work of libtcmu and tcmu-runner seems harder than we thought and is going to take a bit more time to achieve. Let's reinstall libtcmu header files and API first for now as the future sepatation work can still base on this to move on and qemu-tcmu can also make a little forward. @mikechristie @amarts @lxbsz