### PR TITLE
tcmu:fix extra backslash

### DIFF
--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -21,7 +21,7 @@
 #define TCMU_LOG_DEBUG_SCSI_CMD	(LOG_DEBUG + 1)	/* scsi cmd debug-level messages */
 
 /* default tcmu log dir path */
-#define TCMU_LOG_DIR_DEFAULT   "/var/log/"
+#define TCMU_LOG_DIR_DEFAULT   "/var/log"
 
 struct tcmu_device;
 

--- a/tcmu.conf
+++ b/tcmu.conf
@@ -12,6 +12,6 @@
 # log_level = 3
 #
 # Logging Directory Path
-# The default logging Directory path is /var/log/, uncomment it
+# The default logging Directory path is /var/log, uncomment it
 # and set your own path:
-# log_dir_path = "/var/log/"
+# log_dir_path = "/var/log"

--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -290,7 +290,7 @@ retry:
 		 * is called from the main IO thread and will wait for
 		 * commands started before it via the aio wait call.
 		 */
-		tcmu_dev_dbg(dev, "Could not access dev. Try reopen.");
+		tcmu_dev_dbg(dev, "Could not access dev. Try reopen.\n");
 		ret = tcmu_reopen_dev(dev, false, 0);
 		if (!ret && retry < 1) {
 			retry++;


### PR DESCRIPTION
There is such a record in the log:create_file_output:461: log file path now is '**_/var/log//tcmu-runner.log_**'

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>