### PR TITLE
tcmu: reconfig_device convert err log to debug

### DIFF
--- a/api.c
+++ b/api.c
@@ -348,7 +348,7 @@ void tcmu_cdb_print_info(struct tcmu_device *dev,
 	sprintf(buf + n, "\n");
 
 	if (info) {
-		tcmu_dev_warn(dev, "%s", buf);
+		tcmu_dev_dbg(dev, "%s", buf);
 	} else {
 		tcmu_dev_dbg_scsi_cmd(dev, "%s", buf);
 	}

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -154,7 +154,7 @@ static int reconfig_device(struct tcmulib_context *ctx, char *dev_name,
 	}
 
 	if (!dev->handler->reconfig) {
-		tcmu_dev_err(dev, "Reconfiguration is not supported with this device.\n");
+		tcmu_dev_dbg(dev, "Reconfiguration is not supported with this device.\n");
 		return -EOPNOTSUPP;
 	}
 
@@ -177,8 +177,8 @@ static int reconfig_device(struct tcmulib_context *ctx, char *dev_name,
 
 	ret = dev->handler->reconfig(dev, &cfg);
 	if (ret < 0) {
-		tcmu_dev_err(dev, "Handler reconfig failed with error %d.\n",
-			     ret);
+		tcmu_dev_dbg(dev, "Handler reconfig failed with error %s.\n",
+		             strerror(-ret));
 		return ret;
 	}
 


### PR DESCRIPTION
These logs looks annoying with ERROR tags:

2019-06-14 17:56:33.567 1887 [ERROR] reconfig_device:195 glfs/blockvol:
Handler reconfig failed with error -95.
2019-06-14 17:56:33.569 1887 [ERROR] reconfig_device:195 glfs/blockvol:
Handler reconfig failed with error -95.
2019-06-14 17:56:33.577 1887 [ERROR] reconfig_device:195 glfs/blockvol:
Handler reconfig failed with error -95.
2019-06-14 17:56:33.578 1887 [ERROR] reconfig_device:195 glfs/blockvol:
Handler reconfig failed with error -95.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>