### PR TITLE
tcmur:fix format character on handle_writesame_check

### DIFF
--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -658,7 +658,7 @@ static int handle_writesame_check(struct tcmu_device *dev, struct tcmulib_cmd *c
 	if (ret)
 		return ret;
 
-	tcmu_dev_dbg(dev, "Start lba: %llu, number of lba:: %hu, last lba: %llu\n",
+	tcmu_dev_dbg(dev, "Start lba: %llu, number of lba: %u, last lba: %llu\n",
 		     start_lba, lba_cnt, start_lba + lba_cnt - 1);
 
 	return TCMU_STS_OK;


### PR DESCRIPTION
Incorrect format characters, data overflow。

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>