### PR TITLE
Misc handler reopen fixes

### DIFF
--- a/alua.c
+++ b/alua.c
@@ -541,7 +541,7 @@ bool lock_is_required(struct tcmu_device *dev)
 static void *alua_lock_thread_fn(void *arg)
 {
 	/* TODO: set UA based on bgly's patches */
-	tcmu_acquire_dev_lock(arg, false, -1);
+	tcmu_acquire_dev_lock(arg, -1);
 	return NULL;
 }
 
@@ -641,7 +641,7 @@ static int tcmu_explicit_transition(struct list_head *group_list,
 			/* just change local state */
 			break;
 
-		ret = tcmu_acquire_dev_lock(dev, true, group->id);
+		ret = tcmu_acquire_dev_lock(dev, group->id);
 		if (ret == TCMU_STS_HW_ERR) {
 			return TCMU_STS_EXPL_TRANSITION_ERR;
 		} else if (ret) {

--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -455,7 +455,12 @@ static void *dyn_config_start(void *arg)
 
 int tcmu_watch_config(struct tcmu_config *cfg)
 {
-	return pthread_create(&cfg->thread_id, NULL, dyn_config_start, cfg);
+	int ret;
+
+	ret = pthread_create(&cfg->thread_id, NULL, dyn_config_start, cfg);
+	if (ret)
+		return -ret;
+	return 0;
 }
 
 void tcmu_unwatch_config(struct tcmu_config *cfg)

--- a/main.c
+++ b/main.c
@@ -602,6 +602,8 @@ static void tcmur_stop_device(void *arg)
 	tcmu_cancel_lock_thread(dev);
 	tcmu_cancel_recovery(dev);
 
+	tcmu_release_dev_lock(dev);
+
 	pthread_mutex_lock(&rdev->state_lock);
 	if (rdev->flags & TCMUR_DEV_FLAG_IS_OPEN) {
 		rdev->flags &= ~TCMUR_DEV_FLAG_IS_OPEN;
@@ -609,10 +611,8 @@ static void tcmur_stop_device(void *arg)
 	}
 	pthread_mutex_unlock(&rdev->state_lock);
 
-	if (is_open) {
-		tcmu_release_dev_lock(dev);
+	if (is_open)
 		rhandler->close(dev);
-	}
 
 	pthread_mutex_lock(&rdev->state_lock);
 	rdev->flags |= TCMUR_DEV_FLAG_STOPPED;

--- a/main.c
+++ b/main.c
@@ -800,20 +800,28 @@ static int dev_added(struct tcmu_device *dev)
 		     block_size, dev_size);
 
 	ret = pthread_spin_init(&rdev->lock, 0);
-	if (ret != 0)
+	if (ret) {
+		ret = -ret;
 		goto free_rdev;
+	}
 
 	ret = pthread_mutex_init(&rdev->caw_lock, NULL);
-	if (ret != 0)
+	if (ret) {
+		ret = -ret;
 		goto cleanup_dev_lock;
+	}
 
 	ret = pthread_mutex_init(&rdev->format_lock, NULL);
-	if (ret != 0)
+	if (ret) {
+		ret = -ret;
 		goto cleanup_caw_lock;
+	}
 
 	ret = pthread_mutex_init(&rdev->state_lock, NULL);
-	if (ret != 0)
+	if (ret) {
+		ret = -ret;
 		goto cleanup_format_lock;
+	}
 
 	ret = setup_io_work_queue(dev);
 	if (ret < 0)
@@ -837,13 +845,17 @@ static int dev_added(struct tcmu_device *dev)
 	rdev->flags |= TCMUR_DEV_FLAG_IS_OPEN;
 
 	ret = pthread_cond_init(&rdev->lock_cond, NULL);
-	if (ret < 0)
+	if (ret) {
+		ret = -ret;
 		goto close_dev;
+	}
 
 	ret = pthread_create(&rdev->cmdproc_thread, NULL, tcmur_cmdproc_thread,
 			     dev);
-	if (ret < 0)
+	if (ret) {
+		ret = -ret;
 		goto cleanup_lock_cond;
+	}
 
 	return 0;
 

--- a/target.c
+++ b/target.c
@@ -251,7 +251,7 @@ done:
 	 */
 	list_for_each_safe(&tpg->devs, rdev, tmp_rdev, recovery_entry) {
 		list_del(&rdev->recovery_entry);
-		ret = __tcmu_reopen_dev(rdev->dev, false, -1);
+		ret = __tcmu_reopen_dev(rdev->dev, -1);
 		if (ret) {
 			tcmu_dev_err(rdev->dev, "Could not reinitialize device. (err %d).\n",
 				     ret);

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -786,6 +786,9 @@ int tcmur_handle_writesame(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
 	int ret;
 
+	if (tcmu_dev_in_recovery(dev))
+		return TCMU_STS_BUSY;
+
 	ret = alua_check_state(dev, cmd);
 	if (ret)
 		return ret;
@@ -1809,6 +1812,9 @@ int tcmur_handle_caw(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	int ret;
 	uint8_t sectors = cmd->cdb[13];
 
+	if (tcmu_dev_in_recovery(dev))
+		return TCMU_STS_BUSY;
+
 	/* From sbc4r12a section 5.3 COMPARE AND WRITE command
 	 * A NUMBER OF LOGICAL BLOCKS field set to zero specifies that no
 	 * read operations shall be performed, no logical block data shall
@@ -2408,12 +2414,7 @@ static int handle_try_passthrough(struct tcmu_device *dev,
 
 	track_aio_request_start(rdev);
 
-	if (tcmu_dev_in_recovery(dev)) {
-		ret = TCMU_STS_BUSY;
-	} else {
-		ret = rhandler->handle_cmd(dev, cmd);
-	}
-
+	ret = rhandler->handle_cmd(dev, cmd);
 	if (ret != TCMU_STS_ASYNC_HANDLED)
 		track_aio_request_finish(rdev, NULL);
 

--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -363,8 +363,7 @@ retry:
 	return ret;
 }
 
-int tcmu_acquire_dev_lock(struct tcmu_device *dev, bool is_sync,
-			  uint16_t tag)
+int tcmu_acquire_dev_lock(struct tcmu_device *dev, uint16_t tag)
 {
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
 	struct tcmur_device *rdev = tcmu_dev_get_private(dev);
@@ -428,7 +427,7 @@ done:
 	 * the aio handler. For explicit ALUA, we execute the lock call from
 	 * the main io processing thread, so we only flush here for implicit.
 	 */
-	if (!is_sync)
+	if (pthread_self() != rdev->cmdproc_thread)
 		tcmu_dev_flush_ring(dev);
 
 	/* TODO: set UA based on bgly's patches */

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -82,8 +82,8 @@ int tcmu_cancel_lock_thread(struct tcmu_device *dev);
 void tcmu_notify_conn_lost(struct tcmu_device *dev);
 void tcmu_notify_lock_lost(struct tcmu_device *dev);
 
-int __tcmu_reopen_dev(struct tcmu_device *dev, bool in_lock_thread, int retries);
-int tcmu_reopen_dev(struct tcmu_device *dev, bool in_lock_thread, int retries);
+int __tcmu_reopen_dev(struct tcmu_device *dev, int retries);
+int tcmu_reopen_dev(struct tcmu_device *dev, int retries);
 
 int tcmu_acquire_dev_lock(struct tcmu_device *dev, bool is_sync, uint16_t tag);
 void tcmu_release_dev_lock(struct tcmu_device *dev);

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -85,7 +85,7 @@ void tcmu_notify_lock_lost(struct tcmu_device *dev);
 int __tcmu_reopen_dev(struct tcmu_device *dev, int retries);
 int tcmu_reopen_dev(struct tcmu_device *dev, int retries);
 
-int tcmu_acquire_dev_lock(struct tcmu_device *dev, bool is_sync, uint16_t tag);
+int tcmu_acquire_dev_lock(struct tcmu_device *dev, uint16_t tag);
 void tcmu_release_dev_lock(struct tcmu_device *dev);
 int tcmu_get_lock_tag(struct tcmu_device *dev, uint16_t *tag);
 void tcmu_update_dev_lock_state(struct tcmu_device *dev);


### PR DESCRIPTION
This patchset fixes a couple bugs in the reopen code path.

1. Accessing freed tcmur_dev_get_private when close has been done but open has not completed.
2. Initiator probe commands are failed during reopening/locking so paths are not automatically added.
3. Misc fixes for pthread function error handling and cleanups