### PR TITLE
tcmur: fix check_iovec_length

### DIFF
--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -101,9 +101,9 @@ static inline int check_iovec_length(struct tcmu_device *dev,
 {
 	size_t iov_length = tcmu_iovec_length(cmd->iovec, cmd->iov_cnt);
 
-	if (iov_length != sectors * tcmu_get_dev_block_size(dev)) {
-		tcmu_dev_err(dev, "iov len mismatch: iov len %zu, xfer len %u, block size %u\n",
-			     iov_length, sectors, tcmu_get_dev_block_size(dev));
+	if (iov_length < sectors * tcmu_get_dev_block_size(dev)) {
+		tcmu_dev_err(dev, "iov size %zu is not enough and needs at least %u\n",
+			     iov_length, sectors * tcmu_get_dev_block_size(dev));
 		return TCMU_STS_HW_ERR;
 	}
 	return TCMU_STS_OK;


### PR DESCRIPTION
readsector0 checker for multipath is not working, and the log like:

[DEBUG_SCSI_CMD] tcmu_print_cdb_info:1069 glfs/block0: 28 0 0 0 0 0 0 0 1 0
[ERROR] check_lba_and_length:107: iov len mismatch: iov len 4096, xfer len 1, block size 512
check_lba_and_length:107: iov len mismatch: iov len 4096, xfer len 1, block size 512

This is because in kernel space the sg->length is aligned to the
page size, and also the ringbufer data area's block size. So here
we need to make sure that the iov len is not less than the scsi
command's require.

Signed-off-by: Xiubo Li <xiubli@redhat.com>