### PR TITLE
unmap and xcopy IO size fixes

### DIFF
--- a/api.c
+++ b/api.c
@@ -580,7 +580,6 @@ finish_page83:
 	{
 		char data[64];
 		uint32_t max_xfer_length;
-		uint32_t opt_unmap_gran;
 		uint32_t unmap_gran_align;
 		uint16_t val16;
 		uint32_t val32;
@@ -626,7 +625,7 @@ finish_page83:
 
 		if (rhandler->unmap) {
 			/* MAXIMUM UNMAP LBA COUNT */
-			val32 = htobe32(VPD_MAX_UNMAP_LBA_COUNT);
+			val32 = htobe32(tcmu_get_dev_max_unmap_len(dev));
 			memcpy(&data[20], &val32, 4);
 
 			/* MAXIMUM UNMAP BLOCK DESCRIPTOR COUNT */
@@ -634,8 +633,7 @@ finish_page83:
 			memcpy(&data[24], &val32, 4);
 
 			/* OPTIMAL UNMAP GRANULARITY */
-			opt_unmap_gran = tcmu_get_dev_opt_unmap_gran(dev);
-			val32 = htobe32(opt_unmap_gran);
+			val32 = htobe32(tcmu_get_dev_opt_unmap_gran(dev));
 			memcpy(&data[28], &val32, 4);
 
 			/* UNMAP GRANULARITY ALIGNMENT */

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -869,6 +869,21 @@ uint32_t tcmu_get_dev_opt_unmap_gran(struct tcmu_device *dev)
 }
 
 /**
+ * tcmu_set/get_dev_max_unmap_len - set/get device's man unmap len
+ * @dev: tcmu device
+ * @len: max unmap len in block_size sectors
+ */
+void tcmu_set_dev_max_unmap_len(struct tcmu_device *dev, uint32_t len)
+{
+	dev->max_unmap_len = len;
+}
+
+uint32_t tcmu_get_dev_max_unmap_len(struct tcmu_device *dev)
+{
+	return dev->max_unmap_len;
+}
+
+/**
  * tcmu_set/get_dev_unmap_gran_align - set/get device's unmap granularity alignment
  * @dev: tcmu device
  * @len: unmap granularity alignment length in block_size sectors

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -854,6 +854,21 @@ uint32_t tcmu_get_dev_max_xfer_len(struct tcmu_device *dev)
 }
 
 /**
+ * tcmu_set_dev_opt_xcopy_rw_len - set device's emulated xcopy chunk len
+ * @dev: tcmu device
+ * @len: optimal RW len, in block_size sectors, for emulate xcopy operations
+ */
+void tcmu_set_dev_opt_xcopy_rw_len(struct tcmu_device *dev, uint32_t len)
+{
+	dev->opt_xcopy_rw_len = len;
+}
+
+uint32_t tcmu_get_dev_opt_xcopy_rw_len(struct tcmu_device *dev)
+{
+	return dev->opt_xcopy_rw_len;
+}
+
+/**
  * tcmu_set/get_dev_opt_unmap_gran - set/get device's optimal unmap granularity
  * @dev: tcmu device
  * @len: optimal unmap granularity length in block_size sectors

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -857,9 +857,12 @@ uint32_t tcmu_get_dev_max_xfer_len(struct tcmu_device *dev)
  * tcmu_set/get_dev_opt_unmap_gran - set/get device's optimal unmap granularity
  * @dev: tcmu device
  * @len: optimal unmap granularity length in block_size sectors
+ * @split: true if handler needs unmaps larger then len to be split for it.
  */
-void tcmu_set_dev_opt_unmap_gran(struct tcmu_device *dev, uint32_t len)
+void tcmu_set_dev_opt_unmap_gran(struct tcmu_device *dev, uint32_t len,
+				 bool split)
 {
+	dev->split_unmaps = split;
 	dev->opt_unmap_gran = len;
 }
 

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -71,7 +71,7 @@ enum {
 #define CFGFS_MOD_PARAM CFGFS_TARGET_MOD"/parameters"
 
 /* Temporarily limit this to 32M */
-#define VPD_MAX_UNMAP_LBA_COUNT            (32 * 1024 * 1024)
+#define VPD_MAX_UNMAP_LBA_COUNT            65536
 #define VPD_MAX_UNMAP_BLOCK_DESC_COUNT     0x04
 /* Temporarily limit this is 0x1 */
 #define MAX_CAW_LENGTH                     0x01

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -135,6 +135,8 @@ void tcmu_set_dev_block_size(struct tcmu_device *dev, uint32_t block_size);
 uint32_t tcmu_get_dev_block_size(struct tcmu_device *dev);
 void tcmu_set_dev_max_xfer_len(struct tcmu_device *dev, uint32_t len);
 uint32_t tcmu_get_dev_max_xfer_len(struct tcmu_device *dev);
+void tcmu_set_dev_opt_xcopy_rw_len(struct tcmu_device *dev, uint32_t len);
+uint32_t tcmu_get_dev_opt_xcopy_rw_len(struct tcmu_device *dev);
 void tcmu_set_dev_max_unmap_len(struct tcmu_device *dev, uint32_t len);
 uint32_t tcmu_get_dev_max_unmap_len(struct tcmu_device *dev);
 void tcmu_set_dev_opt_unmap_gran(struct tcmu_device *dev, uint32_t len,

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -137,7 +137,8 @@ void tcmu_set_dev_max_xfer_len(struct tcmu_device *dev, uint32_t len);
 uint32_t tcmu_get_dev_max_xfer_len(struct tcmu_device *dev);
 void tcmu_set_dev_max_unmap_len(struct tcmu_device *dev, uint32_t len);
 uint32_t tcmu_get_dev_max_unmap_len(struct tcmu_device *dev);
-void tcmu_set_dev_opt_unmap_gran(struct tcmu_device *dev, uint32_t len);
+void tcmu_set_dev_opt_unmap_gran(struct tcmu_device *dev, uint32_t len,
+				 bool split);
 uint32_t tcmu_get_dev_opt_unmap_gran(struct tcmu_device *dev);
 void tcmu_set_dev_unmap_gran_align(struct tcmu_device *dev, uint32_t len);
 uint32_t tcmu_get_dev_unmap_gran_align(struct tcmu_device *dev);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -135,6 +135,8 @@ void tcmu_set_dev_block_size(struct tcmu_device *dev, uint32_t block_size);
 uint32_t tcmu_get_dev_block_size(struct tcmu_device *dev);
 void tcmu_set_dev_max_xfer_len(struct tcmu_device *dev, uint32_t len);
 uint32_t tcmu_get_dev_max_xfer_len(struct tcmu_device *dev);
+void tcmu_set_dev_max_unmap_len(struct tcmu_device *dev, uint32_t len);
+uint32_t tcmu_get_dev_max_unmap_len(struct tcmu_device *dev);
 void tcmu_set_dev_opt_unmap_gran(struct tcmu_device *dev, uint32_t len);
 uint32_t tcmu_get_dev_opt_unmap_gran(struct tcmu_device *dev);
 void tcmu_set_dev_unmap_gran_align(struct tcmu_device *dev, uint32_t len);

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -50,6 +50,7 @@ struct tcmu_device {
 	uint64_t num_lbas;
 	uint32_t block_size;
 	uint32_t max_xfer_len;
+	uint32_t opt_xcopy_rw_len;
 	bool split_unmaps;
 	uint32_t max_unmap_len;
 	uint32_t opt_unmap_gran;

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -50,6 +50,7 @@ struct tcmu_device {
 	uint64_t num_lbas;
 	uint32_t block_size;
 	uint32_t max_xfer_len;
+	uint32_t max_unmap_len;
 	uint32_t opt_unmap_gran;
 	uint32_t unmap_gran_align;
 	unsigned int write_cache_enabled:1;

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -50,6 +50,7 @@ struct tcmu_device {
 	uint64_t num_lbas;
 	uint32_t block_size;
 	uint32_t max_xfer_len;
+	bool split_unmaps;
 	uint32_t max_unmap_len;
 	uint32_t opt_unmap_gran;
 	uint32_t unmap_gran_align;

--- a/main.c
+++ b/main.c
@@ -762,7 +762,7 @@ static int dev_added(struct tcmu_device *dev)
 	 * override in their open function.
 	 */
 	tcmu_set_dev_max_unmap_len(dev, VPD_MAX_UNMAP_LBA_COUNT);
-	tcmu_set_dev_opt_unmap_gran(dev, max_sectors);
+	tcmu_set_dev_opt_unmap_gran(dev, max_sectors, true);
 	tcmu_set_dev_unmap_gran_align(dev, 0);
 
 	tcmu_dev_dbg(dev, "Got block_size %d, size in bytes %"PRId64"\n",

--- a/main.c
+++ b/main.c
@@ -764,6 +764,11 @@ static int dev_added(struct tcmu_device *dev)
 	tcmu_set_dev_max_unmap_len(dev, VPD_MAX_UNMAP_LBA_COUNT);
 	tcmu_set_dev_opt_unmap_gran(dev, max_sectors, true);
 	tcmu_set_dev_unmap_gran_align(dev, 0);
+	/*
+	 * By default we will try to do RWs for xcopys in max_sector chunks,
+	 * but handlers that can do larger internal IOs should override.
+	 */
+	tcmu_set_dev_opt_xcopy_rw_len(dev, max_sectors);
 
 	tcmu_dev_dbg(dev, "Got block_size %d, size in bytes %"PRId64"\n",
 		     block_size, dev_size);

--- a/main.c
+++ b/main.c
@@ -726,7 +726,6 @@ static int dev_added(struct tcmu_device *dev)
 	struct list_head group_list;
 	struct tcmur_device *rdev;
 	int32_t block_size, max_sectors;
-	uint32_t max_xfer_length;
 	int64_t dev_size;
 	int ret;
 
@@ -756,6 +755,14 @@ static int dev_added(struct tcmu_device *dev)
 	if (max_sectors < 0)
 		goto free_rdev;
 	tcmu_set_dev_max_xfer_len(dev, max_sectors);
+
+	/*
+	 * Set the optimal unmap granularity to max xfer len. Optimal unmap
+	 * alignment starts at the begining of the device. Handlers can
+	 * override in their open function.
+	 */
+	tcmu_set_dev_opt_unmap_gran(dev, max_sectors);
+	tcmu_set_dev_unmap_gran_align(dev, 0);
 
 	tcmu_dev_dbg(dev, "Got block_size %d, size in bytes %"PRId64"\n",
 		     block_size, dev_size);
@@ -800,14 +807,6 @@ static int dev_added(struct tcmu_device *dev)
 	ret = pthread_cond_init(&rdev->lock_cond, NULL);
 	if (ret < 0)
 		goto close_dev;
-
-	/*
-	 * Set the optimal unmap granularity to max xfer len. Optimal unmap
-	 * alignment starts at the begining of the device.
-	 */
-	max_xfer_length = tcmu_get_dev_max_xfer_len(dev);
-	tcmu_set_dev_opt_unmap_gran(dev, max_xfer_length);
-	tcmu_set_dev_unmap_gran_align(dev, 0);
 
 	ret = pthread_create(&rdev->cmdproc_thread, NULL, tcmur_cmdproc_thread,
 			     dev);

--- a/main.c
+++ b/main.c
@@ -761,6 +761,7 @@ static int dev_added(struct tcmu_device *dev)
 	 * alignment starts at the begining of the device. Handlers can
 	 * override in their open function.
 	 */
+	tcmu_set_dev_max_unmap_len(dev, VPD_MAX_UNMAP_LBA_COUNT);
 	tcmu_set_dev_opt_unmap_gran(dev, max_sectors);
 	tcmu_set_dev_unmap_gran_align(dev, 0);
 

--- a/rbd.c
+++ b/rbd.c
@@ -932,6 +932,10 @@ static int tcmu_rbd_open(struct tcmu_device *dev, bool reopen)
 		goto stop_image;
 	}
 
+	tcmu_set_dev_max_unmap_len(dev, (image_info.obj_size * 4) /
+				   tcmu_get_dev_block_size(dev));
+	tcmu_set_dev_opt_unmap_gran(dev, image_info.obj_size /
+				    tcmu_get_dev_block_size(dev));
 	tcmu_set_dev_write_cache_enabled(dev, 0);
 
 	free(dev_cfg_dup);

--- a/rbd.c
+++ b/rbd.c
@@ -932,10 +932,15 @@ static int tcmu_rbd_open(struct tcmu_device *dev, bool reopen)
 		goto stop_image;
 	}
 
+	/*
+	 * librbd/ceph can better split and align unmaps, so just have
+	 * runner pass the entire unmap to us. To try and balance overflowing
+	 * the OSD/ceph side queues with discards limit it to up to 4.
+	 */
 	tcmu_set_dev_max_unmap_len(dev, (image_info.obj_size * 4) /
 				   tcmu_get_dev_block_size(dev));
 	tcmu_set_dev_opt_unmap_gran(dev, image_info.obj_size /
-				    tcmu_get_dev_block_size(dev));
+				    tcmu_get_dev_block_size(dev), false);
 	tcmu_set_dev_write_cache_enabled(dev, 0);
 
 	free(dev_cfg_dup);

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -1109,7 +1109,8 @@ static int xcopy_locate_udev(struct tcmulib_context *ctx,
 			continue;
 
 		*udev = dev;
-		tcmu_dev_dbg(dev, "Located tcmu devivce: %s\n", dev->dev_name);
+		tcmu_dev_dbg(dev, "Located tcmu devivce: %s\n",
+			     dev->tcm_dev_name);
 
 		return 0;
 	}

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -377,9 +377,9 @@ static int handle_unmap_internal(struct tcmu_device *dev, struct tcmulib_cmd *or
 		tcmu_dev_dbg(dev, "Parameter list %d, start lba: %"PRIu64", end lba: %"PRIu64", nlbas: %"PRIu64"\n",
 			     i++, lba, lba + nlbas - 1, nlbas);
 
-		if (nlbas > VPD_MAX_UNMAP_LBA_COUNT) {
+		if (nlbas > tcmu_get_dev_max_unmap_len(dev)) {
 			tcmu_dev_err(dev, "Illegal parameter list LBA count %"PRIu64" exceeds:%u\n",
-				     nlbas, VPD_MAX_UNMAP_LBA_COUNT);
+				     nlbas, tcmu_get_dev_max_unmap_len(dev));
 			ret = TCMU_STS_INVALID_PARAM_LIST;
 			goto state_unlock;
 		}

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -951,7 +951,6 @@ out:
 #define XCOPY_TARGET_DESC_LEN           32
 #define XCOPY_SEGMENT_DESC_B2B_LEN      28
 #define XCOPY_NAA_IEEE_REGEX_LEN        16
-#define XCOPY_MAX_SECTORS               1024
 
 struct xcopy {
 	struct tcmu_device *origdev;
@@ -1586,11 +1585,10 @@ static int handle_xcopy(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		goto finish_err;
 	}
 
-	src_max_sectors = tcmu_get_dev_max_xfer_len(xcopy->src_dev);
-	dst_max_sectors = tcmu_get_dev_max_xfer_len(xcopy->dst_dev);
+	src_max_sectors = tcmu_get_dev_opt_xcopy_rw_len(xcopy->src_dev);
+	dst_max_sectors = tcmu_get_dev_opt_xcopy_rw_len(xcopy->dst_dev);
 
 	max_sectors = min(src_max_sectors, dst_max_sectors);
-	max_sectors = min(max_sectors, (uint32_t)XCOPY_MAX_SECTORS);
 	copy_lbas = min(max_sectors, xcopy->lba_cnt);
 	xcopy->copy_lbas = copy_lbas;
 


### PR DESCRIPTION
For unmap and xcopy the hw max sectors / max xfer len is a little small for handlers like rbd. The following patches allow us to use larger IO sizes for unmap and xcopy while still allowing initiators to send smaller IOs for normal RWs.