### PR TITLE
tcmu: Simplify command completion

### DIFF
--- a/file_example.c
+++ b/file_example.c
@@ -111,8 +111,7 @@ static int file_read(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	}
 	ret = TCMU_STS_OK;
 done:
-	cmd->done(dev, cmd, ret);
-	return TCMU_STS_OK;
+	return ret;
 }
 
 static int file_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
@@ -136,8 +135,7 @@ static int file_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	}
 	ret = TCMU_STS_OK;
 done:
-	cmd->done(dev, cmd, ret);
-	return TCMU_STS_OK;
+	return ret;
 }
 
 static int file_flush(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
@@ -152,8 +150,7 @@ static int file_flush(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	}
 	ret = TCMU_STS_OK;
 done:
-	cmd->done(dev, cmd, ret);
-	return TCMU_STS_OK;
+	return ret;
 }
 
 static int file_reconfig(struct tcmu_device *dev, struct tcmulib_cfg_info *cfg)

--- a/file_optical.c
+++ b/file_optical.c
@@ -1452,8 +1452,7 @@ static int fbo_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	    cdb[0] != GPCMD_GET_EVENT_STATUS_NOTIFICATION) {
 		tcmu_set_sense_key_specific_info(sense, state->format_progress);
 		ret = TCMU_STS_FRMT_IN_PROGRESS;
-		cmd->done(dev, cmd, ret);
-		return 0;
+		return ret;
 	}
 
 	switch(cdb[0]) {
@@ -1543,8 +1542,7 @@ static int fbo_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 		ret = TCMU_STS_NOT_HANDLED;
 	}
 
-	cmd->done(dev, cmd, ret);
-	return 0;
+	return ret;
 }
 
 static const char fbo_cfg_desc[] =

--- a/qcow.c
+++ b/qcow.c
@@ -1454,8 +1454,7 @@ static int qcow_read(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	}
 	ret = TCMU_STS_OK;
 done:
-	cmd->done(dev, cmd, ret);
-	return TCMU_STS_OK;
+	return ret;
 }
 
 static int qcow_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
@@ -1479,8 +1478,7 @@ static int qcow_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	}
 	ret = TCMU_STS_OK;
 done:
-	cmd->done(dev, cmd, ret);
-	return TCMU_STS_OK;
+	return ret;
 }
 
 static int qcow_flush(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
@@ -1495,8 +1493,7 @@ static int qcow_flush(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	}
 	ret = TCMU_STS_OK;
 done:
-	cmd->done(dev, cmd, ret);
-	return TCMU_STS_OK;
+	return ret;
 }
 
 static const char qcow_cfg_desc[] = "The path to the QEMU QCOW image file.";

--- a/tcmur_aio.c
+++ b/tcmur_aio.c
@@ -141,7 +141,6 @@ static void *io_work_queue(void *arg)
 	struct tcmu_device *dev = arg;
 	struct tcmur_device *rdev = tcmu_get_daemon_dev_private(dev);
 	struct tcmu_io_queue *io_wq = &rdev->work_queue;
-	int ret;
 
 	while (1) {
 		struct tcmu_work *work;
@@ -166,9 +165,7 @@ static void *io_work_queue(void *arg)
 		cmd = work->cmd;
 		pthread_cleanup_push(_cleanup_io_work, work);
 
-		ret = work->fn(work->dev, cmd);
-		if (ret)
-			cmd->done(dev, cmd, ret);
+		cmd->done(dev, cmd,work->fn(work->dev, cmd));
 
 		pthread_cleanup_pop(1); /* cleanup work */
 	}


### PR DESCRIPTION
Instead of requiring handlers with nr_thread > 0 to call
cmd->done we can call in in the io_work_queue, which then
allows for the handlers to pass back any return code.
At the moment handlers can only pass back TCMU_STS_OK

Signed-off-by: Bryant G. Ly <bly@catalogicsoftware.com>