### PR TITLE
tcmur:fix the initial value of the return var

### DIFF
--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -328,7 +328,7 @@ int tcmu_acquire_dev_lock(struct tcmu_device *dev, bool is_sync,
 {
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
 	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);
-	int retries = 0, ret = TCMU_STS_OK;
+	int retries = 0, ret = TCMU_STS_HW_ERR;
 
 	/* Block the kernel device. */
 	tcmu_block_device(dev);


### PR DESCRIPTION
when function aio_wait_for_empty_queue return non-zero，STPG command should return conversion failed。

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>