### PR TITLE
Update the ringbuffer tail here if the cmd is timedout in ringbuffer in kernel space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(tcmu
   libtcmu_log.c
   libtcmu_config.c
   libtcmu_time.c
+  libtcmu_timer.c
   )
 set_target_properties(tcmu
   PROPERTIES
@@ -74,6 +75,7 @@ add_library(tcmu_static
   libtcmu_log.c
   libtcmu_config.c
   libtcmu_time.c
+  libtcmu_timer.c
   )
 target_include_directories(tcmu_static
   PUBLIC ${LIBNL_INCLUDE_DIR}

--- a/ccan/ccan/list/list.h
+++ b/ccan/ccan/list/list.h
@@ -306,6 +306,58 @@ static inline bool list_empty_nocheck(const struct list_head *h)
 	return h->n.next == &h->n;
 }
 
+static inline void __list_splice(struct list_head *list, struct list_head *head)
+{
+    list->n.prev->next = head->n.next;
+    head->n.next->prev = list->n.prev;
+
+    head->n.next = list->n.next;
+    list->n.next->prev = &head->n;
+}
+
+static inline void
+list_splice(struct list_head *list, struct list_head *head)
+{
+    if (list_empty(list))
+        return;
+
+    __list_splice(list, head);
+}
+
+/* Splice moves @list to the head of the list at @head. */
+static inline void
+list_splice_init(struct list_head *list, struct list_head *head)
+{
+    if (list_empty(list))
+        return;
+
+    __list_splice(list, head);
+    list_head_init(list);
+}
+
+/**
+ * list_replace - replace old entry by new one
+ * @old : the element to be replaced
+ * @new : the new element to insert
+ *
+ * If @old was empty, it will be overwritten.
+ */
+static inline void
+list_replace(struct list_head *old, struct list_head *new)
+{
+    new->n.next = old->n.next;
+    new->n.next->prev = &new->n;
+    new->n.prev = old->n.prev;
+    new->n.prev->next = &new->n;
+}
+
+static inline void
+list_replace_init(struct list_head *old, struct list_head *new)
+{
+    list_replace(old, new);
+    list_head_init(old);
+}
+
 /**
  * list_del - delete an entry from an (unknown) linked list.
  * @n: the list_node to delete from the list.

--- a/consumer.c
+++ b/consumer.c
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
 							     cmd->iovec,
 							     cmd->iov_cnt,
 							     cmd->sense_buf);
-					tcmulib_command_complete(dev, cmd, ret);
+					tcmulib_command_complete(dev, cmd, ret, false);
 				}
 
 				tcmulib_processing_complete(dev);

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -814,6 +814,16 @@ uint64_t tcmu_get_dev_num_lbas(struct tcmu_device *dev)
 	return dev->num_lbas;
 }
 
+void tcmu_set_dev_cmd_time_out(struct tcmu_device *dev, unsigned int cmd_time_out)
+{
+	dev->cmd_time_out = cmd_time_out;
+}
+
+unsigned int tcmu_get_dev_cmd_time_out(struct tcmu_device *dev)
+{
+	return dev->cmd_time_out;
+}
+
 /**
  * tcmu_update_num_lbas - Update num LBAs based on the new size.
  * @dev: tcmu device to update

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -113,7 +113,7 @@ struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev);
  *
  * result is scsi status, or TCMU_STS_NOT_HANDLED or TCMU_ASYNC_HANDLED.
  */
-void tcmulib_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int result);
+void tcmulib_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd, int result, bool timeout);
 
 /* Call when start processing commands (before calling tcmulib_get_next_command()) */
 void tcmulib_processing_start(struct tcmu_device *dev);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -131,6 +131,8 @@ char *tcmu_get_dev_cfgstring(struct tcmu_device *dev);
 void tcmu_set_dev_num_lbas(struct tcmu_device *dev, uint64_t num_lbas);
 uint64_t tcmu_get_dev_num_lbas(struct tcmu_device *dev);
 int tcmu_update_num_lbas(struct tcmu_device *dev, uint64_t new_size);
