### PR TITLE
runner/rbd: misc implicit failover fixes

### DIFF
--- a/alua.c
+++ b/alua.c
@@ -387,8 +387,8 @@ static int alua_set_state(struct tcmu_device *dev, struct alua_grp *group,
  * @group_list: list of alua groups
  * @enabled_group_id: group id of the local enabled alua group
  *
- * If the handler is not able to update the remote nodes's state during STPG
- * handling we update it now.
+ * If the handler is not able to update the remote nodes's state during ALUA
+ * transition handling we update it now.
  */
 static int alua_sync_state(struct tcmu_device *dev,
 			   struct list_head *group_list,
@@ -400,6 +400,11 @@ static int alua_sync_state(struct tcmu_device *dev,
 	uint16_t ao_group_id;
 	uint8_t alua_state;
 	int ret;
+
+	if (rdev->failover_type == TMCUR_DEV_FAILOVER_IMPLICIT) {
+		tcmu_update_dev_lock_state(dev);
+		return TCMU_STS_OK;
+	}
 
 	if (rdev->failover_type != TMCUR_DEV_FAILOVER_EXPLICIT ||
 	    !rhandler->get_lock_tag)

--- a/alua.c
+++ b/alua.c
@@ -560,7 +560,7 @@ int alua_implicit_transition(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		goto done;
 	} else if (rdev->lock_state == TCMUR_DEV_LOCK_LOCKING) {
 		tcmu_dev_info(dev, "Lock acquisition operation is already in process.");
-		ret = TCMU_STS_TRANSITION;
+		ret = TCMU_STS_BUSY;
 		goto done;
 	}
 
@@ -585,7 +585,7 @@ int alua_implicit_transition(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		rdev->lock_state = TCMUR_DEV_LOCK_UNLOCKED;
 		ret = TCMU_STS_IMPL_TRANSITION_ERR;
 	} else {
-		ret = TCMU_STS_TRANSITION;
+		ret = TCMU_STS_BUSY;
 	}
 
 done:

--- a/rbd.c
+++ b/rbd.c
@@ -963,7 +963,7 @@ static int tcmu_rbd_handle_blacklisted_cmd(struct tcmu_device *dev,
 	 * running IO is failed due to librbd's immediate blacklisting
 	 * during lock acquisition on a higher priority path.
 	 */
-	return TCMU_STS_TRANSITION;
+	return TCMU_STS_BUSY;
 }
 
 /*

--- a/rbd.c
+++ b/rbd.c
@@ -526,6 +526,19 @@ static int tcmu_rbd_has_lock(struct tcmu_device *dev)
 	return 0;
 }
 
+static int tcmu_rbd_get_lock_state(struct tcmu_device *dev)
+{
+	int ret;
+
+	ret = tcmu_rbd_has_lock(dev);
+	if (ret == 1)
+		return TCMUR_DEV_LOCK_LOCKED;
+	else if (ret == 0 || ret == -ESHUTDOWN)
+		return TCMUR_DEV_LOCK_UNLOCKED;
+	else
+		return TCMUR_DEV_LOCK_UNKNOWN;
+}
+
 /**
  * tcmu_rbd_lock_break - break rbd exclusive lock if needed
  * @dev: device to break the lock for.
@@ -1461,6 +1474,7 @@ struct tcmur_handler tcmu_rbd_handler = {
 	.lock          = tcmu_rbd_lock,
 	.unlock        = tcmu_rbd_unlock,
 	.get_lock_tag  = tcmu_rbd_get_lock_tag,
+	.get_lock_state = tcmu_rbd_get_lock_state,
 #endif
 };
 

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -127,6 +127,11 @@ struct tcmur_handler {
 	int (*get_lock_tag)(struct tcmu_device *dev, uint16_t *tag);
 
 	/*
+	 * Must return TCMUR_DEV_LOCK state value.
+	 */
+	int (*get_lock_state)(struct tcmu_device *dev);
+
+	/*
 	 * internal field, don't touch this
 	 *
 	 * indicates to tcmu-runner whether this is an internal handler loaded

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -2319,6 +2319,8 @@ static int handle_inquiry(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	port = tcmu_get_enabled_port(&group_list);
 	if (!port) {
 		tcmu_dev_dbg(dev, "no enabled ports found. Skipping ALUA support\n");
+	} else {
+		tcmu_update_dev_lock_state(dev);
 	}
 
 	ret = tcmu_emulate_inquiry(dev, port, cmd->cdb, cmd->iovec,

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -33,6 +33,7 @@ enum {
 	TCMUR_DEV_LOCK_UNLOCKED,
 	TCMUR_DEV_LOCK_LOCKED,
 	TCMUR_DEV_LOCK_LOCKING,
+	TCMUR_DEV_LOCK_UNKNOWN,
 };
 
 struct tcmur_device {
@@ -83,5 +84,6 @@ int tcmu_reopen_dev(struct tcmu_device *dev, bool in_lock_thread, int retries);
 int tcmu_acquire_dev_lock(struct tcmu_device *dev, bool is_sync, uint16_t tag);
 void tcmu_release_dev_lock(struct tcmu_device *dev);
 int tcmu_get_lock_tag(struct tcmu_device *dev, uint16_t *tag);
+void tcmu_update_dev_lock_state(struct tcmu_device *dev);
 
 #endif


### PR DESCRIPTION
1. Update lock state when getting a RTPG or INQUIRY to make sure when a
path is added back after a failover, we re-grab the lock later.

2. Use BUSY instead of ALUA STATE TRANSITION to work around a bug in the linux alua layer.