### PR TITLE
To enhance the reuseability of code, move function 'tcmu_cancel_thread' from 'main.c' to 'api.c' .

### DIFF
--- a/api.c
+++ b/api.c
@@ -1200,3 +1200,25 @@ void tcmu_print_cdb_info(struct tcmu_device *dev,
 	if (bytes > CDB_FIX_SIZE)
 		free(buf);
 }
+
+void tcmu_cancel_thread(pthread_t thread)
+{
+	void *join_retval;
+	int ret;
+
+	ret = pthread_cancel(thread);
+	if (ret) {
+		tcmu_err("pthread_cancel failed with value %d\n", ret);
+		return;
+	}
+
+	ret = pthread_join(thread, &join_retval);
+	if (ret) {
+		tcmu_err("pthread_join failed with value %d\n", ret);
+		return;
+	}
+
+	if (join_retval != PTHREAD_CANCELED)
+		tcmu_err("unexpected join retval: %p\n", join_retval);
+}
+

--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -22,6 +22,7 @@
 #include "darray.h"
 #include "libtcmu_config.h"
 #include "libtcmu_log.h"
+#include "tcmu-runner.h"
 
 #include "ccan/list/list.h"
 
@@ -522,24 +523,7 @@ free_cfg:
 
 static void tcmu_cancel_config_thread(struct tcmu_config *cfg)
 {
-	pthread_t thread_id = cfg->thread_id;
-	void *join_retval;
-	int ret;
-
-	ret = pthread_cancel(thread_id);
-	if (ret) {
-		tcmu_err("pthread_cancel failed with value %d\n", ret);
-		return;
-	}
-
-	ret = pthread_join(thread_id, &join_retval);
-	if (ret) {
-		tcmu_err("pthread_join failed with value %d\n", ret);
-		return;
-	}
-
-	if (join_retval != PTHREAD_CANCELED)
-		tcmu_err("unexpected join retval: %p\n", join_retval);
+	tcmu_cancel_thread(cfg->thread_id);
 }
 
 void tcmu_destroy_config(struct tcmu_config *cfg)

--- a/main.c
+++ b/main.c
@@ -838,27 +838,6 @@ free_rdev:
 	return ret;
 }
 
-void tcmu_cancel_thread(pthread_t thread)
-{
-	void *join_retval;
-	int ret;
-
-	ret = pthread_cancel(thread);
-	if (ret) {
-		tcmu_err("pthread_cancel failed with value %d\n", ret);
-		return;
-	}
-
-	ret = pthread_join(thread, &join_retval);
-	if (ret) {
-		tcmu_err("pthread_join failed with value %d\n", ret);
-		return;
-	}
-
-	if (join_retval != PTHREAD_CANCELED)
-		tcmu_err("unexpected join retval: %p\n", join_retval);
-}
-
 static void dev_removed(struct tcmu_device *dev)
 {
 	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);


### PR DESCRIPTION
Move the definition of function 'void tcmu_cancel_thread(pthread_t thread)' from 'main.c' to 'api.c', 
so this function can be called by 'main.c', 'libtcmu_config.c' or other module. 
There is no need to implement the same code two or more times.