+void tcmu_set_dev_cmd_time_out(struct tcmu_device *dev, unsigned int cmd_time_out);
+unsigned int tcmu_get_dev_cmd_time_out(struct tcmu_device *dev);
 void tcmu_set_dev_block_size(struct tcmu_device *dev, uint32_t block_size);
 uint32_t tcmu_get_dev_block_size(struct tcmu_device *dev);
 void tcmu_set_dev_max_xfer_len(struct tcmu_device *dev, uint32_t len);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -119,6 +119,10 @@ struct tcmulib_cmd {
 
 	/* callback to finish/continue command processing */
 	cmd_done_t done;
+
+	struct tcmu_device *dev;
+	struct tcmu_timer *timer;
+	bool timeout;
 };
 
 /* Set/Get methods for the opaque tcmu_device */

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -55,6 +55,7 @@ struct tcmu_device {
 	uint32_t max_unmap_len;
 	uint32_t opt_unmap_gran;
 	uint32_t unmap_gran_align;
+	unsigned int cmd_time_out;
 	unsigned int write_cache_enabled:1;
 	unsigned int solid_state_media:1;
 

--- a/libtcmu_timer.c
+++ b/libtcmu_timer.c
@@ -1,0 +1,365 @@
+/*
+ * tcmu timer wheel
+ *
+ * Copyright (C) 1991, 1992  Linus Torvalds
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * This file is licensed to you under your choice of the GNU Lesser
+ * General Public License, version 2.1 or any later version (LGPLv2.1 or
+ * later), or the Apache License 2.0.
+ *
+ * Most of the code is from glusterfs project and which is from Linux
+ * kernel's internal timer wheel driver.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <errno.h>
+
+#include "libtcmu_timer.h"
+#include "tcmu-runner.h"
+
+#define TVR_BITS  8
+#define TVN_BITS  6
+#define TVR_SIZE  (1 << TVR_BITS)
+#define TVN_SIZE  (1 << TVN_BITS)
+#define TVR_MASK  (TVR_SIZE - 1)
+#define TVN_MASK  (TVN_SIZE - 1)
+
+#define BITS_PER_LONG  64
+
+struct tvec {
+	struct list_head vec[TVN_SIZE];
+};
+
+struct tvec_root {
+	struct list_head vec[TVR_SIZE];
+};
+
+struct tvec_base {
+	pthread_t runner;             /* run_timer() */
+
+	unsigned long timer_sec;      /* time counter */
+
+	struct tvec_root tv1;
+	struct tvec tv2;
+	struct tvec tv3;
+	struct tvec tv4;
+	struct tvec tv5;
+};
+
+static struct tvec_base *timer_base;
+static pthread_spinlock_t timer_base_lock;      /* base lock */
+
+static inline void __tcmu_add_timer (struct tcmu_timer *timer)
+{
+	int i;
+	unsigned long idx;
+	unsigned long expires;
+	struct list_head *vec;
+
+	expires = timer->expires;
+
+	idx = expires - timer_base->timer_sec;
+
+	if (idx < TVR_SIZE) {
+		i = expires & TVR_MASK;
+		vec = timer_base->tv1.vec + i;
+	} else if (idx < 1 << (TVR_BITS + TVN_BITS)) {
+		i = (expires >> TVR_BITS) & TVN_MASK;
+		vec = timer_base->tv2.vec + i;
+	} else if (idx < 1 << (TVR_BITS + 2*TVN_BITS)) {
+		i = (expires >> (TVR_BITS + TVN_BITS)) & TVN_MASK;
+		vec = timer_base->tv3.vec + i;
+	} else if (idx < 1 << (TVR_BITS + 3*TVN_BITS)) {
+		i = (expires >> (TVR_BITS + 2*TVN_BITS)) & TVN_MASK;
+		vec = timer_base->tv4.vec + i;
+	} else if (idx < 0) {
+		vec = timer_base->tv1.vec + (timer_base->timer_sec & TVR_MASK);
+	} else {
+		i = (expires >> (TVR_BITS + 3*TVN_BITS)) & TVN_MASK;
+		vec = timer_base->tv5.vec + i;
+	}
+
+	list_add_tail(vec, &timer->entry);
+}
+
+static inline unsigned long tcmu_fls(unsigned long word)
+{
+	return BITS_PER_LONG - __builtin_clzl(word);
+}
+
+static inline unsigned long apply_slack(struct tcmu_timer *timer)
+{
+	long delta;
+	unsigned long mask, expires, expires_limit;
+	int bit;
+
+	expires = timer->expires;
+
+	delta = expires - timer_base->timer_sec;
+	if (delta < 256)
+		return expires;
+
+	expires_limit = expires + delta / 256;
+	mask = expires ^ expires_limit;
+	if (mask == 0)
+		return expires;
+
+	bit = tcmu_fls(mask);
+	mask = (1UL << bit) - 1;
+
+	expires_limit = expires_limit & ~(mask);
+	return expires_limit;
+}
+
+static inline int cascade(struct tvec *tv, int index)
+{
+	struct tcmu_timer *timer, *tmp;
+	struct list_head tv_list;
+
+	list_replace_init(tv->vec + index, &tv_list);
+
+	list_for_each_safe(&tv_list, tmp, timer, entry) {
+		__tcmu_add_timer(timer);
+	}
+
+	return index;
+}
+
+#define INDEX(N)  ((timer_base->timer_sec >> (TVR_BITS + N * TVN_BITS)) & TVN_MASK)
+
+/**
+ * run expired timers
+ */
+static inline void run_timers(void)
+{
+	unsigned long index;
+	struct tcmu_timer *timer;
+	struct list_head work_list;
+	struct list_head *head = &work_list;
+
+	pthread_spin_lock(&timer_base_lock);
+
+	index  = timer_base->timer_sec & TVR_MASK;
+
+	if (!index && (!cascade(&timer_base->tv2, INDEX(0))) &&
+			(!cascade(&timer_base->tv3, INDEX(1))) &&
+			(!cascade(&timer_base->tv4, INDEX(2))))
+		cascade(&timer_base->tv5, INDEX(3));
+
+	timer_base->timer_sec++;
+	list_replace_init(timer_base->tv1.vec + index, head);
+	while (!list_empty(head)) {
+		void (*fn)(struct tcmu_timer *, void *);
+		void *data;
+
+		timer = list_first_entry(head, struct tcmu_timer, entry);
+		fn = timer->function;
+		data = timer->data;
+
+		list_del_init(&timer->entry);
+		fn(timer, data);
+	}
+
+	pthread_spin_unlock(&timer_base_lock);
+}
+
+void *runner(void *arg)
+{
+	struct timeval tv = {0,};
+
+	while(1) {
+		run_timers();
+
+		tv.tv_sec = 1;
+		tv.tv_usec = 0;
+		select(0, NULL, NULL, NULL, &tv);
+	}
+
+	return NULL;
+}
+
+static inline int timer_pending(struct tcmu_timer *timer)
+{
+	struct list_node *entry = &timer->entry;
+
+	return entry->next != entry;
+}
+
+static inline int __detach_if_pending(struct tcmu_timer *timer)
+{
+	if (!timer_pending(timer))
+		return 0;
+
+	list_del_init(&timer->entry);
+	return 1;
+}
+
+static inline int __mod_timer(struct tcmu_timer *timer, int pending_only)
+{
+	int ret = 0;
+
+	ret = __detach_if_pending(timer);
+	if (!ret && pending_only)
+		goto done;
+
+	ret = 1;
+	__tcmu_add_timer(timer);
+
+done:
+	return ret;
+}
+
+/* interface */
+
+/**
+ * Add a timer in the timer wheel
+ */
+int tcmu_add_timer(struct tcmu_timer *timer)
+{
+	pthread_spin_lock(&timer_base_lock);
+
+	timer->expires += timer_base->timer_sec;
+	timer->expires = apply_slack(timer);
+	__tcmu_add_timer(timer);
+
+	pthread_spin_unlock(&timer_base_lock);
+
+	return 0;
+}
+
+/**
+ * Remove a timer from the timer wheel
+ */
+int tcmu_del_timer(struct tcmu_timer *timer)
+{
+	int ret = 0;
+
+	pthread_spin_lock(&timer_base_lock);
+
+	if (timer_pending(timer)) {
+		ret = 1;
+		list_del_init(&timer->entry);
+	}
+
+	pthread_spin_unlock(&timer_base_lock);
+
+	return ret;
+}
+
+int tcmu_mod_timer_pending(struct tcmu_timer *timer,
+		unsigned long expires)
+{
+	int ret = 1;
+
+	pthread_spin_lock(&timer_base_lock);
+
+	timer->expires = expires + timer_base->timer_sec;
+	timer->expires = apply_slack(timer);
+	ret = __mod_timer(timer, 1);
+
+	pthread_spin_unlock(&timer_base_lock);
+
+	return ret;
+}
+
+int tcmu_mod_timer(struct tcmu_timer *timer, unsigned long expires)
+{
+	int ret = 1;
+
+	pthread_spin_lock (&timer_base_lock);
+
+	/* fast path optimization */
+	if (timer_pending(timer) && timer->expires == expires)
+		goto unblock;
+
+	timer->expires = expires + timer_base->timer_sec;
+	timer->expires = apply_slack(timer);
+
+	ret = __mod_timer(timer, 0);
+
+unblock:
+	pthread_spin_unlock(&timer_base_lock);
+
+	return ret;
+}
+
+void tcmu_cleanup_timer_base(void)
+{
+	int ret = 0;
+
+	pthread_spin_lock(&timer_base_lock);
+	if (!timer_base)
+		goto unlock;
+
+	tcmu_cancel_thread(timer_base->runner);
+
+	/* destroy lock */
+	if (pthread_spin_destroy(&timer_base_lock) != 0)
+		tcmu_err("could not cleanup mailbox lock %d\n", ret);
+
+	/* deallocated timer timer_base */
+	free(timer_base);
+unlock:
+	pthread_spin_unlock(&timer_base_lock);
+}
+
+/**
+ * Initialize various timer wheel lists and spawn a thread that
+ * invokes run_timers()
+ */
+int tcmu_init_timer_base(void)
+{
+	struct timeval tv = {0,};
+	int ret = 0;
+	int i = 0;
+
+	if (timer_base) {
+		tcmu_warn("The timer is already initialized!\n");
+		return 0;
+	}
+
+	timer_base = malloc(sizeof(*timer_base));
+	if (!timer_base) {
+		tcmu_err("malloc timer_base failed!\n");
+		return -ENOMEM;
+	}
+
+	ret = pthread_spin_init(&timer_base_lock, 0);
+	if (ret != 0)
+		goto free_base;
+
+	for (i = 0; i < TVN_SIZE; i++) {
+		list_head_init(timer_base->tv5.vec + i);
+		list_head_init(timer_base->tv4.vec + i);
+		list_head_init(timer_base->tv3.vec + i);
+		list_head_init(timer_base->tv2.vec + i);
+	}
+
+	for (i = 0; i < TVR_SIZE; i++) {
+		list_head_init(timer_base->tv1.vec + i);
+	}
+
+	ret = gettimeofday(&tv, 0);
+	if (ret < 0)
+		goto destroy_lock;
+	timer_base->timer_sec = tv.tv_sec;
+
+	ret = pthread_create(&timer_base->runner, NULL, runner, timer_base);
+	if (ret != 0)
+		goto destroy_lock;
+
+	return 0;
+
+destroy_lock:
+	pthread_spin_destroy(&timer_base_lock);
+free_base:
+	free(timer_base);
+	return ret;
+}

