### PR TITLE
Add method to query whether OOOC is supported

### DIFF
--- a/libtcmu.c
+++ b/libtcmu.c
@@ -381,7 +381,8 @@ void tcmu_dev_flush_ring(struct tcmu_device *dev)
 	tcmu_dev_dbg(dev, "ring clear\n");
 }
 
-bool tcmu_dev_oooc_supported(struct tcmu_device* dev) {
+bool tcmu_dev_oooc_supported(struct tcmu_device* dev)
+{
 	return dev->map->flags & TCMU_MAILBOX_FLAG_CAP_OOOC;
 }
 

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -381,6 +381,10 @@ void tcmu_dev_flush_ring(struct tcmu_device *dev)
 	tcmu_dev_dbg(dev, "ring clear\n");
 }
 
+bool tcmu_dev_oooc_supported(struct tcmu_device* dev) {
+	return dev->map->flags & TCMU_MAILBOX_FLAG_CAP_OOOC;
+}
+
 static int add_device(struct tcmulib_context *ctx, char *dev_name,
 		      char *cfgstring, bool reopen)
 {

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -143,6 +143,7 @@ void tcmu_dev_set_unmap_enabled(struct tcmu_device *dev, bool enabled);
 bool tcmu_dev_get_unmap_enabled(struct tcmu_device *dev);
 struct tcmulib_handler *tcmu_dev_get_handler(struct tcmu_device *dev);
 void tcmu_dev_flush_ring(struct tcmu_device *dev);
+bool tcmu_dev_oooc_supported(struct tcmu_device* dev);
 
 /* Set/Get methods for interacting with configfs */
 char *tcmu_cfgfs_get_str(const char *path);


### PR DESCRIPTION
It's useful for users of libtcmu to be able to query at runtime whether or not the kernel supports out-of-order command (OOOC) completion as this has an impact on how handlers may service SCSI commands. Looking at the kernel version or module version of `target_core_user` is painful as it requires knowing exactly which versions support OOOC, some older kernel modules have the OOOC changes back-ported for example. 

In this commit:
* Expose a new method `tcmu_dev_oooc_supported()` which looks at the mailbox flags to determine whether OOOC is supported.