### PR TITLE
lock: create the lock directory when it is not exist

### DIFF
--- a/main.c
+++ b/main.c
@@ -48,7 +48,7 @@
 #include "libtcmu_config.h"
 #include "libtcmu_log.h"
 
-# define TCMU_LOCK_FILE   "/var/run/lock/tcmu.lock"
+#define TCMU_LOCK_FILE   "/run/tcmu.lock"
 
 static char *handler_path = DEFAULT_HANDLER_PATH;
 


### PR DESCRIPTION
We are hiting the following errors when the lock dir is
not exist:

2019-05-10 05:45:51.186 348 [CRIT] main:981: Starting...
2019-05-10 05:45:51.186 348 [ERROR] main:985: creat(/var/run/lock/tcmu.lock) failed: [No such file or directory]

Signed-off-by: Xiubo Li <xiubli@redhat.com>