### PR TITLE
log: list the number of pending cmds for each device

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(tcmu
   libtcmu_log.c
   libtcmu_config.c
   libtcmu_time.c
+  libtcmu_timer.c
   )
 set_target_properties(tcmu
   PROPERTIES
@@ -75,6 +76,7 @@ add_library(tcmu_static
   libtcmu_log.c
   libtcmu_config.c
   libtcmu_time.c
+  libtcmu_timer.c
   )
 target_include_directories(tcmu_static
   PUBLIC ${LIBNL_INCLUDE_DIR}

--- a/ccan/ccan/list/list.h
+++ b/ccan/ccan/list/list.h
@@ -306,6 +306,58 @@ static inline bool list_empty_nocheck(const struct list_head *h)
 	return h->n.next == &h->n;
 }
 
+static inline void __list_splice(struct list_head *list, struct list_head *head)
+{
+    list->n.prev->next = head->n.next;
+    head->n.next->prev = list->n.prev;
+
+    head->n.next = list->n.next;
+    list->n.next->prev = &head->n;
+}
+
+static inline void
+list_splice(struct list_head *list, struct list_head *head)
+{
+    if (list_empty(list))
+        return;
+
+    __list_splice(list, head);
+}
+
+/* Splice moves @list to the head of the list at @head. */
+static inline void
+list_splice_init(struct list_head *list, struct list_head *head)
+{
+    if (list_empty(list))
+        return;
+
+    __list_splice(list, head);
+    list_head_init(list);
+}
+
+/**
+ * list_replace - replace old entry by new one
+ * @old : the element to be replaced
+ * @new : the new element to insert
+ *
+ * If @old was empty, it will be overwritten.
+ */
+static inline void
+list_replace(struct list_head *old, struct list_head *new)
+{
+    new->n.next = old->n.next;
+    new->n.next->prev = &new->n;
+    new->n.prev = old->n.prev;
+    new->n.prev->next = &new->n;
+}
+
+static inline void
+list_replace_init(struct list_head *old, struct list_head *new)
+{
+    list_replace(old, new);
+    list_head_init(old);
+}
+
 /**
  * list_del - delete an entry from an (unknown) linked list.
  * @n: the list_node to delete from the list.

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -111,6 +111,10 @@ struct tcmulib_cmd {
 
 	/* callback to finish/continue command processing */
 	cmd_done_t done;
+
+	struct tcmu_device *dev;
+	struct tcmu_timer *timer;
+	uint16_t timeout;
 };
 
 /* Set/Get methods for the opaque tcmu_device */

--- a/libtcmu_log.h
+++ b/libtcmu_log.h
@@ -26,6 +26,9 @@
 
 struct tcmu_device;
 struct tcmu_config;
+extern struct list_head pending_cmds_head;
+extern pthread_cond_t pending_cmds_cond;
+extern pthread_mutex_t pending_cmds_lock;
 
 void tcmu_set_log_level(int level);
 unsigned int tcmu_get_log_level(void);
