### PR TITLE
glfs: add writesame support

### DIFF
--- a/api.c
+++ b/api.c
@@ -229,6 +229,30 @@ void tcmu_zero_iovec(struct iovec *iovec, size_t iov_cnt)
 	}
 }
 
+static inline bool tcmu_zeroed_mem(const char *buf, size_t size)
+{
+    int i;
+
+    for (i = 0; i < size; i++) {
+        if (buf[i])
+		return false;
+    }
+
+    return true;
+}
+
+bool tcmu_zeroed_iovec(struct iovec *iovec, size_t iov_cnt)
+{
+    int i;
+
+    for (i = 0; i < iov_cnt; i++) {
+        if (!tcmu_zeroed_mem(iovec[i].iov_base, iovec[i].iov_len))
+		return false;
+    }
+
+    return true;
+}
+
 /*
  * Copy data into an iovec, and consume the space in the iovec.
  *

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -177,6 +177,7 @@ off_t tcmu_compare_with_iovec(void *mem, struct iovec *iovec, size_t size);
 size_t tcmu_seek_in_iovec(struct iovec *iovec, size_t count);
 void tcmu_seek_in_cmd_iovec(struct tcmulib_cmd *cmd, size_t count);
 void tcmu_zero_iovec(struct iovec *iovec, size_t iov_cnt);
+bool tcmu_zeroed_iovec(struct iovec *iovec, size_t iov_cnt);
 size_t tcmu_memcpy_into_iovec(struct iovec *iovec, size_t iov_cnt, void *src, size_t len);
 size_t tcmu_memcpy_from_iovec(void *dest, size_t len, struct iovec *iovec, size_t iov_cnt);
 size_t tcmu_iovec_length(struct iovec *iovec, size_t iov_cnt);

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -312,7 +312,7 @@ static int align_and_split_unmap(struct tcmu_device *dev,
 	lbas = opt_unmap_gran - (lba & mask);
 	lbas = min(lbas, nlbas);
 
-	tcmu_dev_dbg(dev, "OPTIMAL UNMAP GRANULARITY: %"PRIu64", UNMAP GRANULARITY ALIGNMENT mask: %"PRIu64", lbas %"PRIu64"\n",
+	tcmu_dev_dbg(dev, "OPTIMAL UNMAP GRANULARITY: %"PRIu64", UNMAP GRANULARITY ALIGNMENT mask: %"PRIu64", lbas: %"PRIu64"\n",
 		     opt_unmap_gran, mask, lbas);
 
 	while (nlbas) {


### PR DESCRIPTION
This will invoke zerro fill API due to there has no truely write
same routine yet. Since the writesame emulator in tcmur will do
the same, so it shouldn't be a problem of this.

Signed-off-by: Xiubo Li <xiubli@redhat.com>