### PR TITLE
tcmu: Fix rpm build with existing logrotate tcmu directory

### DIFF
--- a/tcmu-runner.spec
+++ b/tcmu-runner.spec
@@ -141,6 +141,7 @@ Development header(s) for developing against libtcmu.
 %dir %{_sysconfdir}/tcmu/
 %config %{_sysconfdir}/tcmu/tcmu.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/tcmu-runner
+%config(noreplace) %{_sysconfdir}/logrotate.d/tcmu-runner.bak
 
 %files -n libtcmu
 %{_libdir}/libtcmu*.so.*


### PR DESCRIPTION
Provides: libtcmu-devel = 1.4.2-1.el7 libtcmu-devel(x86-64) = 1.4.2-1.el7                                                                                                   
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1                                             
Requires: libtcmu.so.2()(64bit)                                                                                                                                             
Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/tcmu-runner/extra/rpmbuild/BUILDROOT/tcmu-runner-1.4.2-1.el7.x86_64                                         
error: Installed (but unpackaged) file(s) found:                                                                                                                            
   /etc/logrotate.d/tcmu-runner.bak/tcmu-runner                                                                                                                             
                                                                                                                                                                            
                                                                                                                                                                            
RPM build errors:                                                                                                                                                           
    Installed (but unpackaged) file(s) found:                                                                                                                               
   /etc/logrotate.d/tcmu-runner.bak/tcmu-runner
