### PR TITLE
logrotate: fix duplicate log entry error

### DIFF
--- a/logrotate.conf_install.cmake.in
+++ b/logrotate.conf_install.cmake.in
@@ -1,4 +1,4 @@
 if (EXISTS "/etc/logrotate.d/tcmu-runner")
-	file(INSTALL "/etc/logrotate.d/tcmu-runner" DESTINATION "/etc/logrotate.d" RENAME "tcmu-runner.old")
+	file(INSTALL "/etc/logrotate.d/tcmu-runner" DESTINATION "/etc/logrotate.d/tcmu-runner.bak" RENAME "tcmu-runner")
 endif()
 file(INSTALL "${PROJECT_SOURCE_DIR}/logrotate.conf" DESTINATION "/etc/logrotate.d" RENAME "tcmu-runner")


### PR DESCRIPTION
/etc/cron.daily/logrotate:

error: tcmu-runner.old:1 duplicate log entry for /var/log/tcmu-runner-glfs.log
error: tcmu-runner.old:1 duplicate log entry for /var/log/tcmu-runner.log

Signed-off-by: Xiubo Li <xiubli@redhat.com>