### PR TITLE
glfs: set loglevel to INFO

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -31,7 +31,7 @@
 
 #define GLUSTER_PORT "24007"
 #define TCMU_GLFS_LOG_FILENAME "tcmu-runner-glfs.log"  /* MAX 32 CHAR */
-#define TCMU_GLFS_DEBUG_LEVEL  4
+#define TCMU_GLFS_DEBUG_LEVEL  7
 
 /* cache protection */
 pthread_mutex_t glfs_lock;


### PR DESCRIPTION
various loglevels in glusterfs:
 GF_LOG_EMERG    = 1  /* system is unusable */
 GF_LOG_ALERT    = 2  /* action must be taken immediately */
 GF_LOG_CRITICAL = 3  /* critical conditions */
 GF_LOG_ERROR    = 4  /* error conditions */
 GF_LOG_WARNING  = 5  /* warning conditions */
 GF_LOG_NOTICE   = 6  /* normal but significant condition */
 GF_LOG_INFO     = 7  /* informational */
 GF_LOG_DEBUG    = 8  /* debug-level messages */
 GF_LOG_TRACE    = 9  /* trace-level messages */

Thanks to Pranith Kumar K <pkarampu@redhat.com> for pointing this issue.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>