@@ -50,6 +53,7 @@ void tcmu_dbg_scsi_cmd_message(struct tcmu_device *dev, const char *funcname, in
 #define tcmu_dev_crit(dev, ...)  do { tcmu_crit_message(dev, __func__, __LINE__, __VA_ARGS__);} while (0)
 #define tcmu_dev_err(dev, ...)  do { tcmu_err_message(dev, __func__, __LINE__, __VA_ARGS__);} while (0)
 #define tcmu_dev_warn(dev, ...) do { tcmu_warn_message(dev, __func__, __LINE__, __VA_ARGS__);} while (0)
+#define tcmu_dev_warn_simple(dev, ...) do { tcmu_warn_message(dev, NULL, 0, __VA_ARGS__);} while (0)
 #define tcmu_dev_info(dev, ...) do { tcmu_info_message(dev, __func__, __LINE__, __VA_ARGS__);} while (0)
 #define tcmu_dev_dbg(dev, ...)  do { tcmu_dbg_message(dev, __func__, __LINE__, __VA_ARGS__);} while (0)
 #define tcmu_dev_dbg_scsi_cmd(dev, ...)  do { tcmu_dbg_scsi_cmd_message(dev, __func__, __LINE__, __VA_ARGS__);} while (0)

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -20,6 +20,7 @@
 #include <pthread.h>
 
 #include "darray.h"
+#include "ccan/list/list.h"
 
 #define KERN_IFACE_VER 2
 
@@ -34,6 +35,15 @@ struct tcmulib_context {
 
 	GDBusConnection *connection;
 };
+
+#define	CMD_TO_30SEC	30
+#define	CMD_TO_60SEC	60
+#define	CMD_TO_90SEC	90
+#define	CMD_TO_120SEC	120
+#define	CMD_TO_150SEC	150
+#define	CMD_TO_180SEC	180
+#define	CMD_TO_STEP	30
+#define	CMD_TO_COUNT	6
 
 struct tcmu_device {
 	int fd;
@@ -62,6 +72,9 @@ struct tcmu_device {
 
 	struct tcmulib_handler *handler;
 	struct tcmulib_context *ctx;
+
+	uint64_t timeout_cmds[CMD_TO_COUNT];
+	struct list_node entry;
 
 	void *hm_private; /* private ptr for handler module */
 };

--- a/libtcmu_timer.c
+++ b/libtcmu_timer.c
@@ -1,0 +1,367 @@
+/*
+ * tcmu timer wheel
+ *
+ * Copyright (C) 1991, 1992  Linus Torvalds
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * This file is licensed to you under your choice of the GNU Lesser
+ * General Public License, version 2.1 or any later version (LGPLv2.1 or
+ * later), or the Apache License 2.0.
+ *
+ * Most of the code is from glusterfs project and which is from Linux
+ * kernel's internal timer wheel driver.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <errno.h>
+
+#include "libtcmu_timer.h"
+#include "tcmu-runner.h"
+
+#define TVR_BITS  8
+#define TVN_BITS  6
+#define TVR_SIZE  (1 << TVR_BITS)
+#define TVN_SIZE  (1 << TVN_BITS)
+#define TVR_MASK  (TVR_SIZE - 1)
+#define TVN_MASK  (TVN_SIZE - 1)
+
+#define BITS_PER_LONG  64
+
+struct tvec {
+	struct list_head vec[TVN_SIZE];
+};
+
+struct tvec_root {
+	struct list_head vec[TVR_SIZE];
+};
+
+struct tvec_base {
+	pthread_t runner;             /* run_timer() */
+
+	unsigned long timer_sec;      /* time counter */
+
+	struct tvec_root tv1;
+	struct tvec tv2;
+	struct tvec tv3;
+	struct tvec tv4;
+	struct tvec tv5;
+};
+
+static struct tvec_base *timer_base;
+static pthread_spinlock_t timer_base_lock;      /* base lock */
+
+static inline void __tcmu_add_timer (struct tcmu_timer *timer)
+{
+	int i;
+	unsigned long idx;
+	unsigned long expires;
+	struct list_head *vec;
+
+	expires = timer->expires;
+
+	idx = expires - timer_base->timer_sec;
+
+	if (idx < TVR_SIZE) {
+		i = expires & TVR_MASK;
+		vec = timer_base->tv1.vec + i;
+	} else if (idx < 1 << (TVR_BITS + TVN_BITS)) {
+		i = (expires >> TVR_BITS) & TVN_MASK;
+		vec = timer_base->tv2.vec + i;
+	} else if (idx < 1 << (TVR_BITS + 2*TVN_BITS)) {
+		i = (expires >> (TVR_BITS + TVN_BITS)) & TVN_MASK;
+		vec = timer_base->tv3.vec + i;
+	} else if (idx < 1 << (TVR_BITS + 3*TVN_BITS)) {
+		i = (expires >> (TVR_BITS + 2*TVN_BITS)) & TVN_MASK;
+		vec = timer_base->tv4.vec + i;
+	} else if (idx < 0) {
+		vec = timer_base->tv1.vec + (timer_base->timer_sec & TVR_MASK);
+	} else {
+		i = (expires >> (TVR_BITS + 3*TVN_BITS)) & TVN_MASK;
+		vec = timer_base->tv5.vec + i;
+	}
+
+	list_add_tail(vec, &timer->entry);
+}
+
+static inline unsigned long tcmu_fls(unsigned long word)
+{
+	return BITS_PER_LONG - __builtin_clzl(word);
+}
+
+static inline unsigned long apply_slack(struct tcmu_timer *timer)
+{
+	long delta;
+	unsigned long mask, expires, expires_limit;
+	int bit;
+
+	expires = timer->expires;
+
+	delta = expires - timer_base->timer_sec;
+	if (delta < 256)
+		return expires;
+
+	expires_limit = expires + delta / 256;
+	mask = expires ^ expires_limit;
+	if (mask == 0)
+		return expires;
+
+	bit = tcmu_fls(mask);
+	mask = (1UL << bit) - 1;
+
+	expires_limit = expires_limit & ~(mask);
+	return expires_limit;
+}
+
+static inline int cascade(struct tvec *tv, int index)
+{
+	struct tcmu_timer *timer, *tmp;
+	struct list_head tv_list;
+
+	list_replace_init(tv->vec + index, &tv_list);
+
+	list_for_each_safe(&tv_list, tmp, timer, entry) {
+		__tcmu_add_timer(timer);
+	}
+
+	return index;
+}
+
+#define INDEX(N)  ((timer_base->timer_sec >> (TVR_BITS + N * TVN_BITS)) & TVN_MASK)
+
+/**
+ * run expired timers
+ */
+static inline void run_timers(void)
+{
+	unsigned long index;
+	struct tcmu_timer *timer;
+	struct list_head work_list;
+	struct list_head *head = &work_list;
+
+	pthread_spin_lock(&timer_base_lock);
+
+	index  = timer_base->timer_sec & TVR_MASK;
+
+	if (!index && (!cascade(&timer_base->tv2, INDEX(0))) &&
+			(!cascade(&timer_base->tv3, INDEX(1))) &&
+			(!cascade(&timer_base->tv4, INDEX(2))))
+		cascade(&timer_base->tv5, INDEX(3));
+
+	timer_base->timer_sec++;
+	list_replace_init(timer_base->tv1.vec + index, head);
+	while (!list_empty(head)) {
+		void (*fn)(struct tcmu_timer *, void *);
+		void *data;
+
+		timer = list_first_entry(head, struct tcmu_timer, entry);
+		fn = timer->function;
+		data = timer->data;
+
+		list_del_init(&timer->entry);
+		pthread_spin_unlock(&timer_base_lock);
+		fn(timer, data);
+		pthread_spin_lock(&timer_base_lock);
+	}
+
+	pthread_spin_unlock(&timer_base_lock);
+}
+
+void *runner(void *arg)
+{
+	struct timeval tv = {0,};
+
+	while(1) {
+		run_timers();
+
+		tv.tv_sec = 1;
+		tv.tv_usec = 0;
+		select(0, NULL, NULL, NULL, &tv);
+	}
+
+	return NULL;
+}
+
+static inline int timer_pending(struct tcmu_timer *timer)
+{
+	struct list_node *entry = &timer->entry;
+
+	return entry->next != entry;
+}
+
+static inline int __detach_if_pending(struct tcmu_timer *timer)
+{
+	if (!timer_pending(timer))
+		return 0;
+
+	list_del_init(&timer->entry);
+	return 1;
+}
+
+static inline int __mod_timer(struct tcmu_timer *timer, int pending_only)
+{
+	int ret = 0;
+
+	ret = __detach_if_pending(timer);
+	if (!ret && pending_only)
+		goto done;
+
+	ret = 1;
+	__tcmu_add_timer(timer);
+
+done:
+	return ret;
+}
+
+/* interface */
+
+/**
+ * Add a timer in the timer wheel
+ */
+int tcmu_add_timer(struct tcmu_timer *timer)
+{
+	pthread_spin_lock(&timer_base_lock);
+
+	timer->expires += timer_base->timer_sec;
+	timer->expires = apply_slack(timer);
+	__tcmu_add_timer(timer);
+
+	pthread_spin_unlock(&timer_base_lock);
+
+	return 0;
+}
+
+/**
+ * Remove a timer from the timer wheel
+ */
+int tcmu_del_timer(struct tcmu_timer *timer)
+{
+	int ret = 0;
+
+	pthread_spin_lock(&timer_base_lock);
+
+	if (timer_pending(timer)) {
+		ret = 1;
+		list_del_init(&timer->entry);
+	}
+
+	pthread_spin_unlock(&timer_base_lock);
+
+	return ret;
+}
+
+int tcmu_mod_timer_pending(struct tcmu_timer *timer,
+		unsigned long expires)
+{
+	int ret = 1;
+
+	pthread_spin_lock(&timer_base_lock);
+
+	timer->expires = expires + timer_base->timer_sec;
+	timer->expires = apply_slack(timer);
+	ret = __mod_timer(timer, 1);
+
+	pthread_spin_unlock(&timer_base_lock);
+
+	return ret;
+}
+
+int tcmu_mod_timer(struct tcmu_timer *timer, unsigned long expires)
+{
+	int ret = 1;
+
+	pthread_spin_lock (&timer_base_lock);
+
+	/* fast path optimization */
+	if (timer_pending(timer) && timer->expires == expires)
+		goto unblock;
+
+	timer->expires = expires + timer_base->timer_sec;
+	timer->expires = apply_slack(timer);
+
+	ret = __mod_timer(timer, 0);
+
+unblock:
+	pthread_spin_unlock(&timer_base_lock);
+
+	return ret;
+}
+
+void tcmu_cleanup_timer_base(void)
+{
+	int ret = 0;
+
+	pthread_spin_lock(&timer_base_lock);
+	if (!timer_base)
+		goto unlock;
+
+	tcmu_thread_cancel(timer_base->runner);
+
+	/* destroy lock */
+	if (pthread_spin_destroy(&timer_base_lock) != 0)
+		tcmu_err("could not cleanup mailbox lock %d\n", ret);
+
+	/* deallocated timer timer_base */
+	free(timer_base);
+unlock:
+	pthread_spin_unlock(&timer_base_lock);
+}
+
+/**
+ * Initialize various timer wheel lists and spawn a thread that
+ * invokes run_timers()
+ */
+int tcmu_init_timer_base(void)
+{
+	struct timeval tv = {0,};
+	int ret = 0;
+	int i = 0;
+
+	if (timer_base) {
+		tcmu_warn("The timer is already initialized!\n");
+		return 0;
+	}
+
+	timer_base = malloc(sizeof(*timer_base));
+	if (!timer_base) {
+		tcmu_err("malloc timer_base failed!\n");
+		return -ENOMEM;
+	}
+
+	ret = pthread_spin_init(&timer_base_lock, 0);
+	if (ret != 0)
+		goto free_base;
+
+	for (i = 0; i < TVN_SIZE; i++) {
+		list_head_init(timer_base->tv5.vec + i);
+		list_head_init(timer_base->tv4.vec + i);
+		list_head_init(timer_base->tv3.vec + i);
+		list_head_init(timer_base->tv2.vec + i);
+	}
+
+	for (i = 0; i < TVR_SIZE; i++) {
+		list_head_init(timer_base->tv1.vec + i);
+	}
+
+	ret = gettimeofday(&tv, 0);
+	if (ret < 0)
+		goto destroy_lock;
+	timer_base->timer_sec = tv.tv_sec;
+
+	ret = pthread_create(&timer_base->runner, NULL, runner, timer_base);
+	if (ret != 0)
+		goto destroy_lock;
+
+	return 0;
+
+destroy_lock:
+	pthread_spin_destroy(&timer_base_lock);
+free_base:
+	free(timer_base);
+	return ret;
+}

--- a/libtcmu_timer.h
+++ b/libtcmu_timer.h
@@ -1,0 +1,33 @@
+/*
+ * tcmu timer wheel
+ *
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * This file is licensed to you under your choice of the GNU Lesser
+ * General Public License, version 2.1 or any later version (LGPLv2.1 or
+ * later), or the Apache License 2.0.
+ */
+
+#ifndef __LIBTCMU_TIMER_H
+#define __LIBTCMU_TIMER_H
+
+#include <pthread.h>
+#include "ccan/list/list.h"
+
+struct tcmu_timer {
+        void *data;
+        unsigned long expires;
+
+        void (*function)(struct tcmu_timer *, void *);
+
+        struct list_node entry;
+};
+
+int tcmu_init_timer_base(void);
+void tcmu_cleanup_timer_base(void);
+int tcmu_add_timer(struct tcmu_timer *);
+int tcmu_del_timer(struct tcmu_timer *);
+int tcmu_mod_timer_pending(struct tcmu_timer *, unsigned long);
+int tcmu_mod_timer(struct tcmu_timer *, unsigned long);
+
+#endif

--- a/main.c
+++ b/main.c
@@ -47,6 +47,7 @@
 #include "version.h"
 #include "libtcmu_config.h"
 #include "libtcmu_log.h"
+#include "libtcmu_timer.h"
 
 #define TCMU_LOCK_FILE   "/run/tcmu.lock"
 
@@ -1022,6 +1023,12 @@ int main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
+	ret = tcmu_init_timer_base();
+	if (ret) {
+		tcmu_err("failed to init tcmu timer base!\n");
+		exit(1);
+	}
+
 	while (1) {
 		int option_index = 0;
 		int c, nr_files;
@@ -1234,6 +1241,8 @@ free_config:
 	tcmu_free_config(tcmu_cfg);
 	if (new_path)
 		free(handler_path);
+
+	tcmu_cleanup_timer_base();
 
 	if (ret)
 		exit(EXIT_FAILURE);

--- a/tcmur_cmd_handler.h
+++ b/tcmur_cmd_handler.h
@@ -31,5 +31,6 @@ typedef int (*tcmur_caw_fn_t)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
                               size_t iov_cnt);
 int tcmur_handle_caw(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
                      tcmur_caw_fn_t caw_fn);
+void tcmur_cmd_timeout(struct tcmu_timer *timer, void *data);
 
 #endif /* __TCMUR_CMD_HANDLER_H */


### PR DESCRIPTION
Currently we have hit the problem that tcmu-runner couldn't get any
response from the gluster backend for many times in the product, and
there is no any explict evidence from the logs.

This patch will add one timer for each cmd and will record the number
pending cmds for each tcmu device in 5/10/15/20/25/30+ seconds.