### PR TITLE
fix rbd: fix tcmu_rbd_get_lock_state get a bad 'state' pointer

### DIFF
--- a/main.c
+++ b/main.c
@@ -745,6 +745,10 @@ static int dev_added(struct tcmu_device *dev)
 	if (!rdev)
 		return -ENOMEM;
 
+        ret = pthread_spin_init(&rdev->ref_lock);
+        if (ret != 0)
+                goto free_rdev;
+
 	tcmu_dev_set_private(dev, rdev);
 	list_node_init(&rdev->recovery_entry);
 	rdev->dev = dev;

--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -425,6 +425,14 @@ void tcmu_update_dev_lock_state(struct tcmu_device *dev)
 	if (!rhandler->get_lock_state)
 		return;
 
+        pthread_mutex_lock(&rdev->state_lock);
+        if (rdev->flags != TCMUR_DEV_FLAG_IS_OPEN) {
+                pthread_mutex_unlock(&rdev->state_lock);
+                return ;
+        }
+
+       pthread_mutex_unlock(&rdev->state_lock);
+
 	state = rhandler->get_lock_state(dev);
 	pthread_mutex_lock(&rdev->state_lock);
 	if (rdev->lock_state == TCMUR_DEV_LOCK_LOCKED &&
@@ -435,6 +443,20 @@ void tcmu_update_dev_lock_state(struct tcmu_device *dev)
 	}
 	pthread_mutex_unlock(&rdev->state_lock);
 }
+
+
+void tcmur_dev_lock(struct tcmu_device *dev)
+{
+	struct tcmur_device *rdev = tcmu_dev_get_private(dev);
+        pthread_spin_lock(&rdev->ref_lock);
+}
+
+void tcmur_dev_unlock(struct tcmu_device *dev)
+{
+	struct tcmur_device *rdev = tcmu_dev_get_private(dev);
+        pthread_spin_unlock(&rdev->ref_lock);
+}
+
 
 void tcmur_dev_set_private(struct tcmu_device *dev, void *private)
 {

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -73,6 +73,7 @@ struct tcmur_device {
 
 	uint32_t format_progress;
 	pthread_mutex_t format_lock; /* for atomic format operations */
+        pthread_spinlock_t ref_lock;
 };
 
 bool tcmu_dev_in_recovery(struct tcmu_device *dev);
@@ -92,5 +93,6 @@ void tcmu_update_dev_lock_state(struct tcmu_device *dev);
 
 void tcmur_dev_set_private(struct tcmu_device *dev, void *private);
 void *tcmur_dev_get_private(struct tcmu_device *dev);
-
+void tcmur_dev_lock(struct tcmu_device *dev);
+void tcmur_dev_unlock(struct tcmu_device *dev);
 #endif


### PR DESCRIPTION

When  the recovery thread reopen a  librbd image,  during the `close` and `open` operation, 
if a inquiry command call `tcmu_update_dev_lock_state` ,  it will get  a bad `state` pointer which it already was free by `close` operation

Signed-off-by: qiwuqiang  <qiwuqiang@umcloud.com>
