### PR TITLE
format-security: fix snprintf usage

### DIFF
--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -172,9 +172,9 @@ do { \
 	memset(cfg->key, 0, sizeof(cfg->key)); \
 	if (!option) { \
 		option = tcmu_register_option(#key, TCMU_OPT_STR); \
-		snprintf(cfg->key, sizeof(cfg->key), cfg->def_##key); \
+		snprintf(cfg->key, sizeof(cfg->key), "%s", cfg->def_##key); \
 	} else { \
-		snprintf(cfg->key, sizeof(cfg->key), option->opt_str); \
+		snprintf(cfg->key, sizeof(cfg->key), "%s", option->opt_str); \
 		if (option->opt_str) \
 			free(option->opt_str); \
 	} \
@@ -479,7 +479,7 @@ struct tcmu_config* tcmu_initialize_config(void)
 	}
 
 	log_dir = getenv("TCMU_LOGDIR");
-	snprintf(cfg->def_log_dir, PATH_MAX, log_dir ? log_dir : TCMU_LOG_DIR_DEFAULT);
+	snprintf(cfg->def_log_dir, PATH_MAX, "%s", log_dir ? log_dir : TCMU_LOG_DIR_DEFAULT);
 	cfg->def_log_level = TCMU_CONF_LOG_INFO;
 
 	return cfg;

--- a/main.c
+++ b/main.c
@@ -1017,7 +1017,7 @@ int main(int argc, char **argv)
 			}
 			break;
 		case 'l':
-			snprintf(tcmu_cfg->def_log_dir, PATH_MAX, optarg);
+			snprintf(tcmu_cfg->def_log_dir, PATH_MAX, "%s", optarg);
 			break;
 		case 'f':
 			nr_files = atol(optarg);


### PR DESCRIPTION
Fixing compiler warnings for -Werror=format-security                             
                                                                                 
Warnings Example:                                                                
----------------                                                                 
                                                                                 
libtcmu_config.c: In function 'tcmu_conf_set_options':                           
libtcmu_config.c:196:21: error: format not a string literal and \                
                no format arguments [-Werror=format-security]                    
 TCMU_PARSE_CFG_STR(cfg, log_dir); 

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>