### PR TITLE
Fix misc lock/error handler bugs.

### DIFF
--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -224,8 +224,6 @@ int tcmu_cancel_lock_thread(struct tcmu_device *dev)
 	 * It looks like lock calls are not cancelable, so
 	 * we wait here to avoid crashes.
 	 */
-	tcmu_dev_dbg(dev, "Waiting on lock thread\n");
-
 	tcmu_dev_dbg(rdev->dev, "waiting for lock thread to exit\n");
 	ret = pthread_cond_wait(&rdev->lock_cond, &rdev->state_lock);
 	pthread_mutex_unlock(&rdev->state_lock);

--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -74,8 +74,10 @@ int __tcmu_reopen_dev(struct tcmu_device *dev, bool in_lock_thread, int retries)
 		rdev->lock_state = TCMUR_DEV_LOCK_UNLOCKED;
 	pthread_mutex_unlock(&rdev->state_lock);
 
-	tcmu_dev_dbg(dev, "Closing device.\n");
-	rhandler->close(dev);
+	if (rdev->flags & TCMUR_DEV_FLAG_IS_OPEN) {
+		tcmu_dev_dbg(dev, "Closing device.\n");
+		rhandler->close(dev);
+	}
 
 	pthread_mutex_lock(&rdev->state_lock);
 	rdev->flags &= ~TCMUR_DEV_FLAG_IS_OPEN;

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -48,6 +48,7 @@ struct tcmur_device {
 	pthread_t recovery_thread;
 	struct list_node recovery_entry;
 
+	bool lock_lost;
 	uint8_t lock_state;
 	pthread_t lock_thread;
 	pthread_cond_t lock_cond;


### PR DESCRIPTION
The following patches fix 2 bugs:

1. We are doing a double close on the handler if the first one is called from a lock or get_tag call, and the second one is called due to escalating the error handler.

2. With rbd we can get into a state where we cannot break the lock and you see -16 errors over and over. The patch for this is optional and may be dropped.

Jason fixed ceph here:

http://tracker.ceph.com/issues/34534

so the tcmu-runner patch would just be tiny optimization for the case where the blacklist is intact, we call lock, that fails and then we do the reopen. With the patch we go right to reopen.