--- a/libtcmu_timer.h
+++ b/libtcmu_timer.h
@@ -1,0 +1,33 @@
+/*
+ * tcmu timer wheel
+ *
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * This file is licensed to you under your choice of the GNU Lesser
+ * General Public License, version 2.1 or any later version (LGPLv2.1 or
+ * later), or the Apache License 2.0.
+ */
+
+#ifndef __LIBTCMU_TIMER_H
+#define __LIBTCMU_TIMER_H
+
+#include <pthread.h>
+#include "ccan/list/list.h"
+
+struct tcmu_timer {
+        void *data;
+        unsigned long expires;
+
+        void (*function)(struct tcmu_timer *, void *);
+
+        struct list_node entry;
+};
+
+int tcmu_init_timer_base(void);
+void tcmu_cleanup_timer_base(void);
+int tcmu_add_timer(struct tcmu_timer *);
+int tcmu_del_timer(struct tcmu_timer *);
+int tcmu_mod_timer_pending(struct tcmu_timer *, unsigned long);
+int tcmu_mod_timer(struct tcmu_timer *, unsigned long);
+
+#endif

--- a/main.c
+++ b/main.c
@@ -733,6 +733,7 @@ static int dev_added(struct tcmu_device *dev)
 	struct tcmur_device *rdev;
 	int32_t block_size, max_sectors;
 	int64_t dev_size;
