### PR TITLE
rpm: remove %defattr

### DIFF
--- a/tcmu-runner.spec
+++ b/tcmu-runner.spec
@@ -120,7 +120,6 @@ Development header(s) for developing against libtcmu.
 %{__rm} -rf %{buildroot}
 
 %files
-%defattr(-,root,root)
 %{_bindir}/tcmu-runner
 %dir %{_sysconfdir}/dbus-1/
 %dir %{_sysconfdir}/dbus-1/system.d


### PR DESCRIPTION
RHEL 4's RPM was the last version to require this.