### PR TITLE
Optionally link against tcmalloc for improved small IO performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(with-qcow "build qcow handler" true)
 option(with-rbd "build Ceph rbd handler" true)
 option(with-zbc "build zbc handler" true)
 option(with-fbo "build fbo handler" true)
+option(with-tcmalloc "link against tcmalloc" true)
 
 find_library(LIBNL_LIB nl-3)
 find_library(LIBNL_GENL_LIB nl-genl-3)
@@ -34,6 +35,10 @@ pkg_check_modules(KMOD REQUIRED libkmod)
 
 find_library(PTHREAD pthread)
 find_library(DL dl)
+
+if (with-tcmalloc)
+  find_library(TCMALLOC_LIB tcmalloc)
+endif(with-tcmalloc)
 
 # Stuff for building the shared library
 add_library(tcmu
@@ -108,6 +113,7 @@ target_link_libraries(tcmu-runner
   ${PTHREAD}
   ${DL}
   ${KMOD_LIBRARIES}
+  ${TCMALLOC_LIB}
   -Wl,--no-export-dynamic
   -Wl,--dynamic-list=${CMAKE_SOURCE_DIR}/main-syms.txt
   )

--- a/tcmu-runner.spec
+++ b/tcmu-runner.spec
@@ -25,6 +25,10 @@
 # rpmbuild -ta @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz --without fbo
 %{?_without_fbo:%global _without_fbo -Dwith-fbo=false}
 
+# without tcmalloc dependency
+# if you wish to exclude tcmalloc, use below command
+# rpmbuild -ta @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.gz --without tcmalloc
+%{?_without_tcmalloc:%global _without_tcmalloc -Dwith-tcmalloc=false}
 
 
 Name:          tcmu-runner
@@ -51,6 +55,11 @@ Requires(pre): librados2, librbd1
 %if ( 0%{!?_without_glfs:1} )
 BuildRequires: glusterfs-api-devel
 Requires(pre): glusterfs-api
+%endif
+
+%if 0%{!?_without_tcmalloc:1}
+BuildRequires: gperftools-devel
+Requires:      gperftools-libs
 %endif
 
 Requires(pre): kmod, zlib, libnl3, glib2, logrotate, rsyslog


### PR DESCRIPTION
Under high-throughput, small IO size workloads, librbd can see up to a
20% performance increase when using tcmalloc instead of the default
glibc allocator.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>