+	unsigned int cmd_time_out;
 	int ret;
 
 	rdev = calloc(1, sizeof(*rdev));
@@ -756,6 +757,13 @@ static int dev_added(struct tcmu_device *dev)
 		goto free_rdev;
 	}
 	tcmu_set_dev_num_lbas(dev, dev_size / block_size);
+
+	cmd_time_out = tcmu_get_attribute(dev, "cmd_time_out");
+	if (cmd_time_out < 0) {
+		tcmu_dev_err(dev, "Could not get cmd_time_out\n");
+		goto free_rdev;
+	}
+	tcmu_set_dev_cmd_time_out(dev, cmd_time_out);
 
 	max_sectors = tcmu_get_attribute(dev, "hw_max_sectors");
 	if (max_sectors < 0)

--- a/rbd.c
+++ b/rbd.c
@@ -1490,6 +1490,7 @@ struct tcmur_handler tcmu_rbd_handler = {
 	.get_lock_tag  = tcmu_rbd_get_lock_tag,
 	.get_lock_state = tcmu_rbd_get_lock_state,
 #endif
+	.has_timer     = true;
 };
 
 int handler_init(void)

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -139,6 +139,8 @@ struct tcmur_handler {
 	 * latter case opaque will point to a struct dbus_info.
 	 */
 	bool _is_dbus_handler;
+
+	bool has_timer;
 };
 
 /*

--- a/tcmu-synthesizer.c
+++ b/tcmu-synthesizer.c
@@ -93,7 +93,7 @@ static gboolean syn_dev_callback(GIOChannel *source,
 				     cmd->cdb,
 				     cmd->iovec,
 				     cmd->iov_cnt);
-		tcmulib_command_complete(dev, cmd, ret);
+		tcmulib_command_complete(dev, cmd, ret, false);
 	}
 
 	tcmulib_processing_complete(dev);

--- a/tcmur_cmd_handler.h
+++ b/tcmur_cmd_handler.h
@@ -20,7 +20,7 @@ int tcmur_generic_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
 int tcmur_cmd_passthrough_handler(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
 bool tcmur_handler_is_passthrough_only(struct tcmur_handler *rhandler);
 void tcmur_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
-			    int ret);
+			    int ret, bool timeout);
 typedef int (*tcmur_writesame_fn_t)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 			   uint64_t off, uint64_t len, struct iovec *iov, size_t iov_cnt);
 int tcmur_handle_writesame(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
@@ -31,5 +31,6 @@ typedef int (*tcmur_caw_fn_t)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
                               size_t iov_cnt);
 int tcmur_handle_caw(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
                      tcmur_caw_fn_t caw_fn);
+void tcmur_cmd_timeout(struct tcmu_timer *timer, void *data);
 
 #endif /* __TCMUR_CMD_HANDLER_H */


### PR DESCRIPTION
Here we add one timer for each scsi command in tcmu-runner, and the time out value is (cmd_time_out + 5) seconds to make sure before the timer is fired in userspace here, the timer in ringbuffer in kernel space has already been fired.

Fixed: #485 

@mikechristie @pkalever Please review. 