### PR TITLE
log: buffer messages for early log calls by config and deamon setup

### DIFF
--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -224,13 +224,19 @@ log_internal(int pri, struct tcmu_device *dev, const char *funcname,
 	if (!fmt)
 		return;
 
-	if (!tcmu_logbuf || !tcmu_logbuf->finish_initialize) {
+	if (!tcmu_logbuf) {
 		/* handle early log calls by config and deamon setup */
 		vfprintf(stderr, fmt, args);
 		return;
 	}
 
 	pthread_mutex_lock(&tcmu_logbuf->lock);
+
+	if (!tcmu_logbuf->finish_initialize) {
+		/* handle early log calls by config and deamon setup */
+		vfprintf(stderr, fmt, args);
+		goto unlock;
+	}
 
 	/* Format the log msg */
 	if (dev) {

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -44,7 +44,9 @@ struct tcmu_device;
 
 void tcmu_set_log_level(int level);
 unsigned int tcmu_get_log_level(void);
+void tcmu_early_setup_log(void);
 int tcmu_setup_log(void);
+void tcmu_early_destroy_log(bool destroy_all);
 void tcmu_destroy_log(void);
 
 __attribute__ ((format (printf, 4, 5)))

--- a/main.c
+++ b/main.c
@@ -972,6 +972,8 @@ int main(int argc, char **argv)
 	int fd;
 	int ret;
 
+	tcmu_info("Starting...\n");
+
 	while (1) {
 		int option_index = 0;
 		int c, nr_files;

--- a/main.c
+++ b/main.c
@@ -972,6 +972,7 @@ int main(int argc, char **argv)
 	int fd;
 	int ret;
 
+	tcmu_early_setup_log();
 	tcmu_info("Starting...\n");
 
 	while (1) {
@@ -1034,6 +1035,8 @@ int main(int argc, char **argv)
 
 	if (tcmu_setup_log())
 		goto destroy_config;
+
+	tcmu_early_destroy_log(false);
 
 	fd = creat(TCMU_LOCK_FILE, S_IRUSR | S_IWUSR);
 	if (fd == -1) {
@@ -1170,6 +1173,7 @@ free_opt:
 	if (new_path)
 		free(handler_path);
 	tcmu_logdir_destroy();
+	tcmu_early_destroy_log(true);
 
 	exit(1);
 }


### PR DESCRIPTION
We need to log all the messages into tcmu-runner log file.
...
2018-09-04 00:11:51.376 28011 [INFO] Starting...
2018-09-04 00:11:51.376 28011 [INFO] Inotify is watching "/etc/tcmu/tcmu.conf", wd: 6930144, mask: IN_ALL_EVENTS
2018-09-04 00:11:51.376 28011 [INFO] log_thread_start:587: Log thread finishes initializing!
2018-09-04 00:11:51.547 28011 [ERROR] reconfig_device:183 glfs/block0: Handler reconfig failed with error -95.
2018-09-04 00:11:51.550 28011 [ERROR] reconfig_device:183 glfs/block0: Handler reconfig failed with error -95.
...
