### PR TITLE
logger: add critical log level support

### DIFF
--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -163,9 +163,7 @@ static void tcmu_conf_set_options(struct tcmu_config *cfg)
 {
 	/* set log_level option */
 	TCMU_PARSE_CFG_INT(cfg, log_level, TCMU_CONF_LOG_INFO);
-	if (cfg->log_level) {
-		tcmu_set_log_level(cfg->log_level);
-	}
+	tcmu_set_log_level(cfg->log_level);
 
 	/* set log_dir path option */
 	TCMU_PARSE_CFG_STR(cfg, log_dir_path, TCMU_LOG_DIR_DEFAULT);

--- a/libtcmu_config.h
+++ b/libtcmu_config.h
@@ -23,7 +23,8 @@ struct tcmu_config {
 };
 
 /*
- * There are 5 logging levels supported in tcmu.conf:
+ * There are 6 logging levels supported in tcmu.conf:
+ *    0: CRIT
  *    1: ERROR
  *    2: WARNING
  *    3: INFO
@@ -31,7 +32,8 @@ struct tcmu_config {
  *    5: DEBUG SCSI CMD
  */
 enum {
-	TCMU_CONF_LOG_LEVEL_MIN = 1,
+	TCMU_CONF_LOG_LEVEL_MIN = 0,
+	TCMU_CONF_LOG_CRIT = 0,
 	TCMU_CONF_LOG_ERROR = 1,
 	TCMU_CONF_LOG_WARN,
 	TCMU_CONF_LOG_INFO,
@@ -41,6 +43,7 @@ enum {
 };
 
 static const char *const log_level_lookup[] = {
+	[TCMU_CONF_LOG_CRIT]	= "CRIT",
 	[TCMU_CONF_LOG_ERROR]	= "ERROR",
 	[TCMU_CONF_LOG_WARN]	= "WARNING",
 	[TCMU_CONF_LOG_INFO]	= "INFO",

--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -67,6 +67,8 @@ static pthread_mutex_t tcmu_log_dir_lock = PTHREAD_MUTEX_INITIALIZER;
 static inline int to_syslog_level(int level)
 {
 	switch (level) {
+	case TCMU_CONF_LOG_CRIT:
+		return TCMU_LOG_CRIT;
 	case TCMU_CONF_LOG_ERROR:
 		return TCMU_LOG_ERROR;
 	case TCMU_CONF_LOG_WARN:
@@ -95,7 +97,7 @@ void tcmu_set_log_level(int level)
 	else if (level < TCMU_CONF_LOG_LEVEL_MIN)
 		level = TCMU_CONF_LOG_LEVEL_MIN;
 
-	tcmu_info("log level now is %s\n", log_level_lookup[level]);
+	tcmu_crit("log level now is %s\n", log_level_lookup[level]);
 	tcmu_log_level = to_syslog_level(level);
 }
 
@@ -254,6 +256,16 @@ log_internal(int pri, struct tcmu_device *dev, const char *funcname,
 	pthread_cleanup_pop(0);
 }
 
+void tcmu_crit_message(struct tcmu_device *dev, const char *funcname,
+		       int linenr, const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	log_internal(TCMU_LOG_CRIT, dev, funcname, linenr, fmt, args);
+	va_end(args);
+}
+
 void tcmu_err_message(struct tcmu_device *dev, const char *funcname,
 		      int linenr, const char *fmt, ...)
 {
@@ -360,6 +372,8 @@ static int create_syslog_output(struct log_buf *logbuf, int pri,
 static const char *loglevel_string(int priority)
 {
 	switch (priority) {
+	case TCMU_LOG_CRIT:
+		return "CRIT";
 	case TCMU_LOG_ERROR:
 		return "ERROR";
 	case TCMU_LOG_WARN:
@@ -458,7 +472,7 @@ static int create_file_output(struct log_buf *logbuf, int pri,
 	pthread_mutex_unlock(&logbuf->file_out_lock);
 	pthread_cleanup_pop(0);
 
-	tcmu_info("log file path now is '%s'\n", log_file_path);
+	tcmu_crit("log file path now is '%s'\n", log_file_path);
 	return 0;
 }
 

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -14,6 +14,7 @@
 #include <stdarg.h>
 #include <stdbool.h>
 
+#define TCMU_LOG_CRIT	LOG_CRIT	/* critical conditions */
 #define TCMU_LOG_ERROR	LOG_ERR		/* error conditions */
 #define TCMU_LOG_WARN	LOG_WARNING	/* warning conditions */
 #define TCMU_LOG_INFO	LOG_INFO	/* informational */
@@ -33,6 +34,8 @@ int tcmu_make_absolute_logfile(char *path, const char *filename);
 int tcmu_resetup_log_file(char *log_dir_path);
 
 __attribute__ ((format (printf, 4, 5)))
+void tcmu_crit_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
+__attribute__ ((format (printf, 4, 5)))
 void tcmu_err_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
 __attribute__ ((format (printf, 4, 5)))
 void tcmu_warn_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
@@ -43,6 +46,7 @@ void tcmu_dbg_message(struct tcmu_device *dev, const char *funcname, int linenr,
 __attribute__ ((format (printf, 4, 5)))
 void tcmu_dbg_scsi_cmd_message(struct tcmu_device *dev, const char *funcname, int linenr, const char *fmt, ...);
 
+#define tcmu_dev_crit(dev, ...)  do { tcmu_crit_message(dev, __func__, __LINE__, __VA_ARGS__);} while (0)
 #define tcmu_dev_err(dev, ...)  do { tcmu_err_message(dev, __func__, __LINE__, __VA_ARGS__);} while (0)
 #define tcmu_dev_warn(dev, ...) do { tcmu_warn_message(dev, __func__, __LINE__, __VA_ARGS__);} while (0)
 #define tcmu_dev_info(dev, ...) do { tcmu_info_message(dev, __func__, __LINE__, __VA_ARGS__);} while (0)
@@ -50,6 +54,7 @@ void tcmu_dbg_scsi_cmd_message(struct tcmu_device *dev, const char *funcname, in
 #define tcmu_dev_dbg_scsi_cmd(dev, ...)  do { tcmu_dbg_scsi_cmd_message(dev, __func__, __LINE__, __VA_ARGS__);} while (0)
 
 
+#define tcmu_crit(...) do { tcmu_crit_message(NULL, __func__, __LINE__, __VA_ARGS__);} while (0)
 #define tcmu_err(...)  do { tcmu_err_message(NULL, __func__, __LINE__, __VA_ARGS__);} while (0)
 #define tcmu_warn(...) do { tcmu_warn_message(NULL, __func__, __LINE__, __VA_ARGS__);} while (0)
 #define tcmu_info(...) do { tcmu_info_message(NULL, __func__, __LINE__, __VA_ARGS__);} while (0)

--- a/tcmu.conf
+++ b/tcmu.conf
@@ -1,7 +1,8 @@
 # Master TCMU configuration file
 
 # Logging Controls
-# There are 5 logging levels supported:
+# There are 6 logging levels supported:
+#    0: CRIT
 #    1: ERROR
 #    2: WARNING
 #    3: INFO


### PR DESCRIPTION
When changing the loglevel in the tcmu.conf for the dynamic logger,
we need to verify it is really working. Currently this hit log is
one INFO level message, which won't work in the ERR and WARN loglevel
cases.


Signed-off-by: Xiubo Li <xiubli@redhat.com>