### PR TITLE
runner:fix the ret when reopen dev failed in cmd stpg

### DIFF
--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -393,8 +393,7 @@ retry:
 		if (ret) {
 			tcmu_dev_err(dev, "Could not reopen device while taking lock. Err %d.\n",
 				     ret);
-			/* We were fenced and were not able to clear it. */
-			ret = TCMU_STS_FENCED;
+			ret = TCMU_STS_TIMEOUT;
 			goto drop_conn;
 		}
 	}


### PR DESCRIPTION
if the device with the successful close()
but failed open() in tcmu_acquire_dev_lock,after
the cmd stpg failed,the device will never reopen
again。so change the ret from TCMU_STS_FENCED to
TCMU_STS_TIMEOUT,let the device into the recovery
list.

Signed-off-by: 李明辉10144360 <li.minghui7@zte.com.cn>