### PR TITLE
rpm: use valid short name licenses in License field

### DIFF
--- a/tcmu-runner.spec
+++ b/tcmu-runner.spec
@@ -30,7 +30,7 @@
 Name:          tcmu-runner
 Summary:       A daemon that handles the userspace side of the LIO TCM-User backstore
 Group:         System Environment/Daemons
-License:       Apache 2.0 or LGPLv2.1
+License:       ASL 2.0 or LGPLv2+
 Version:       1.4.0
 URL:           https://github.com/open-iscsi/tcmu-runner
 


### PR DESCRIPTION
Fedora has a list of valid "short names" to use in the License field.

From https://fedoraproject.org/wiki/Licensing:Main :

Apache 2.0 should be "ASL 2.0"

LGPLv2.1 or greater should be "LGPLv2+"