### PR TITLE
cmake: set '-fno-builtin-XYZ' options when tcmalloc is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ find_library(DL dl)
 
 if (with-tcmalloc)
   find_library(TCMALLOC_LIB tcmalloc)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free")
 endif(with-tcmalloc)
 
 # Stuff for building the shared library


### PR DESCRIPTION
Fixes: #561 

Signed-off-by: Jason Dillaman <dillaman@redhat.com>