### PR TITLE
runner: fix crash during compound command execution

### DIFF
--- a/tcmur_aio.c
+++ b/tcmur_aio.c
@@ -142,6 +142,7 @@ static void *io_work_queue(void *arg)
 	struct tcmu_device *dev = arg;
 	struct tcmur_device *rdev = tcmu_dev_get_private(dev);
 	struct tcmu_io_queue *io_wq = &rdev->work_queue;
+	int ret;
 
 	while (1) {
 		struct tcmu_work *work;
@@ -166,7 +167,8 @@ static void *io_work_queue(void *arg)
 		cmd = work->cmd;
 		pthread_cleanup_push(_cleanup_io_work, work);
 
-		cmd->done(dev, cmd,work->fn(work->dev, cmd));
+		ret = work->fn(work->dev, cmd);
+		cmd->done(dev, cmd, ret);
 
 		pthread_cleanup_pop(1); /* cleanup work */
 	}


### PR DESCRIPTION
Some systems/compilers seem to be loading cmd->done then executing
work->fn. xcopy/unmap/caw set the done function in the work fn so we end
up crasing due to a null pointer.

This has us set the done function before calling the work fn. It also
splits up the line that calls done to make it easier to read.

Signed-off-by: Mike Christie <mchristi@redhat.com>