### PR TITLE
cmake: add a minor .so version number to libtcmu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(tcmu
   )
 set_target_properties(tcmu
   PROPERTIES
+  VERSION 2.1
   SOVERSION "2"
   )
 target_include_directories(tcmu


### PR DESCRIPTION
The minor .so version number should be bumped when backwards compatible
ABI changes are made.

This commit results in the following build output:
  libtcmu.so -> libtcmu.so.2
  libtcmu.so.2 -> libtcmu.so.2.1
  libtcmu.so.2.1

Link: https://www.spinics.net/lists/target-devel/msg17636.html
Signed-off-by: David Disseldorp <ddiss@suse.de>