### PR TITLE
glfs: retry 5 times to wait the meta data updated successfully

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -672,9 +672,11 @@ static int tcmu_glfs_reconfig(struct tcmu_device *dev,
 	struct glfs_state *gfsp = tcmur_dev_get_private(dev);
 	struct stat st;
 	int ret = -EIO;
+	int retry = 0;
 
 	switch (cfg->type) {
 	case TCMULIB_CFG_DEV_SIZE:
+retry:
 		ret = glfs_lstat(gfsp->fs, gfsp->hosts->path, &st);
 		if (ret) {
 			tcmu_dev_warn(dev, "glfs_lstat failed: %m\n");
@@ -683,6 +685,15 @@ static int tcmu_glfs_reconfig(struct tcmu_device *dev,
 			/* Let the targetcli command return success */
 			ret = 0;
 		} else if (st.st_size != cfg->data.dev_size) {
+			/*
+			 * Retry 5 times to make sure that the size has been
+			 * successfully updated.
+			 */
+			if (retry++ < 5) {
+				sleep (1);
+				goto retry;
+			}
+
 			tcmu_dev_err(dev,
 				     "device size and backing size disagree: device %"PRId64" backing %lld\n",
 				     cfg->data.dev_size, (long long) st.st_size);


### PR DESCRIPTION
For the 'gluster-block modify' we can hit one issue in the same
client with multi-precesses, here is the gluster-blockd and
tcmu-runner.

We do glfs_ftruncate in gluster-blockd to resize the volume file
and then in tcmu-runner to check the size by using the glfs_lstat
but get the old size, which hasn't been updated yet.

But from the mountpoint's ls command, we can see that the size is
already upated to new one.

Here we will went to wait for most 5 seconds and retry 5 times to
make sure the cache has been flushed successfully to the volume.

Fixes: https://github.com/gluster/gluster-block/issues/204
Signed-off-by: Xiubo Li <xiubli@redhat.com>