### PR TITLE
cmake: drop rsyslog build time check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,6 @@ find_package(PkgConfig)
 pkg_check_modules(GLIB REQUIRED gio-unix-2.0)
 pkg_check_modules(KMOD REQUIRED libkmod)
 
-find_program(RSYSLOG rsyslogd)
-if (NOT RSYSLOG)
-  message(FATAL_ERROR "rsyslog not found!")
-endif ()
-
 find_library(PTHREAD pthread)
 find_library(DL dl)
 


### PR DESCRIPTION
rsyslog is a *runtime* dependency for the tcmu-runner systemd service.
It doesn't make sense to check for it at build time.

Signed-off-by: David Disseldorp <ddiss@suse.de>