### PR TITLE
tcmu: link libtcmalloc with libtcmu and handlers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(tcmu
   ${LIBNL_LIB}
   ${LIBNL_GENL_LIB}
   ${GLIB_LIBRARIES}
+  ${TCMALLOC_LIB}
   )
 install(TARGETS tcmu LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
@@ -90,6 +91,7 @@ target_include_directories(tcmu_static
   )
 target_link_libraries(tcmu_static
   ${GLIB_LIBRARIES}
+  ${TCMALLOC_LIB}
   )
 
 # Stuff for building the main binary
@@ -133,6 +135,7 @@ target_include_directories(tcmu-synthesizer
   )
 target_link_libraries(tcmu-synthesizer
   ${GLIB_LIBRARIES}
+  ${TCMALLOC_LIB}
   )
 
 install(TARGETS RUNTIME DESTINATION bin)
@@ -180,7 +183,7 @@ if (with-fbo)
 	target_include_directories(handler_file_optical
   	PUBLIC ${PROJECT_SOURCE_DIR}/ccan
   	)
-	target_link_libraries(handler_file_optical ${PTHREAD})
+	target_link_libraries(handler_file_optical ${PTHREAD} ${TCMALLOC_LIB})
 	install(TARGETS handler_file_optical DESTINATION ${CMAKE_INSTALL_LIBDIR}/tcmu-runner)
 endif (with-fbo)
 
@@ -205,6 +208,7 @@ if (with-zbc)
 	target_include_directories(handler_file_zbc
 	  PUBLIC ${PROJECT_SOURCE_DIR}/ccan
 	  )
+	target_link_libraries(handler_file_zbc ${TCMALLOC_LIB})
 	install(TARGETS handler_file_zbc DESTINATION ${CMAKE_INSTALL_LIBDIR}/tcmu-runner)
 endif (with-zbc)
 
@@ -225,6 +229,7 @@ if (with-rbd)
 	  )
 	target_link_libraries(handler_rbd
 	  ${LIBRBD}
+	  ${TCMALLOC_LIB}
 	  )
 	install(TARGETS handler_rbd DESTINATION ${CMAKE_INSTALL_LIBDIR}/tcmu-runner)
 endif (with-rbd)
@@ -253,6 +258,7 @@ if (with-glfs)
 	  )
 	target_link_libraries(handler_glfs
 	  ${GFAPI}
+	  ${TCMALLOC_LIB}
 	  )
 	install(TARGETS handler_glfs DESTINATION ${CMAKE_INSTALL_LIBDIR}/tcmu-runner)
 endif (with-glfs)
@@ -282,6 +288,7 @@ if (with-qcow)
 	endif (HAVE_LINUX_FALLOC)
 	target_link_libraries(handler_qcow
 	  ${ZLIB_LIBRARIES}
+	  ${TCMALLOC_LIB}
 	  )
 	install(TARGETS handler_qcow DESTINATION ${CMAKE_INSTALL_LIBDIR}/tcmu-runner)
 endif (with-qcow)


### PR DESCRIPTION
Without patch:

$ ldd /usr/bin/tcmu-runner | grep -c libtcmalloc
1
$ ldd /usr/lib64/libtcmu.so | grep -c libtcmalloc
0
$ ldd /usr/lib64/tcmu-runner/handler_file_optical.so | grep -c libtcmalloc
0
$ ldd /usr/lib64/tcmu-runner/handler_file_zbc.so | grep -c libtcmalloc
0
$ ldd /usr/lib64/tcmu-runner/handler_glfs.so | grep -c libtcmalloc
0

With patch:

$ ldd /usr/bin/tcmu-runner | grep libtcmalloc
      libtcmalloc.so.4 => /lib64/libtcmalloc.so.4 (0x00007f6d6f5ae000)
$ ldd /usr/lib64/libtcmu.so | grep libtcmalloc
      libtcmalloc.so.4 => /lib64/libtcmalloc.so.4 (0x00007f5050952000)
$ ldd /usr/lib64/tcmu-runner/handler_file_optical.so | grep libtcmalloc
      libtcmalloc.so.4 => /lib64/libtcmalloc.so.4 (0x00007f6c8286c000)
$ ldd /usr/lib64/tcmu-runner/handler_file_zbc.so | grep libtcmalloc
      libtcmalloc.so.4 => /lib64/libtcmalloc.so.4 (0x00007f9b95f1e000)
$ ldd /usr/lib64/tcmu-runner/handler_glfs.so | grep libtcmalloc
      libtcmalloc.so.4 => /lib64/libtcmalloc.so.4 (0x00007ff09bb77000)

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>