### PR TITLE
rbd:check lock ownership in tcmu_rbd_get_lock_tag

### DIFF
--- a/rbd.c
+++ b/rbd.c
@@ -599,6 +599,10 @@ static int tcmu_rbd_get_lock_tag(struct tcmu_device *dev, uint16_t *tag)
 	size_t buf_len = TCMU_RBD_LOCKER_BUF_LEN;
 	int ret;
 
+	/* Not owner,force tcmu to report standby */
+	if (tcmu_rbd_has_lock(dev) != 1)
+		return TCMU_STS_NO_LOCK_HOLDERS;
+
 	memset(buf, 0, buf_len);
 
 	ret = rbd_metadata_get(state->image, TCMU_RBD_LOCKER_TAG_KEY,


### PR DESCRIPTION
The tcmu service restarts abnormally when the lock is obtained, the initiator sends an rtpg command to get the alua status is AO, but since the current client is not the ownership of the lock, the IO cannot be executed.
The ownership of the lock is the client before the tcmu service restarts, and it is also stored in the rbd metadata.

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>