### PR TITLE
add checking of logging formats vs. arguments

### DIFF
--- a/api.c
+++ b/api.c
@@ -1192,9 +1192,9 @@ void tcmu_print_cdb_info(struct tcmu_device *dev,
 	sprintf(buf + n, "\n");
 
 	if (info) {
-		tcmu_dev_warn(dev, buf);
+		tcmu_dev_warn(dev, "%s", buf);
 	} else {
-		tcmu_dev_dbg_scsi_cmd(dev, buf);
+		tcmu_dev_dbg_scsi_cmd(dev, "%s", buf);
 	}
 
 	if (bytes > CDB_FIX_SIZE)

--- a/file_zbc.c
+++ b/file_zbc.c
@@ -13,6 +13,7 @@
 #define _GNU_SOURCE
 #include <stddef.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1887,7 +1888,7 @@ static int zbc_check_rdwr(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	size_t iov_length = tcmu_iovec_length(cmd->iovec, cmd->iov_cnt);
 
 	if (iov_length != nr_lbas * zdev->lba_size) {
-		tcmu_dev_err(dev, "iov len mismatch: iov len %zu, xfer len %lu, block size %lu\n",
+		tcmu_dev_err(dev, "iov len mismatch: iov len %zu, xfer len %zu, block size %zu\n",
 			     iov_length, nr_lbas, zdev->lba_size);
 		return tcmu_set_sense_data(cmd->sense_buf,
 					   HARDWARE_ERROR,
@@ -1895,7 +1896,7 @@ static int zbc_check_rdwr(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	}
 
 	if (lba + nr_lbas > zdev->capacity || lba + nr_lbas < lba) {
-		tcmu_dev_err(dev, "cmd exceeds last lba %llu (lba %llu, xfer len %lu)\n",
+		tcmu_dev_err(dev, "cmd exceeds last lba %llu (lba %"PRIu64", xfer len %zu)\n",
 			     zdev->capacity, lba, nr_lbas);
 		return tcmu_set_sense_data(cmd->sense_buf,
 					   ILLEGAL_REQUEST,
@@ -2028,7 +2029,7 @@ static int zbc_write_check_zones(struct tcmu_device *dev,
 		zone = zbc_get_zone(zdev, lba, false);
 		if (!zone) {
 			tcmu_dev_err(zdev->dev,
-				     "Get zone at LBA %llu failed\n",
+				     "Get zone at LBA %"PRIu64" failed\n",
 				     lba);
 			return tcmu_set_sense_data(cmd->sense_buf,
 						   HARDWARE_ERROR,
@@ -2040,7 +2041,7 @@ static int zbc_write_check_zones(struct tcmu_device *dev,
 			zone_type = zone->type;
 		if (zone->type != zone_type) {
 			tcmu_dev_err(dev,
-				     "Write boundary violation lba %llu, xfer len %lu\n",
+				     "Write boundary violation lba %"PRIu64", xfer len %zu\n",
 				     lba, nr_lbas);
 			return tcmu_set_sense_data(cmd->sense_buf,
 						   ILLEGAL_REQUEST,
@@ -2059,7 +2060,7 @@ static int zbc_write_check_zones(struct tcmu_device *dev,
 
 		/* Check LBA on write pointer */
 		if (zbc_zone_seq_req(zone) && lba != zone->wp) {
-			tcmu_dev_err(dev, "Unaligned write lba %llu, wp %llu\n",
+			tcmu_dev_err(dev, "Unaligned write lba %"PRIu64", wp %llu\n",
 				     lba, zone->wp);
 			return tcmu_set_sense_data(cmd->sense_buf,
 						   ILLEGAL_REQUEST,
@@ -2070,7 +2071,7 @@ static int zbc_write_check_zones(struct tcmu_device *dev,
 		if (zbc_zone_seq_req(zone) &&
 		     lba + nr_lbas > zone->start + zone->len) {
 			tcmu_dev_err(dev,
-				     "Write boundary violation lba %llu, xfer len %lu\n",
+				     "Write boundary violation lba %"PRIu64", xfer len %zu\n",
 				     lba, nr_lbas);
 			return tcmu_set_sense_data(cmd->sense_buf,
 						   ILLEGAL_REQUEST,
@@ -2129,7 +2130,7 @@ static int zbc_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		zone = zbc_get_zone(zdev, lba, false);
 		if (lba + nr_lbas > zone->start + zone->len) {
 			tcmu_dev_err(dev,
-				     "Write boundary violation lba %llu, xfer len %lu\n",
+				     "Write boundary violation lba %"PRIu64", xfer len %zu\n",
 				     lba, nr_lbas);
 			return tcmu_set_sense_data(cmd->sense_buf,
 						   ILLEGAL_REQUEST,

--- a/glfs.c
+++ b/glfs.c
@@ -676,7 +676,7 @@ static int tcmu_glfs_reconfig(struct tcmu_device *dev,
 			ret = 0;
 		} else if (st.st_size != cfg->data.dev_size) {
 			tcmu_dev_err(dev,
-				     "device size and backing size disagree: device %lld backing %lld\n",
+				     "device size and backing size disagree: device %"PRId64" backing %lld\n",
 				     cfg->data.dev_size, (long long) st.st_size);
 			ret = -EINVAL;
 		}

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -47,10 +47,15 @@ unsigned int tcmu_get_log_level(void);
 int tcmu_setup_log(void);
 void tcmu_destroy_log(void);
 
+__attribute__ ((format (printf, 4, 5)))
 void tcmu_err_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
+__attribute__ ((format (printf, 4, 5)))
 void tcmu_warn_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
+__attribute__ ((format (printf, 4, 5)))
 void tcmu_info_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
+__attribute__ ((format (printf, 4, 5)))
 void tcmu_dbg_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
+__attribute__ ((format (printf, 4, 5)))
 void tcmu_dbg_scsi_cmd_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
 
 char *tcmu_get_logdir(void);

--- a/main.c
+++ b/main.c
@@ -757,7 +757,7 @@ static int dev_added(struct tcmu_device *dev)
 		goto free_rdev;
 	tcmu_set_dev_max_xfer_len(dev, max_sectors);
 
-	tcmu_dev_dbg(dev, "Got block_size %ld, size in bytes %lld\n",
+	tcmu_dev_dbg(dev, "Got block_size %d, size in bytes %"PRId64"\n",
 		     block_size, dev_size);
 
 	ret = pthread_spin_init(&rdev->lock, 0);

--- a/rbd.c
+++ b/rbd.c
@@ -674,7 +674,7 @@ static int tcmu_rbd_set_lock_tag(struct tcmu_device *dev, uint16_t tcmu_tag)
 	 */
 	ret = rbd_lock_get_owners(state->image, &lock_mode, owners,
 				  &num_owners);
-	tcmu_dev_dbg(dev, "set tag get lockowner got %d %d\n", ret, num_owners);
+	tcmu_dev_dbg(dev, "set tag get lockowner got %d %zd\n", ret, num_owners);
 	if (ret)
 		return ret;
 
@@ -1073,7 +1073,7 @@ static void rbd_finish_aio_generic(rbd_completion_t completion,
 		tcmu_dev_err(dev, "Invalid IO request.\n");
 		tcmu_r = TCMU_STS_INVALID_CDB;
 	} else if (ret < 0) {
-		tcmu_dev_err(dev, "Got fatal IO error %d.\n", ret);
+		tcmu_dev_err(dev, "Got fatal IO error %"PRId64".\n", ret);
 
 		if (aio_cb->type == RBD_AIO_TYPE_READ)
 			tcmu_r = TCMU_STS_RD_ERR;
@@ -1296,7 +1296,7 @@ static int tcmu_rbd_aio_writesame(struct tcmu_device *dev,
 	if (ret < 0)
 		goto out_free_bounce_buffer;
 
-	tcmu_dev_dbg(dev, "Start write same off:%llu, len:%llu\n", off, len);
+	tcmu_dev_dbg(dev, "Start write same off:%"PRIu64", len:%"PRIu64"\n", off, len);
 
 	ret = rbd_aio_writesame(state->image, off, len, aio_cb->bounce_buffer,
 				length, completion, 0);

--- a/target.c
+++ b/target.c
@@ -235,7 +235,7 @@ static void *tgt_port_grp_recovery_thread_fn(void *arg)
 
 	if (ret < 0) {
 		tcmu_err("Could not disable %s/%s/tpgt_%hu (err %d).\n",
-			 ret, tpg->fabric, tpg->wwn, tpg->tpgt);
+			 tpg->fabric, tpg->wwn, tpg->tpgt, ret);
 		/* just recover the devs and leave the tpg in curr state */
 		goto done;
 	}
@@ -265,7 +265,7 @@ done:
 		ret = tcmu_set_tpg_int(tpg, "enable", 1);
 		if (ret) {
 			tcmu_err("Could not enable %s/%s/tpgt_%hu (err %d).\n",
-				 ret, tpg->fabric, tpg->wwn, tpg->tpgt);
+				 tpg->fabric, tpg->wwn, tpg->tpgt, ret);
 		} else {
 			tcmu_info("Enabled %s/%s/tpgt_%hu.\n", tpg->fabric, tpg->wwn,
 				  tpg->tpgt);


### PR DESCRIPTION
Add compiler hint
	__attribute__ ((format (printf, 4, 5)))
to tcmu_err_message(), et. al. so that the compiler will check the
arguments against the printf format string.

Also change several places in various source files to bring the formats
into conformance with the data types being formatted.

Signed-off-by: David Butterfield <David.Butterfield@wdc.com>