### PR TITLE
Lock bounce fixes

### DIFF
--- a/alua.c
+++ b/alua.c
@@ -27,8 +27,6 @@
 #include "target.h"
 #include "alua.h"
 
-#define TCMU_ALUA_INVALID_GROUP_ID USHRT_MAX
-
 static char *tcmu_get_alua_str_setting(struct alua_grp *group,
 				       const char *setting)
 {
@@ -412,7 +410,7 @@ static int alua_sync_state(struct tcmu_device *dev,
 
 	ret = tcmu_get_lock_tag(dev, &ao_group_id);
 	if (ret == TCMU_STS_NO_LOCK_HOLDERS) {
-		ao_group_id = TCMU_ALUA_INVALID_GROUP_ID;
+		ao_group_id = TCMU_INVALID_LOCK_TAG;
 	} else if (ret != TCMU_STS_OK)
 		return ret;
 

--- a/rbd.c
+++ b/rbd.c
@@ -755,7 +755,8 @@ static int tcmu_rbd_lock(struct tcmu_device *dev, uint16_t tag)
 
 set_lock_tag:
 	tcmu_dev_warn(dev, "Acquired exclusive lock.\n");
-	ret = tcmu_rbd_set_lock_tag(dev, tag);
+	if (tag != TCMU_INVALID_LOCK_TAG)
+		ret = tcmu_rbd_set_lock_tag(dev, tag);
 
 done:
 	tcmu_rbd_service_status_update(dev, ret == 0 ? true : false);

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -110,9 +110,9 @@ struct tcmur_handler {
 	unmap_fn_t unmap;
 
 	/*
-	 * If the lock is acquired and the tag is non-NULL, it must be
-	 * associated with the lock and returned by get_lock_tag on local
-	 * and remote nodes. When unlock is successful, the tag
+	 * If the lock is acquired and the tag is not TCMU_INVALID_LOCK_TAG,
+	 * it must be associated with the lock and returned by get_lock_tag on
+	 * local and remote nodes. When unlock is successful, the tag
 	 * associated with the lock must be deleted.
 	 *
 	 * Returns a TCMU_STS indicating success/failure.

--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -386,16 +386,15 @@ retry:
 			retries++;
 			goto retry;
 		}
+		/*
+		 * If we can't unfence ourself the lock is probably bouncing
+		 * due to path initialization. Allow the other node to hold the
+		 * lock for now, and the initiator will drive retries.
+		 */
 	}
 
 drop_conn:
-	/*
-	 * If we cannot unfence ourself or we cannot reach the backend,
-	 * disable the tpg until we can reopen the device. The initiator
-	 * can try another path while we try to fix things up in the
-	 * background.
-	 */
-	if (ret == TCMU_STS_TIMEOUT || ret == TCMU_STS_FENCED) {
+	if (ret == TCMU_STS_TIMEOUT) {
 		tcmu_dev_dbg(dev, "Fail handler device connection.\n");
 		tcmu_notify_conn_lost(dev);
 	}

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -15,6 +15,8 @@
 
 #include "tcmur_aio.h"
 
+#define TCMU_INVALID_LOCK_TAG USHRT_MAX
+
 #define TCMUR_DEV_FLAG_FORMATTING	(1 << 0)
 #define TCMUR_DEV_FLAG_IN_RECOVERY	(1 << 1)
 #define TCMUR_DEV_FLAG_IS_OPEN		(1 << 2)


### PR DESCRIPTION
Fix a issue commonly seen with Linux initiators where during dm-multipath device initialization the lock bounces between gateways so much tcmu-runner ends up escalating the issue by dropping the iscsi connection by disabling the TPG. This results in probe related IO failing and/or dm-multipath path failures.