### PR TITLE
Further tune libtcmu

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -573,6 +573,7 @@ static void glfs_async_cbk(glfs_fd_t *fd, ssize_t ret, void *data)
 	glfs_cbk_cookie *cookie = data;
 	struct tcmu_device *dev = cookie->dev;
 	struct tcmulib_cmd *cmd = cookie->cmd;
+	struct tcmur_cmd_state *rcmd_state = tcmu_cmd_get_private(cmd);
 	size_t length = cookie->length;
 
 	if (ret < 0 || ret != length) {
@@ -592,7 +593,7 @@ static void glfs_async_cbk(glfs_fd_t *fd, ssize_t ret, void *data)
 		ret = TCMU_STS_OK;
 	}
 
-	cmd->done(dev, cmd, ret);
+	rcmd_state->done(dev, cmd, ret);
 	free(cookie);
 }
 

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -956,7 +956,7 @@ struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev)
 			}
 
 			/* Alloc memory for cmd itself, iovec and cdb */
-			cmd = malloc(sizeof(*cmd) + sizeof(*cmd->iovec) * ent->req.iov_cnt + cdb_len);
+			cmd = calloc(1, sizeof(*cmd) + sizeof(*cmd->iovec) * ent->req.iov_cnt + cdb_len);
 			if (!cmd)
 				return NULL;
 			cmd->cmd_id = ent->hdr.cmd_id;

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -744,6 +744,16 @@ int tcmulib_master_fd_ready(struct tcmulib_context *ctx)
 	return nl_recvmsgs_default(ctx->nl_sock);
 }
 
+void *tcmu_cmd_get_private(struct tcmulib_cmd *cmd)
+{
+	return cmd->hm_private;
+}
+
+void tcmu_cmd_set_private(struct tcmulib_cmd *cmd, void *private)
+{
+	cmd->hm_private = private;
+}
+
 void *tcmu_dev_get_private(struct tcmu_device *dev)
 {
 	return dev->hm_private;

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -116,8 +116,6 @@ struct tcmulib_cmd {
 /* Set/Get methods for the opaque tcmu_device */
 void *tcmu_dev_get_private(struct tcmu_device *dev);
 void tcmu_dev_set_private(struct tcmu_device *dev, void *priv);
-void *tcmu_get_daemon_dev_private(struct tcmu_device *dev);
-void tcmu_set_daemon_dev_private(struct tcmu_device *dev, void *priv);
 int tcmu_dev_get_fd(struct tcmu_device *dev);
 char *tcmu_dev_get_cfgstring(struct tcmu_device *dev);
 void tcmu_dev_set_num_lbas(struct tcmu_device *dev, uint64_t num_lbas);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -94,8 +94,6 @@ enum {
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
-typedef void (*cmd_done_t)(struct tcmu_device *, struct tcmulib_cmd *, int);
-
 struct tcmulib_cmd {
 	uint16_t cmd_id;
 	uint8_t *cdb;
@@ -103,15 +101,11 @@ struct tcmulib_cmd {
 	size_t iov_cnt;
 	uint8_t sense_buf[SENSE_BUFFERSIZE];
 
-	/*
-	 * this is mostly used by compound operations as such operations
-	 * need to carry some state around for multiple commands.
-	 */
-	void *cmdstate;
-
-	/* callback to finish/continue command processing */
-	cmd_done_t done;
+	void *hm_private; /* private ptr for handler module */
 };
+
+void *tcmu_cmd_get_private(struct tcmulib_cmd *cmd);
+void tcmu_cmd_set_private(struct tcmulib_cmd *cmd, void *private);
 
 /* Set/Get methods for the opaque tcmu_device */
 void *tcmu_dev_get_private(struct tcmu_device *dev);

--- a/rbd.c
+++ b/rbd.c
@@ -1076,6 +1076,7 @@ static void rbd_finish_aio_generic(rbd_completion_t completion,
 {
 	struct tcmu_device *dev = aio_cb->dev;
 	struct tcmulib_cmd *tcmulib_cmd = aio_cb->tcmulib_cmd;
+	struct tcmur_cmd_state *rcmd_state = tcmu_cmd_get_private(tcmulib_cmd);
 	struct iovec *iov = aio_cb->iov;
 	size_t iov_cnt = aio_cb->iov_cnt;
 	uint32_t cmp_offset;
@@ -1115,7 +1116,7 @@ static void rbd_finish_aio_generic(rbd_completion_t completion,
 		}
 	}
 
-	tcmulib_cmd->done(dev, tcmulib_cmd, tcmu_r);
+	rcmd_state->done(dev, tcmulib_cmd, tcmu_r);
 
 	if (aio_cb->bounce_buffer)
 		free(aio_cb->bounce_buffer);

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -142,6 +142,19 @@ struct tcmur_handler {
 	bool _is_dbus_handler;
 };
 
+typedef void (*cmd_done_t)(struct tcmu_device *, struct tcmulib_cmd *, int);
+
+struct tcmur_cmd_state {
+        /*
+         * this is mostly used by compound operations as such operations
+         * need to carry some state around for multiple commands.
+         */
+        void *cmdstate;
+
+        /* callback to finish/continue command processing */
+        cmd_done_t done;
+};
+
 /*
  * Each tcmu-runner (tcmur) handler plugin must export the
  * following. It usually just calls tcmur_register_handler.

--- a/tcmur_aio.c
+++ b/tcmur_aio.c
@@ -146,6 +146,7 @@ static void *io_work_queue(void *arg)
 	while (1) {
 		struct tcmu_work *work;
 		struct tcmulib_cmd *cmd;
+		struct tcmur_cmd_state *rcmd_state;
 
 		pthread_cleanup_push(_cleanup_mutex_lock, &io_wq->io_lock);
 		pthread_mutex_lock(&io_wq->io_lock);
@@ -164,9 +165,10 @@ static void *io_work_queue(void *arg)
 
 		/* kick start I/O request */
 		cmd = work->cmd;
+		rcmd_state = tcmu_cmd_get_private(cmd);
 		pthread_cleanup_push(_cleanup_io_work, work);
 
-		cmd->done(dev, cmd,work->fn(work->dev, cmd));
+		rcmd_state->done(dev, cmd, work->fn(work->dev, cmd));
 
 		pthread_cleanup_pop(1); /* cleanup work */
 	}


### PR DESCRIPTION
This is one of the last TODO items from #498 which replaces cmdstate and done in tcmulib_cmd struct with a hm_private pointer. This patchset doesn't touch the access to tcmulib_cmd with helper functions part. 