### PR TITLE
Log stuck commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,23 @@ o- backstores .......................................................... [...]
 /backstores/user:rbd> create cfgstring=pool/rbd1;osd_op_timeout=30 name=rbd0 size=1G
 Created user-backed storage object rbd0 size 1073741824.
 
+The cfgstrng format is:
 
-Note that the cfgstring is handler specific. The format is:
+cfgstring=;tcmu-runner daemon arguments;handler arguments
+
+The following tcmu-runner daemon arguments are optional:
+
+- tcmur_cmd_time_out: Number of seconds before logging the command as timed out,
+and executing a handler specific timeout handler if supported.
+
+If passed in they must start before the handler specific arguments and each
+argument must start and end with a semicolon ";".
+
+Example using the rbd cfgstring with the optional tcmur_cmd_timeout arg:
+
+create ;tcmur_cmd_timeout=20;pool/rbd1;osd_op_timeout=30 name=rbd0 size=1G
+
+The handler specific arguments and their formats are:
 
 - **rbd**: /pool_name/image_name[;osd_op_timeout=N;conf=N;id=N]
 (osd_op_timeout is optional and N is in seconds)

--- a/consumer.c
+++ b/consumer.c
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
 
 				tcmulib_processing_start(dev);
 
-				while ((cmd = tcmulib_get_next_command(dev)) != NULL) {
+				while ((cmd = tcmulib_get_next_command(dev, 0)) != NULL) {
 					ret = foo_handle_cmd(dev,
 							     cmd->cdb,
 							     cmd->iovec,

--- a/file_example.c
+++ b/file_example.c
@@ -84,7 +84,7 @@ static void file_close(struct tcmu_device *dev)
 	free(state);
 }
 
-static int file_read(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+static int file_read(struct tcmu_device *dev, struct tcmur_cmd *cmd,
 		     struct iovec *iov, size_t iov_cnt, size_t length,
 		     off_t offset)
 {
@@ -115,7 +115,7 @@ done:
 	return ret;
 }
 
-static int file_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+static int file_write(struct tcmu_device *dev, struct tcmur_cmd *cmd,
 		      struct iovec *iov, size_t iov_cnt, size_t length,
 		      off_t offset)
 {
@@ -139,7 +139,7 @@ done:
 	return ret;
 }
 
-static int file_flush(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+static int file_flush(struct tcmu_device *dev, struct tcmur_cmd *cmd)
 {
 	struct file_state *state = tcmur_dev_get_private(dev);
 	int ret;

--- a/file_optical.c
+++ b/file_optical.c
@@ -75,7 +75,7 @@ struct fbo_state {
 	int curr_handler;
 };
 
-static int fbo_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
+static int fbo_handle_cmd(struct tcmu_device *dev, struct tcmur_cmd *cmd);
 
 static void fbo_report_op_change(struct tcmu_device *dev, uint8_t code)
 {
@@ -1436,7 +1436,7 @@ static int fbo_emulate_read_format_capacities(struct tcmu_device *dev,
 /*
  * Return scsi status or TCMU_STS_NOT_HANDLED
  */
-static int fbo_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+static int fbo_handle_cmd(struct tcmu_device *dev, struct tcmur_cmd *cmd)
 {
 	uint8_t *cdb = cmd->cdb;
 	struct iovec *iovec = cmd->iovec;

--- a/file_optical.c
+++ b/file_optical.c
@@ -75,8 +75,6 @@ struct fbo_state {
 	int curr_handler;
 };
 
-static int fbo_handle_cmd(struct tcmu_device *dev, struct tcmur_cmd *cmd);
-
 static void fbo_report_op_change(struct tcmu_device *dev, uint8_t code)
 {
 	struct fbo_state *state = tcmur_dev_get_private(dev);
@@ -1436,8 +1434,9 @@ static int fbo_emulate_read_format_capacities(struct tcmu_device *dev,
 /*
  * Return scsi status or TCMU_STS_NOT_HANDLED
  */
-static int fbo_handle_cmd(struct tcmu_device *dev, struct tcmur_cmd *cmd)
+static int fbo_handle_cmd(struct tcmu_device *dev, struct tcmur_cmd *tcmur_cmd)
 {
+	struct tcmulib_cmd *cmd = tcmur_cmd->lib_cmd;
 	uint8_t *cdb = cmd->cdb;
 	struct iovec *iovec = cmd->iovec;
 	size_t iov_cnt = cmd->iov_cnt;

--- a/file_zbc.c
+++ b/file_zbc.c
@@ -2216,7 +2216,7 @@ static int zbc_flush(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
  * Handle command emulation.
  * Return scsi status or TCMU_STS_NOT_HANDLED
  */
-static int zbc_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+static int zbc_handle_cmd(struct tcmu_device *dev, struct tcmur_cmd *cmd)
 {
 	uint8_t *cdb = cmd->cdb;
 	struct iovec *iovec = cmd->iovec;

--- a/file_zbc.c
+++ b/file_zbc.c
@@ -2216,8 +2216,9 @@ static int zbc_flush(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
  * Handle command emulation.
  * Return scsi status or TCMU_STS_NOT_HANDLED
  */
-static int zbc_handle_cmd(struct tcmu_device *dev, struct tcmur_cmd *cmd)
+static int zbc_handle_cmd(struct tcmu_device *dev, struct tcmur_cmd *tcmur_cmd)
 {
+	struct tcmulib_cmd *cmd = tcmur_cmd->lib_cmd;
 	uint8_t *cdb = cmd->cdb;
 	struct iovec *iovec = cmd->iovec;
 	size_t iov_cnt = cmd->iov_cnt;

--- a/glfs.c
+++ b/glfs.c
@@ -823,7 +823,8 @@ out:
 static int tcmu_glfs_handle_cmd(struct tcmu_device *dev,
 				struct tcmur_cmd *tcmur_cmd)
 {
-	uint8_t *cdb = tcmur_cmd->cdb;
+	struct tcmulib_cmd *cmd = tcmur_cmd->lib_cmd;
+	uint8_t *cdb = cmd->cdb;
 	int ret;
 
 	switch(cdb[0]) {

--- a/glfs.c
+++ b/glfs.c
@@ -619,7 +619,7 @@ static void glfs_async_cbk(glfs_fd_t *fd, ssize_t ret, void *data)
 		ret = TCMU_STS_OK;
 	}
 
-	cmd->done(dev, cmd, ret);
+	tcmur_cmd_complete(dev, cmd, ret);
 	free(cookie);
 }
 

--- a/glfs.c
+++ b/glfs.c
@@ -81,7 +81,7 @@ struct glfs_state {
 
 typedef struct glfs_cbk_cookie {
 	struct tcmu_device *dev;
-	struct tcmulib_cmd *cmd;
+	struct tcmur_cmd *tcmur_cmd;
 	size_t length;
 	enum {
 		TCMU_GLFS_READ  = 1,
@@ -599,7 +599,7 @@ static void glfs_async_cbk(glfs_fd_t *fd, ssize_t ret, void *data)
 {
 	glfs_cbk_cookie *cookie = data;
 	struct tcmu_device *dev = cookie->dev;
-	struct tcmulib_cmd *cmd = cookie->cmd;
+	struct tcmur_cmd *tcmur_cmd = cookie->tcmur_cmd;
 	size_t length = cookie->length;
 
 	if (ret < 0 || ret != length) {
@@ -619,12 +619,12 @@ static void glfs_async_cbk(glfs_fd_t *fd, ssize_t ret, void *data)
 		ret = TCMU_STS_OK;
 	}
 
-	tcmur_cmd_complete(dev, cmd, ret);
+	tcmur_cmd_complete(dev, tcmur_cmd, ret);
 	free(cookie);
 }
 
 static int tcmu_glfs_read(struct tcmu_device *dev,
-                          struct tcmulib_cmd *cmd,
+                          struct tcmur_cmd *tcmur_cmd,
                           struct iovec *iov, size_t iov_cnt,
                           size_t length, off_t offset)
 {
@@ -637,7 +637,7 @@ static int tcmu_glfs_read(struct tcmu_device *dev,
 		goto out;
 	}
 	cookie->dev = dev;
-	cookie->cmd = cmd;
+	cookie->tcmur_cmd = tcmur_cmd;
 	cookie->length = length;
 	cookie->op = TCMU_GLFS_READ;
 
@@ -656,7 +656,7 @@ out:
 }
 
 static int tcmu_glfs_write(struct tcmu_device *dev,
-                           struct tcmulib_cmd *cmd,
+                           struct tcmur_cmd *tcmur_cmd,
                            struct iovec *iov, size_t iov_cnt,
                            size_t length, off_t offset)
 {
@@ -669,7 +669,7 @@ static int tcmu_glfs_write(struct tcmu_device *dev,
 		goto out;
 	}
 	cookie->dev = dev;
-	cookie->cmd = cmd;
+	cookie->tcmur_cmd = tcmur_cmd;
 	cookie->length = length;
 	cookie->op = TCMU_GLFS_WRITE;
 
@@ -718,7 +718,7 @@ static int tcmu_glfs_reconfig(struct tcmu_device *dev,
 }
 
 static int tcmu_glfs_flush(struct tcmu_device *dev,
-                           struct tcmulib_cmd *cmd)
+                           struct tcmur_cmd *tcmur_cmd)
 {
 	struct glfs_state *state = tcmur_dev_get_private(dev);
 	glfs_cbk_cookie *cookie;
@@ -729,7 +729,7 @@ static int tcmu_glfs_flush(struct tcmu_device *dev,
 		goto out;
 	}
 	cookie->dev = dev;
-	cookie->cmd = cmd;
+	cookie->tcmur_cmd = tcmur_cmd;
 	cookie->length = 0;
 	cookie->op = TCMU_GLFS_FLUSH;
 
@@ -746,7 +746,8 @@ out:
 	return TCMU_STS_NO_RESOURCE;
 }
 
-static int tcmu_glfs_discard(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+static int tcmu_glfs_discard(struct tcmu_device *dev,
+			     struct tcmur_cmd *tcmur_cmd,
                              uint64_t offset, uint64_t length)
 {
 	struct glfs_state *state = tcmur_dev_get_private(dev);
@@ -759,7 +760,7 @@ static int tcmu_glfs_discard(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 		goto out;
 	}
 	cookie->dev = dev;
-	cookie->cmd = cmd;
+	cookie->tcmur_cmd = tcmur_cmd;
 	cookie->length = 0;
 	cookie->op = TCMU_GLFS_DISCARD;
 
@@ -778,7 +779,7 @@ out:
 }
 
 static int tcmu_glfs_writesame(struct tcmu_device *dev,
-			       struct tcmulib_cmd *cmd,
+			       struct tcmur_cmd *tcmur_cmd,
 			       uint64_t offset, uint64_t length,
 			       struct iovec *iov, size_t iov_cnt)
 {
@@ -798,7 +799,7 @@ static int tcmu_glfs_writesame(struct tcmu_device *dev,
 		goto out;
 	}
 	cookie->dev = dev;
-	cookie->cmd = cmd;
+	cookie->tcmur_cmd = tcmur_cmd;
 	cookie->length = 0;
 	cookie->op = TCMU_GLFS_WRITESAME;
 
@@ -819,15 +820,17 @@ out:
 /*
  * Return scsi status or TCMU_STS_NOT_HANDLED
  */
-static int tcmu_glfs_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+static int tcmu_glfs_handle_cmd(struct tcmu_device *dev,
+				struct tcmur_cmd *tcmur_cmd)
 {
-	uint8_t *cdb = cmd->cdb;
+	uint8_t *cdb = tcmur_cmd->cdb;
 	int ret;
 
 	switch(cdb[0]) {
 	case WRITE_SAME:
 	case WRITE_SAME_16:
-		ret = tcmur_handle_writesame(dev, cmd, tcmu_glfs_writesame);
+		ret = tcmur_handle_writesame(dev, tcmur_cmd,
+					     tcmu_glfs_writesame);
 		break;
 	default:
 		ret = TCMU_STS_NOT_HANDLED;

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -940,7 +940,8 @@ do { \
 	dev->cmd_tail = (dev->cmd_tail + tcmu_hdr_get_len((ent)->hdr.len_op)) % mb->cmdr_size; \
 } while (0)
 
-struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev)
+struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev,
+					     int hm_cmd_size)
 {
 	struct tcmu_mailbox *mb = dev->map;
 	struct tcmu_cmd_entry *ent;
@@ -967,7 +968,8 @@ struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev)
 			}
 
 			/* Alloc memory for cmd itself, iovec and cdb */
-			cmd = malloc(sizeof(*cmd) + sizeof(*cmd->iovec) * ent->req.iov_cnt + cdb_len);
+			cmd = malloc(sizeof(*cmd) + hm_cmd_size + cdb_len +
+				     sizeof(*cmd->iovec) * ent->req.iov_cnt);
 			if (!cmd)
 				return NULL;
 			cmd->cmd_id = ent->hdr.cmd_id;
@@ -984,6 +986,10 @@ struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev)
 			/* Copy cdb that currently points to the command ring */
 			cmd->cdb = (uint8_t *) (cmd->iovec + cmd->iov_cnt);
 			memcpy(cmd->cdb, (void *) mb + ent->req.cdb_off, cdb_len);
+
+			/* Setup handler memory area after iovecs and cdb */
+			if (hm_cmd_size)
+				cmd->hm_private = cmd->cdb + cdb_len;
 
 			TCMU_UPDATE_DEV_TAIL(dev, mb, ent);
 			return cmd;

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -785,9 +785,25 @@ uint64_t tcmu_dev_get_num_lbas(struct tcmu_device *dev)
 	return dev->num_lbas;
 }
 
+uint64_t tcmu_lba_to_byte(struct tcmu_device *dev, uint64_t lba)
+{
+	return lba << dev->block_size_shift;
+}
+
+uint64_t tcmu_byte_to_lba(struct tcmu_device *dev, uint64_t byte)
+{
+	return byte >> dev->block_size_shift;
+}
+
+uint64_t tcmu_cdb_to_byte(struct tcmu_device *dev, uint8_t *cdb)
+{
+	return tcmu_lba_to_byte(dev, tcmu_cdb_get_lba(cdb));
+}
+
 void tcmu_dev_set_block_size(struct tcmu_device *dev, uint32_t block_size)
 {
 	dev->block_size = block_size;
+	dev->block_size_shift = ffs(block_size) - 1;
 }
 
 uint32_t tcmu_dev_get_block_size(struct tcmu_device *dev)

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -104,10 +104,14 @@ int tcmulib_master_fd_ready(struct tcmulib_context *ctx);
 
 /*
  * When a device fd becomes ready, call this to get SCSI cmd info in
- * 'cmd' struct.
+ * 'cmd' struct. libtcmu will allocate hm_cmd_size bytes for each cmd
+ * that can be accessed via cmd->hm_private pointer. The memory at
+ * hm_private will be freed in tcmulib_command_complete.
+ *
  * Repeat until it returns false.
  */
-struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev);
+struct tcmulib_cmd *tcmulib_get_next_command(struct tcmu_device *dev,
+					     int hm_cmd_size);
 
 /*
  * Mark the command as complete.

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -111,6 +111,8 @@ struct tcmulib_cmd {
 
 	/* callback to finish/continue command processing */
 	cmd_done_t done;
+
+	void *hm_private;
 };
 
 /* Set/Get methods for the opaque tcmu_device */

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -114,6 +114,8 @@ void tcmu_dev_set_num_lbas(struct tcmu_device *dev, uint64_t num_lbas);
 uint64_t tcmu_dev_get_num_lbas(struct tcmu_device *dev);
 void tcmu_dev_set_block_size(struct tcmu_device *dev, uint32_t block_size);
 uint32_t tcmu_dev_get_block_size(struct tcmu_device *dev);
+uint64_t tcmu_lba_to_byte(struct tcmu_device *dev, uint64_t lba);
+uint64_t tcmu_byte_to_lba(struct tcmu_device *dev, uint64_t byte);
 void tcmu_dev_set_max_xfer_len(struct tcmu_device *dev, uint32_t len);
 uint32_t tcmu_dev_get_max_xfer_len(struct tcmu_device *dev);
 void tcmu_dev_set_opt_xcopy_rw_len(struct tcmu_device *dev, uint32_t len);
@@ -158,6 +160,8 @@ uint64_t tcmu_cdb_get_lba(uint8_t *cdb);
 uint32_t tcmu_cdb_get_xfer_length(uint8_t *cdb);
 void tcmu_cdb_print_info(struct tcmu_device *dev, const struct tcmulib_cmd *cmd,
 			 const char *info);
+uint64_t tcmu_cdb_to_byte(struct tcmu_device *dev, uint8_t *cdb);
+
 /* iovec processing */
 off_t tcmu_iovec_compare(void *mem, struct iovec *iovec, size_t size);
 size_t tcmu_iovec_seek(struct iovec *iovec, size_t count);

--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -94,24 +94,12 @@ enum {
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
-typedef void (*cmd_done_t)(struct tcmu_device *, struct tcmulib_cmd *, int);
-
 struct tcmulib_cmd {
 	uint16_t cmd_id;
 	uint8_t *cdb;
 	struct iovec *iovec;
 	size_t iov_cnt;
 	uint8_t sense_buf[SENSE_BUFFERSIZE];
-
-	/*
-	 * this is mostly used by compound operations as such operations
-	 * need to carry some state around for multiple commands.
-	 */
-	void *cmdstate;
-
-	/* callback to finish/continue command processing */
-	cmd_done_t done;
-
 	void *hm_private;
 };
 

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -45,6 +45,7 @@ struct tcmu_device {
 
 	uint64_t num_lbas;
 	uint32_t block_size;
+	uint32_t block_size_shift;
 	uint32_t max_xfer_len;
 	uint32_t opt_xcopy_rw_len;
 	bool split_unmaps;

--- a/main-syms.txt
+++ b/main-syms.txt
@@ -7,4 +7,5 @@
 	tcmur_dev_update_size;
 	tcmur_dev_set_private;
 	tcmur_dev_get_private;
+	tcmur_cmd_complete;
 };

--- a/main.c
+++ b/main.c
@@ -30,6 +30,7 @@
 #include <gio/gio.h>
 #include <getopt.h>
 #include <poll.h>
+#include <time.h>
 #include <scsi/scsi.h>
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -621,6 +622,131 @@ static void tcmur_stop_device(void *arg)
 	tcmu_dev_dbg(dev, "cmdproc cleanup done\n");
 }
 
+int tcmur_get_time(struct tcmu_device *dev, struct timespec *time)
+{
+	struct tcmur_device *rdev = tcmu_dev_get_private(dev);
+	int ret;
+
+	ret = clock_gettime(CLOCK_MONOTONIC_COARSE, time);
+	if (!ret) {
+		tcmu_dev_dbg(dev, "Current time %lu secs.\n", time->tv_sec);
+		return 0;
+	}
+
+	tcmu_dev_err(dev, "Could not get time. Error %d. Command timeout feature disabled.\n",
+		     ret);
+	rdev->cmd_time_out = 0;
+	return ret;
+}
+
+static bool get_next_cmd_timeout(struct tcmu_device *dev,
+				 struct timespec *curr_time,
+				 struct timespec *tmo)
+{
+	struct tcmur_device *rdev = tcmu_dev_get_private(dev);
+	int run_time, cmd_tmo = rdev->cmd_time_out;
+	struct tcmur_cmd *tcmur_cmd;
+	bool has_timeout = false;
+
+	if (!cmd_tmo)
+		return false;
+
+	memset(tmo, 0, sizeof(*tmo));
+
+	pthread_spin_lock(&rdev->lock);
+	list_for_each(&rdev->cmds_list, tcmur_cmd, cmds_list_entry) {
+		if (tcmur_cmd->timed_out)
+			continue;
+
+		has_timeout = true;
+		run_time = difftime(curr_time->tv_sec,
+				    tcmur_cmd->start_time.tv_sec);
+		if (cmd_tmo > run_time) {
+			tmo->tv_sec = cmd_tmo - run_time;
+		} else {
+			/*
+			 * We do not do a clock call for every command, so
+			 * cmds can time out while we were processing new
+			 * cmds. Force a recheck.
+			 */
+			tmo->tv_sec = 0;
+		}
+
+		tcmu_dev_dbg(dev, "Next cmd id %hu timeout in %lu secs. Current time %lu. Start time %lu\n",
+			     tcmur_cmd->lib_cmd->cmd_id, tmo->tv_sec,
+			     curr_time->tv_sec, tcmur_cmd->start_time.tv_sec);
+		break;
+	}
+	pthread_spin_unlock(&rdev->lock);
+
+	return has_timeout;
+}
+
+static void check_for_timed_out_cmds(struct tcmu_device *dev)
+{
+	struct tcmur_device *rdev = tcmu_dev_get_private(dev);
+	int cmd_tmo = rdev->cmd_time_out;
+	struct tcmur_cmd *tcmur_cmd;
+	struct timespec curr_time;
+	struct tcmulib_cmd *cmd;
+	int run_time;
+	uint8_t *cdb;
+
+	if (!cmd_tmo)
+		return;
+
+	memset(&curr_time, 0, sizeof(curr_time));
+
+	if (tcmur_get_time(dev, &curr_time))
+		return;
+
+	pthread_spin_lock(&rdev->lock);
+	list_for_each(&rdev->cmds_list, tcmur_cmd, cmds_list_entry) {
+		if (tcmur_cmd->timed_out)
+			continue;
+
+		run_time = difftime(curr_time.tv_sec,
+				    tcmur_cmd->start_time.tv_sec);
+		if (run_time < cmd_tmo)
+			continue;
+
+		cmd = tcmur_cmd->lib_cmd;
+
+		if (tcmu_get_log_level() == TCMU_LOG_DEBUG_SCSI_CMD) {
+			tcmu_cdb_print_info(dev, cmd, "timed out.");
+		} else {
+			cdb = cmd->cdb;
+			tcmu_dev_info(dev, "Command %hu SCSI CDB 0x%x at LBA %"PRIu64" for %u blocks timed out.\n",
+				      cmd->cmd_id, cdb[0],
+				      tcmu_cdb_get_lba(cdb),
+				      tcmu_cdb_get_xfer_length(cdb));
+		}
+
+		tcmur_cmd->timed_out = true;
+	}
+	pthread_spin_unlock(&rdev->lock);
+}
+
+static void tcmur_tcmulib_cmd_start(struct tcmu_device *dev,
+				    struct tcmulib_cmd *cmd,
+				    struct timespec *curr_time)
+{
+	struct tcmur_device *rdev = tcmu_dev_get_private(dev);
+	struct tcmur_cmd *tcmur_cmd = cmd->hm_private;
+
+	memset(tcmur_cmd, 0, sizeof(*tcmur_cmd));
+	tcmur_cmd->lib_cmd = cmd;
+	list_node_init(&tcmur_cmd->cmds_list_entry);
+
+	if (rdev->cmd_time_out) {
+		tcmur_cmd->start_time.tv_sec = curr_time->tv_sec;
+
+		pthread_spin_lock(&rdev->lock);
+		list_add_tail(&rdev->cmds_list, &tcmur_cmd->cmds_list_entry);
+		pthread_spin_unlock(&rdev->lock);
+	}
+}
+
 static void *tcmur_cmdproc_thread(void *arg)
 {
 	struct tcmu_device *dev = arg;
@@ -635,16 +761,19 @@ static void *tcmur_cmdproc_thread(void *arg)
 	while (1) {
 		int completed = 0;
 		struct tcmulib_cmd *cmd;
-		struct tcmur_cmd *tcmur_cmd;
+		struct timespec tmo, curr_time;
+		bool set_tmo;
 
 		tcmulib_processing_start(dev);
+
+		if (rdev->cmd_time_out)
+			tcmur_get_time(dev, &curr_time);
 
 		while (!dev_stopping &&
 		       (cmd = tcmulib_get_next_command(dev,
 					sizeof(struct tcmur_cmd))) != NULL) {
 
-			tcmur_cmd = cmd->hm_private;
-			tcmur_cmd->lib_cmd = cmd;
+			tcmur_tcmulib_cmd_start(dev, cmd, &curr_time);
 
 			if (tcmu_get_log_level() == TCMU_LOG_DEBUG_SCSI_CMD)
 				tcmu_cdb_print_info(dev, cmd, NULL);
@@ -673,6 +802,8 @@ static void *tcmur_cmdproc_thread(void *arg)
 		if (completed)
 			tcmulib_processing_complete(dev);
 
+		set_tmo = get_next_cmd_timeout(dev, &curr_time, &tmo);
+
 		pfd.fd = tcmu_dev_get_fd(dev);
 		pfd.events = POLLIN;
 		pfd.revents = 0;
@@ -681,13 +812,19 @@ static void *tcmur_cmdproc_thread(void *arg)
 		 * handling. If we were removing a device, then the uio device's memory
 		 * could be freed, but the poll would be rescheduled and end up accessing
 		 * the released device. */
-		ret = ppoll(&pfd, 1, NULL, NULL);
+		if (set_tmo) {
+			ret = ppoll(&pfd, 1, &tmo, NULL);
+		} else {
+			ret = ppoll(&pfd, 1, NULL, NULL);
+		}
 		if (ret == -1) {
 			tcmu_err("ppoll() returned %d\n", ret);
 			break;
 		}
 
-		if (pfd.revents != POLLIN) {
+		if (!ret) {
+			check_for_timed_out_cmds(dev);
+		} else if (pfd.revents != POLLIN) {
 			tcmu_err("ppoll received unexpected revent: 0x%x\n", pfd.revents);
 			break;
 		}
@@ -747,6 +884,46 @@ static int dev_reconfig(struct tcmu_device *dev, struct tcmulib_cfg_info *cfg)
 	}
 }
 
+static void parse_tcmu_runner_args(struct tcmu_device *dev)
+{
+	struct tcmur_device *rdev = tcmu_dev_get_private(dev);
+	char *arg, *cfg_str, *arg_end, *cfg_end;
+	bool found;
+
+	cfg_str = tcmu_dev_get_cfgstring(dev);
+	/* count ending null in string */
+	cfg_end = cfg_str + strlen(cfg_str) + 1;
+
+	while ((arg = strstr(cfg_str, ";"))) {
+		found = false;
+		arg++;
+
+		if (!strncmp(arg, "tcmur_cmd_time_out=", 19)) {
+			rdev->cmd_time_out = atoi(arg + 19);
+
+			tcmu_dev_dbg(dev, "Using tcmur_cmd_timeout %d\n",
+				     rdev->cmd_time_out);
+			found = true;
+		}
+
+		arg_end = strstr(arg, ";");
+		if (!arg_end) {
+			arg_end = cfg_end;
+		} else {
+			arg_end++;
+		}
+
+
+		if (found) {
+			memmove(arg - 1, arg_end, cfg_end - arg_end + 1);
+		} else {
+			cfg_str = arg;
+		}
+	}
+	tcmu_dev_dbg(dev, "Updated cfgstring: %s.\n",
+		     tcmu_dev_get_cfgstring(dev));
+}
+
 static int dev_added(struct tcmu_device *dev)
 {
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
@@ -762,7 +939,10 @@ static int dev_added(struct tcmu_device *dev)
 
 	tcmu_dev_set_private(dev, rdev);
 	list_node_init(&rdev->recovery_entry);
+	list_head_init(&rdev->cmds_list);
 	rdev->dev = dev;
+
+	parse_tcmu_runner_args(dev);
 
 	ret = -EINVAL;
 	block_size = tcmu_cfgfs_dev_get_attr_int(dev, "hw_block_size");

--- a/main.c
+++ b/main.c
@@ -293,7 +293,7 @@ static void dbus_handler_close(struct tcmu_device *dev)
 }
 
 static int dbus_handler_handle_cmd(struct tcmu_device *dev,
-				   struct tcmulib_cmd *cmd)
+				   struct tcmur_cmd *tcmu_cmd)
 {
 	abort();
 }
@@ -635,11 +635,16 @@ static void *tcmur_cmdproc_thread(void *arg)
 	while (1) {
 		int completed = 0;
 		struct tcmulib_cmd *cmd;
+		struct tcmur_cmd *tcmur_cmd;
 
 		tcmulib_processing_start(dev);
 
 		while (!dev_stopping &&
-		       (cmd = tcmulib_get_next_command(dev, 0)) != NULL) {
+		       (cmd = tcmulib_get_next_command(dev,
+					sizeof(struct tcmur_cmd))) != NULL) {
+
+			tcmur_cmd = cmd->hm_private;
+			tcmur_cmd->lib_cmd = cmd;
 
 			if (tcmu_get_log_level() == TCMU_LOG_DEBUG_SCSI_CMD)
 				tcmu_cdb_print_info(dev, cmd, NULL);

--- a/main.c
+++ b/main.c
@@ -638,7 +638,8 @@ static void *tcmur_cmdproc_thread(void *arg)
 
 		tcmulib_processing_start(dev);
 
-		while (!dev_stopping && (cmd = tcmulib_get_next_command(dev)) != NULL) {
+		while (!dev_stopping &&
+		       (cmd = tcmulib_get_next_command(dev, 0)) != NULL) {
 
 			if (tcmu_get_log_level() == TCMU_LOG_DEBUG_SCSI_CMD)
 				tcmu_cdb_print_info(dev, cmd, NULL);

--- a/main.c
+++ b/main.c
@@ -661,7 +661,7 @@ static void *tcmur_cmdproc_thread(void *arg)
 			 */
 			if (ret != TCMU_STS_ASYNC_HANDLED) {
 				completed = 1;
-				tcmur_command_complete(dev, cmd, ret);
+				tcmur_tcmulib_cmd_complete(dev, cmd, ret);
 			}
 		}
 

--- a/qcow.c
+++ b/qcow.c
@@ -1435,7 +1435,7 @@ static void qcow_close(struct tcmu_device *dev)
 	free(bdev);
 }
 
-static int qcow_read(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+static int qcow_read(struct tcmu_device *dev, struct tcmur_cmd *cmd,
 		     struct iovec *iovec, size_t iov_cnt, size_t length,
 		     off_t offset)
 {
@@ -1459,7 +1459,7 @@ done:
 	return ret;
 }
 
-static int qcow_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+static int qcow_write(struct tcmu_device *dev, struct tcmur_cmd *cmd,
 		      struct iovec *iovec, size_t iov_cnt, size_t length,
 		      off_t offset)
 {
@@ -1483,7 +1483,7 @@ done:
 	return ret;
 }
 
-static int qcow_flush(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+static int qcow_flush(struct tcmu_device *dev, struct tcmur_cmd *cmd)
 {
 	struct bdev *bdev = tcmur_dev_get_private(dev);
 	int ret;

--- a/rbd.c
+++ b/rbd.c
@@ -1097,7 +1097,7 @@ static void rbd_finish_aio_generic(rbd_completion_t completion,
 		tcmu_dev_dbg(dev, "CAW miscompare at offset %u.\n", cmp_offset);
 
 		tcmu_r = TCMU_STS_MISCOMPARE;
-		tcmu_sense_set_info(tcmur_cmd->sense_buf, cmp_offset);
+		tcmu_sense_set_info(tcmur_cmd->lib_cmd->sense_buf, cmp_offset);
 	} else if (ret == -EINVAL) {
 		tcmu_dev_err(dev, "Invalid IO request.\n");
 		tcmu_r = TCMU_STS_INVALID_CDB;
@@ -1411,7 +1411,8 @@ out:
 static int tcmu_rbd_handle_cmd(struct tcmu_device *dev,
 			       struct tcmur_cmd *tcmur_cmd)
 {
-	uint8_t *cdb = tcmur_cmd->cdb;
+	struct tcmulib_cmd *cmd = tcmur_cmd->lib_cmd;
+	uint8_t *cdb = cmd->cdb;
 	int ret;
 
 	switch(cdb[0]) {

--- a/rbd.c
+++ b/rbd.c
@@ -1120,7 +1120,7 @@ static void rbd_finish_aio_generic(rbd_completion_t completion,
 		}
 	}
 
-	tcmulib_cmd->done(dev, tcmulib_cmd, tcmu_r);
+	tcmur_cmd_complete(dev, tcmulib_cmd, tcmu_r);
 
 	if (aio_cb->bounce_buffer)
 		free(aio_cb->bounce_buffer);

--- a/rbd.c
+++ b/rbd.c
@@ -90,7 +90,7 @@ enum rbd_aio_type {
 
 struct rbd_aio_cb {
 	struct tcmu_device *dev;
-	struct tcmulib_cmd *tcmulib_cmd;
+	struct tcmur_cmd *tcmur_cmd;
 
 	enum rbd_aio_type type;
 	union {
@@ -972,9 +972,8 @@ static void tcmu_rbd_close(struct tcmu_device *dev)
 	tcmu_rbd_state_free(state);
 }
 
-static int tcmu_rbd_handle_blacklisted_cmd(struct tcmu_device *dev,
-					   struct tcmulib_cmd *cmd)
-{
+static int tcmu_rbd_handle_blacklisted_cmd(struct tcmu_device *dev)
+		{
 	tcmu_notify_lock_lost(dev);
 	/*
 	 * This will happen during failback normally, because
@@ -991,9 +990,8 @@ static int tcmu_rbd_handle_blacklisted_cmd(struct tcmu_device *dev,
  * we will end up failing the transport connection when we just needed
  * to try a different OSD.
  */
-static int tcmu_rbd_handle_timedout_cmd(struct tcmu_device *dev,
-					struct tcmulib_cmd *cmd)
-{
+static int tcmu_rbd_handle_timedout_cmd(struct tcmu_device *dev)
+		{
 	tcmu_dev_err(dev, "Timing out cmd.\n");
 	tcmu_notify_conn_lost(dev);
 
@@ -1080,7 +1078,7 @@ static void rbd_finish_aio_generic(rbd_completion_t completion,
 				   struct rbd_aio_cb *aio_cb)
 {
 	struct tcmu_device *dev = aio_cb->dev;
-	struct tcmulib_cmd *tcmulib_cmd = aio_cb->tcmulib_cmd;
+	struct tcmur_cmd *tcmur_cmd = aio_cb->tcmur_cmd;
 	struct iovec *iov = aio_cb->iov;
 	size_t iov_cnt = aio_cb->iov_cnt;
 	uint32_t cmp_offset;
@@ -1091,15 +1089,15 @@ static void rbd_finish_aio_generic(rbd_completion_t completion,
 	rbd_aio_release(completion);
 
 	if (ret == -ETIMEDOUT) {
-		tcmu_r = tcmu_rbd_handle_timedout_cmd(dev, tcmulib_cmd);
+		tcmu_r = tcmu_rbd_handle_timedout_cmd(dev);
 	} else if (ret == -ESHUTDOWN || ret == -EROFS) {
-		tcmu_r = tcmu_rbd_handle_blacklisted_cmd(dev, tcmulib_cmd);
+		tcmu_r = tcmu_rbd_handle_blacklisted_cmd(dev);
 	} else if (ret == -EILSEQ && aio_cb->type == RBD_AIO_TYPE_CAW) {
 		cmp_offset = aio_cb->caw.miscompare_offset - aio_cb->caw.offset;
 		tcmu_dev_dbg(dev, "CAW miscompare at offset %u.\n", cmp_offset);
 
 		tcmu_r = TCMU_STS_MISCOMPARE;
-		tcmu_sense_set_info(tcmulib_cmd->sense_buf, cmp_offset);
+		tcmu_sense_set_info(tcmur_cmd->sense_buf, cmp_offset);
 	} else if (ret == -EINVAL) {
 		tcmu_dev_err(dev, "Invalid IO request.\n");
 		tcmu_r = TCMU_STS_INVALID_CDB;
@@ -1120,14 +1118,14 @@ static void rbd_finish_aio_generic(rbd_completion_t completion,
 		}
 	}
 
-	tcmur_cmd_complete(dev, tcmulib_cmd, tcmu_r);
+	tcmur_cmd_complete(dev, tcmur_cmd, tcmu_r);
 
 	if (aio_cb->bounce_buffer)
 		free(aio_cb->bounce_buffer);
 	free(aio_cb);
 }
 
-static int tcmu_rbd_read(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+static int tcmu_rbd_read(struct tcmu_device *dev, struct tcmur_cmd *tcmur_cmd,
 			     struct iovec *iov, size_t iov_cnt, size_t length,
 			     off_t offset)
 {
@@ -1144,7 +1142,7 @@ static int tcmu_rbd_read(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	aio_cb->dev = dev;
 	aio_cb->type = RBD_AIO_TYPE_READ;
 	aio_cb->read.length = length;
-	aio_cb->tcmulib_cmd = cmd;
+	aio_cb->tcmur_cmd = tcmur_cmd;
 	aio_cb->iov = iov;
 	aio_cb->iov_cnt = iov_cnt;
 
@@ -1169,7 +1167,7 @@ out:
 	return TCMU_STS_NO_RESOURCE;
 }
 
-static int tcmu_rbd_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+static int tcmu_rbd_write(struct tcmu_device *dev, struct tcmur_cmd *tcmur_cmd,
 			  struct iovec *iov, size_t iov_cnt, size_t length,
 			  off_t offset)
 {
@@ -1185,7 +1183,7 @@ static int tcmu_rbd_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 
 	aio_cb->dev = dev;
 	aio_cb->type = RBD_AIO_TYPE_WRITE;
-	aio_cb->tcmulib_cmd = cmd;
+	aio_cb->tcmur_cmd = tcmur_cmd;
 
 	ret = rbd_aio_create_completion
 		(aio_cb, (rbd_callback_t) rbd_finish_aio_generic, &completion);
@@ -1210,7 +1208,7 @@ out:
 }
 
 #ifdef RBD_DISCARD_SUPPORT
-static int tcmu_rbd_unmap(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+static int tcmu_rbd_unmap(struct tcmu_device *dev, struct tcmur_cmd *tcmur_cmd,
 			  uint64_t off, uint64_t len)
 {
 	struct tcmu_rbd_state *state = tcmur_dev_get_private(dev);
@@ -1225,7 +1223,7 @@ static int tcmu_rbd_unmap(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	}
 
 	aio_cb->dev = dev;
-	aio_cb->tcmulib_cmd = cmd;
+	aio_cb->tcmur_cmd = tcmur_cmd;
 	aio_cb->type = RBD_AIO_TYPE_WRITE;
 	aio_cb->bounce_buffer = NULL;
 
@@ -1251,7 +1249,7 @@ out:
 
 #ifdef LIBRBD_SUPPORTS_AIO_FLUSH
 
-static int tcmu_rbd_flush(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+static int tcmu_rbd_flush(struct tcmu_device *dev, struct tcmur_cmd *tcmur_cmd)
 {
 	struct tcmu_rbd_state *state = tcmur_dev_get_private(dev);
 	struct rbd_aio_cb *aio_cb;
@@ -1265,7 +1263,7 @@ static int tcmu_rbd_flush(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 	}
 
 	aio_cb->dev = dev;
-	aio_cb->tcmulib_cmd = cmd;
+	aio_cb->tcmur_cmd = tcmur_cmd;
 	aio_cb->type = RBD_AIO_TYPE_WRITE;
 	aio_cb->bounce_buffer = NULL;
 
@@ -1294,7 +1292,7 @@ out:
 
 #ifdef RBD_WRITE_SAME_SUPPORT
 static int tcmu_rbd_aio_writesame(struct tcmu_device *dev,
-				  struct tcmulib_cmd *cmd,
+				  struct tcmur_cmd *tcmur_cmd,
 				  uint64_t off, uint64_t len,
 				  struct iovec *iov, size_t iov_cnt)
 {
@@ -1311,7 +1309,7 @@ static int tcmu_rbd_aio_writesame(struct tcmu_device *dev,
 	}
 
 	aio_cb->dev = dev;
-	aio_cb->tcmulib_cmd = cmd;
+	aio_cb->tcmur_cmd = tcmur_cmd;
 	aio_cb->type = RBD_AIO_TYPE_WRITE;
 
 	aio_cb->bounce_buffer = malloc(length);
@@ -1348,7 +1346,7 @@ out:
 #endif /* RBD_WRITE_SAME_SUPPORT */
 
 #ifdef RBD_COMPARE_AND_WRITE_SUPPORT
-static int tcmu_rbd_aio_caw(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+static int tcmu_rbd_aio_caw(struct tcmu_device *dev, struct tcmur_cmd *tcmur_cmd,
 			    uint64_t off, uint64_t len, struct iovec *iov,
 			    size_t iov_cnt)
 {
@@ -1365,7 +1363,7 @@ static int tcmu_rbd_aio_caw(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	}
 
 	aio_cb->dev = dev;
-	aio_cb->tcmulib_cmd = cmd;
+	aio_cb->tcmur_cmd = tcmur_cmd;
 	aio_cb->type = RBD_AIO_TYPE_CAW;
 	aio_cb->caw.offset = off;
 
@@ -1410,21 +1408,23 @@ out:
 /*
  * Return scsi status or TCMU_STS_NOT_HANDLED
  */
-static int tcmu_rbd_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
+static int tcmu_rbd_handle_cmd(struct tcmu_device *dev,
+			       struct tcmur_cmd *tcmur_cmd)
 {
-	uint8_t *cdb = cmd->cdb;
+	uint8_t *cdb = tcmur_cmd->cdb;
 	int ret;
 
 	switch(cdb[0]) {
 #ifdef RBD_WRITE_SAME_SUPPORT
 	case WRITE_SAME:
 	case WRITE_SAME_16:
-		ret = tcmur_handle_writesame(dev, cmd, tcmu_rbd_aio_writesame);
+		ret = tcmur_handle_writesame(dev, tcmur_cmd,
+					     tcmu_rbd_aio_writesame);
 		break;
 #endif
 #ifdef RBD_COMPARE_AND_WRITE_SUPPORT
 	case COMPARE_AND_WRITE:
-		ret = tcmur_handle_caw(dev, cmd, tcmu_rbd_aio_caw);
+		ret = tcmur_handle_caw(dev, tcmur_cmd, tcmu_rbd_aio_caw);
 		break;
 #endif
 	default:

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -73,7 +73,7 @@ struct tcmur_handler {
 	int nr_threads;
 
 	/*
-	 * Async handle_cmd only handlers return:
+	 * handle_cmd only handlers return:
 	 *
 	 * - TCMU_STS_OK if the command has been executed successfully
 	 * - TCMU_STS_NOT_HANDLED if opcode is not handled
@@ -82,13 +82,16 @@ struct tcmur_handler {
 	 * - TCMU_STS_PASSTHROUGH_ERR For handlers that require low level
 	 *   SCSI processing and want to setup their own sense buffers.
 	 *
-	 * Handlers that set nr_threads > 0 and async handlers
-	 * that implement handle_cmd and the IO callouts below return:
+	 * Handlers that completely execute cmds from the handle_cmd's calling
+	 * context must return a TCMU_STS code from handle_cmd.
+	 *
+	 * Async handlers that queue a command from handle_cmd and complete
+	 * from their own async context return:
 	 *
 	 * - TCMU_STS_OK if the handler has queued the command.
 	 * - TCMU_STS_NOT_HANDLED if the command is not supported.
 	 * - TCMU_STS_NO_RESOURCE if the handler was not able to allocate
-	 *   resources for the command.
+	 *   resources to queue the command.
 	 *
 	 * If TCMU_STS_OK is returned from the callout the handler must call
 	 * the tcmulib_cmd->done function with TCMU_STS return code.
@@ -96,11 +99,16 @@ struct tcmur_handler {
 	handle_cmd_fn_t handle_cmd;
 
 	/*
-	 * Below callbacks are only executed by generic_handle_cmd.
-	 * Returns:
+	 * Below callouts are only executed by generic_handle_cmd.
+	 *
+	 * Handlers that completely execute cmds from the callout's calling
+	 * context must return a TCMU_STS code from the callout.
+	 *
+	 * Async handlers that queue a command from the callout and complete
+	 * it from their own async context return:
 	 * - TCMU_STS_OK if the handler has queued the command.
 	 * - TCMU_STS_NO_RESOURCE if the handler was not able to allocate
-	 *   resources for the command.
+	 *   resources to queue the command.
 	 *
 	 * If TCMU_STS_OK is returned from the callout the handler must call
 	 * the tcmulib_cmd->done function with TCMU_STS return code.

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -27,8 +27,28 @@ extern "C" {
 #include "alua.h"
 #include "scsi.h"
 
-/* Removed next patch */
-#define tcmur_cmd tcmulib_cmd
+struct tcmur_cmd;
+
+struct tcmur_cmd {
+	/* Pointer to tcmulib_get_next_command's cmd. */
+	struct tcmulib_cmd *lib_cmd;
+
+	/* Used by compound commands like CAW, format unit, etc. */
+	struct iovec *iovec;
+	size_t iov_cnt;
+	/*
+	 * Some handlers will manipulcate the iov_base pointer while copying
+	 * to/from it. This is a pointer to the original pointer.
+	 */
+	void *iov_base_copy;
+	void *cmd_state;
+
+	/* Bytes to read/write from iovec */
+	size_t requested;
+
+	/* callback to finish/continue command processing */
+	void (*done)(struct tcmu_device *dev, struct tcmur_cmd *cmd, int ret);
+};
 
 struct tcmulib_cfg_info;
 

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -156,8 +156,7 @@ struct tcmur_handler {
 	bool (*update_logdir)(void);
 };
 
-void tcmur_cmd_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
-			int rc);
+void tcmur_cmd_complete(struct tcmu_device *dev, void *data, int rc);
 
 /*
  * Each tcmu-runner (tcmur) handler plugin must export the

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -20,7 +20,11 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <time.h>
 #include <sys/uio.h>
+
+#include "ccan/list/list.h"
+
 #include "scsi_defs.h"
 #include "libtcmu_log.h"
 #include "libtcmu_common.h"
@@ -45,6 +49,10 @@ struct tcmur_cmd {
 
 	/* Bytes to read/write from iovec */
 	size_t requested;
+
+	struct list_node cmds_list_entry;
+	struct timespec start_time;
+	bool timed_out;
 
 	/* callback to finish/continue command processing */
 	void (*done)(struct tcmu_device *dev, struct tcmur_cmd *cmd, int ret);

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -94,7 +94,7 @@ struct tcmur_handler {
 	 *   resources to queue the command.
 	 *
 	 * If TCMU_STS_OK is returned from the callout the handler must call
-	 * the tcmulib_cmd->done function with TCMU_STS return code.
+	 * tcmur_cmd_complete with TCMU_STS return code to complete the command.
 	 */
 	handle_cmd_fn_t handle_cmd;
 
@@ -111,7 +111,8 @@ struct tcmur_handler {
 	 *   resources to queue the command.
 	 *
 	 * If TCMU_STS_OK is returned from the callout the handler must call
-	 * the tcmulib_cmd->done function with TCMU_STS return code.
+	 * tcmur_cmd_complete with a TCMU_STS return code to complete the
+	 * command.
 	 */
 	rw_fn_t write;
 	rw_fn_t read;
@@ -154,6 +155,9 @@ struct tcmur_handler {
 	 */
 	bool (*update_logdir)(void);
 };
+
+void tcmur_cmd_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+			int rc);
 
 /*
  * Each tcmu-runner (tcmur) handler plugin must export the

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -27,6 +27,9 @@ extern "C" {
 #include "alua.h"
 #include "scsi.h"
 
+/* Removed next patch */
+#define tcmur_cmd tcmulib_cmd
+
 struct tcmulib_cfg_info;
 
 struct tcmur_handler {
@@ -89,7 +92,7 @@ struct tcmur_handler {
 	 * If TCMU_STS_OK is returned from the callout the handler must call
 	 * tcmur_cmd_complete with TCMU_STS return code to complete the command.
 	 */
-	int (*handle_cmd)(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
+	int (*handle_cmd)(struct tcmu_device *dev, struct tcmur_cmd *cmd);
 
 	/*
 	 * Below callouts are only executed by generic_handle_cmd.
@@ -107,12 +110,12 @@ struct tcmur_handler {
 	 * tcmur_cmd_complete with a TCMU_STS return code to complete the
 	 * command.
 	 */
-	int (*read)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+	int (*read)(struct tcmu_device *dev, struct tcmur_cmd *cmd,
 		    struct iovec *iovec, size_t iov_cnt, size_t len, off_t off);
-	int (*write)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+	int (*write)(struct tcmu_device *dev, struct tcmur_cmd *cmd,
 		     struct iovec *iovec, size_t iov_cnt, size_t len, off_t off);
-	int (*flush)(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
-	int (*unmap)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+	int (*flush)(struct tcmu_device *dev, struct tcmur_cmd *cmd);
+	int (*unmap)(struct tcmu_device *dev, struct tcmur_cmd *cmd,
 		     uint64_t off, uint64_t len);
 
 	/*

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -27,13 +27,6 @@ extern "C" {
 #include "alua.h"
 #include "scsi.h"
 
-typedef int (*rw_fn_t)(struct tcmu_device *, struct tcmulib_cmd *,
-		       struct iovec *, size_t, size_t, off_t);
-typedef int (*flush_fn_t)(struct tcmu_device *, struct tcmulib_cmd *);
-typedef int (*handle_cmd_fn_t)(struct tcmu_device *, struct tcmulib_cmd *);
-typedef int (*unmap_fn_t)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
-			  uint64_t off, uint64_t len);
-
 struct tcmulib_cfg_info;
 
 struct tcmur_handler {
@@ -96,7 +89,7 @@ struct tcmur_handler {
 	 * If TCMU_STS_OK is returned from the callout the handler must call
 	 * tcmur_cmd_complete with TCMU_STS return code to complete the command.
 	 */
-	handle_cmd_fn_t handle_cmd;
+	int (*handle_cmd)(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
 
 	/*
 	 * Below callouts are only executed by generic_handle_cmd.
@@ -114,10 +107,13 @@ struct tcmur_handler {
 	 * tcmur_cmd_complete with a TCMU_STS return code to complete the
 	 * command.
 	 */
-	rw_fn_t write;
-	rw_fn_t read;
-	flush_fn_t flush;
-	unmap_fn_t unmap;
+	int (*read)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+		    struct iovec *iovec, size_t iov_cnt, size_t len, off_t off);
+	int (*write)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+		     struct iovec *iovec, size_t iov_cnt, size_t len, off_t off);
+	int (*flush)(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
+	int (*unmap)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+		     uint64_t off, uint64_t len);
 
 	/*
 	 * If the lock is acquired and the tag is not TCMU_INVALID_LOCK_TAG,

--- a/tcmu-synthesizer.c
+++ b/tcmu-synthesizer.c
@@ -91,7 +91,7 @@ static gboolean syn_dev_callback(GIOChannel *source,
 	tcmu_dbg("dev fd cb\n");
 	tcmulib_processing_start(dev);
 
-	while ((cmd = tcmulib_get_next_command(dev)) != NULL) {
+	while ((cmd = tcmulib_get_next_command(dev, 0)) != NULL) {
 		ret = syn_handle_cmd(dev,
 				     cmd->cdb,
 				     cmd->iovec,

--- a/tcmur_aio.c
+++ b/tcmur_aio.c
@@ -168,7 +168,7 @@ static void *io_work_queue(void *arg)
 		pthread_cleanup_push(_cleanup_io_work, work);
 
 		ret = work->fn(work->dev, cmd);
-		cmd->done(dev, cmd, ret);
+		tcmur_cmd_complete(dev, cmd, ret);
 
 		pthread_cleanup_pop(1); /* cleanup work */
 	}

--- a/tcmur_aio.h
+++ b/tcmur_aio.h
@@ -39,11 +39,11 @@ void cleanup_io_work_queue_threads(struct tcmu_device *);
 int setup_aio_tracking(struct tcmur_device *);
 void cleanup_aio_tracking(struct tcmur_device *);
 
-typedef int (*tcmu_work_fn_t)(struct tcmu_device *dev,
-			      struct tcmulib_cmd *cmd);
+typedef int (*tcmu_work_fn_t)(struct tcmu_device *dev, void *data);
+typedef void (*tcmu_done_fn_t)(struct tcmu_device *dev, void *data, int rc);
 
-int async_handle_cmd(struct tcmu_device *, struct tcmulib_cmd *,
-		     tcmu_work_fn_t);
+int aio_request_schedule(struct tcmu_device *, void *, tcmu_work_fn_t,
+			 tcmu_done_fn_t);
 
 /* aio request tracking */
 void track_aio_request_start(struct tcmur_device *);

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -33,8 +33,8 @@ static void _cleanup_spin_lock(void *arg)
 	pthread_spin_unlock(arg);
 }
 
-void tcmur_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
-			    int rc)
+void tcmur_tcmulib_cmd_complete(struct tcmu_device *dev,
+				struct tcmulib_cmd *cmd, int rc)
 {
 	struct tcmur_device *rdev = tcmu_dev_get_private(dev);
 
@@ -53,7 +53,7 @@ static void aio_command_finish(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	struct tcmur_device *rdev = tcmu_dev_get_private(dev);
 	int wake_up;
 
-	tcmur_command_complete(dev, cmd, rc);
+	tcmur_tcmulib_cmd_complete(dev, cmd, rc);
 	track_aio_request_finish(rdev, &wake_up);
 	while (wake_up) {
 		tcmulib_processing_complete(dev);

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -68,42 +68,6 @@ void tcmur_cmd_complete(struct tcmu_device *dev, void *data, int rc)
 	tcmur_cmd->done(dev, tcmur_cmd, rc);
 }
 
-static int alloc_iovec(struct tcmulib_cmd *cmd, size_t length)
-{
-	struct iovec *iov;
-
-	assert(!cmd->iovec);
-
-	iov = calloc(1, sizeof(*iov));
-	if (!iov)
-		goto out;
-	iov->iov_base = calloc(1, length);
-	if (!iov->iov_base)
-		goto free_iov;
-	iov->iov_len = length;
-
-	cmd->iovec = iov;
-	cmd->iov_cnt = 1;
-	return 0;
-
-free_iov:
-	free(iov);
-out:
-	return -ENOMEM;
-}
-
-static void free_iovec(struct tcmulib_cmd *cmd)
-{
-	assert(cmd->iovec);
-	assert(cmd->iovec->iov_base);
-
-	free(cmd->iovec->iov_base);
-	free(cmd->iovec);
-
-	cmd->iov_cnt = 0;
-	cmd->iovec = NULL;
-}
-
 static void tcmur_cmd_iovec_reset(struct tcmur_cmd *tcmur_cmd,
 				  size_t data_length)
 {

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -2186,16 +2186,15 @@ static int handle_rtpg(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 static int passthrough_work_fn(struct tcmu_device *dev, void *data)
 {
 	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
-	struct tcmulib_cmd *cmd = data;
 
-	return rhandler->handle_cmd(dev, cmd);
+	return rhandler->handle_cmd(dev, data);
 }
 
 static int handle_passthrough(struct tcmu_device *dev,
-			      struct tcmulib_cmd *cmd)
+			      struct tcmur_cmd *tcmur_cmd)
 {
-	cmd->done = handle_generic_cbk;
-	return aio_request_schedule(dev, cmd, passthrough_work_fn,
+	tcmur_cmd->done = handle_generic_cbk;
+	return aio_request_schedule(dev, tcmur_cmd, passthrough_work_fn,
 				    tcmur_cmd_complete);
 }
 

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -61,6 +61,12 @@ static void aio_command_finish(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	}
 }
 
+void tcmur_cmd_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+			int rc)
+{
+	cmd->done(dev, cmd, rc);
+}
+
 static int alloc_iovec(struct tcmulib_cmd *cmd, size_t length)
 {
 	struct iovec *iov;

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -442,11 +442,15 @@ done:
 
 static int handle_unmap(struct tcmu_device *dev, struct tcmulib_cmd *origcmd)
 {
+	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
 	uint8_t *cdb = origcmd->cdb;
 	size_t copied, data_length = tcmu_cdb_get_xfer_length(cdb);
 	uint8_t *par;
 	uint16_t dl, bddl;
 	int ret;
+
+	if (!rhandler->unmap)
+		return TCMU_STS_INVALID_CMD;
 
 	/*
 	 * ANCHOR bit check
@@ -1741,7 +1745,11 @@ static int flush_work_fn(struct tcmu_device *dev, void *data)
 
 static int handle_flush(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 {
+	struct tcmur_handler *rhandler = tcmu_get_runner_handler(dev);
 	struct tcmur_cmd *tcmur_cmd = cmd->hm_private;
+
+	if (!rhandler->flush)
+		return TCMU_STS_INVALID_CMD;
 
 	tcmur_cmd->done = handle_generic_cbk;
 	return aio_request_schedule(dev, tcmur_cmd, flush_work_fn,

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -2118,15 +2118,15 @@ static int handle_format_unit(struct tcmu_device *dev, struct tcmulib_cmd *cmd) 
 	state->length = length;
 
 	/* Check length on first write to make sure its not less than 1MB */
-	if ((num_lbas - state->done_blocks) * block_size < length)
-		state->length = (num_lbas - state->done_blocks) * block_size;
+	if (num_lbas * block_size < length)
+		state->length = num_lbas * block_size;
 
 	if (alloc_iovec(writecmd, state->length)) {
 		goto free_state;
 	}
 
-	tcmu_dev_dbg(dev, "start emulate format, done_blocks:%u num_lbas:%"PRIu64" block_size:%u\n",
-		     state->done_blocks, num_lbas, block_size);
+	tcmu_dev_dbg(dev, "start emulate format, num_lbas:%"PRIu64" block_size:%u\n",
+		     num_lbas, block_size);
 
 	/* copy incase handler changes it */
 	state->write_buf = writecmd->iovec->iov_base;

--- a/tcmur_cmd_handler.h
+++ b/tcmur_cmd_handler.h
@@ -14,7 +14,9 @@
 struct tcmu_device;
 struct tcmulib_cmd;
 struct tcmur_cmd;
+struct timespec;
 
+int tcmur_get_time(struct tcmu_device *dev, struct timespec *time);
 int tcmur_dev_update_size(struct tcmu_device *dev, uint64_t new_size);
 void tcmur_set_pending_ua(struct tcmu_device *dev, int ua);
 int tcmur_generic_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd);

--- a/tcmur_cmd_handler.h
+++ b/tcmur_cmd_handler.h
@@ -19,8 +19,8 @@ void tcmur_set_pending_ua(struct tcmu_device *dev, int ua);
 int tcmur_generic_handle_cmd(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
 int tcmur_cmd_passthrough_handler(struct tcmu_device *dev, struct tcmulib_cmd *cmd);
 bool tcmur_handler_is_passthrough_only(struct tcmur_handler *rhandler);
-void tcmur_command_complete(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
-			    int ret);
+void tcmur_tcmulib_cmd_complete(struct tcmu_device *dev,
+				struct tcmulib_cmd *cmd, int ret);
 typedef int (*tcmur_writesame_fn_t)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 			   uint64_t off, uint64_t len, struct iovec *iov, size_t iov_cnt);
 int tcmur_handle_writesame(struct tcmu_device *dev, struct tcmulib_cmd *cmd,

--- a/tcmur_cmd_handler.h
+++ b/tcmur_cmd_handler.h
@@ -13,6 +13,7 @@
 
 struct tcmu_device;
 struct tcmulib_cmd;
+struct tcmur_cmd;
 
 int tcmur_dev_update_size(struct tcmu_device *dev, uint64_t new_size);
 void tcmur_set_pending_ua(struct tcmu_device *dev, int ua);
@@ -21,15 +22,17 @@ int tcmur_cmd_passthrough_handler(struct tcmu_device *dev, struct tcmulib_cmd *c
 bool tcmur_handler_is_passthrough_only(struct tcmur_handler *rhandler);
 void tcmur_tcmulib_cmd_complete(struct tcmu_device *dev,
 				struct tcmulib_cmd *cmd, int ret);
-typedef int (*tcmur_writesame_fn_t)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
-			   uint64_t off, uint64_t len, struct iovec *iov, size_t iov_cnt);
-int tcmur_handle_writesame(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+typedef int (*tcmur_writesame_fn_t)(struct tcmu_device *dev,
+				    struct tcmur_cmd *tcmur_cmd, uint64_t off,
+				    uint64_t len, struct iovec *iov,
+				    size_t iov_cnt);
+int tcmur_handle_writesame(struct tcmu_device *dev, struct tcmur_cmd *tcmur_cmd,
 			   tcmur_writesame_fn_t write_same_fn);
 
-typedef int (*tcmur_caw_fn_t)(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
-                              uint64_t off, uint64_t len, struct iovec *iov,
-                              size_t iov_cnt);
-int tcmur_handle_caw(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
+typedef int (*tcmur_caw_fn_t)(struct tcmu_device *dev,
+			      struct tcmur_cmd *tcmur_cmd, uint64_t off,
+			      uint64_t len, struct iovec *iov, size_t iov_cnt);
+int tcmur_handle_caw(struct tcmu_device *dev, struct tcmur_cmd *tcmur_cmd,
                      tcmur_caw_fn_t caw_fn);
 
 #endif /* __TCMUR_CMD_HANDLER_H */

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -73,6 +73,9 @@ struct tcmur_device {
 
 	uint32_t format_progress;
 	pthread_mutex_t format_lock; /* for atomic format operations */
+
+	int cmd_time_out;
+	struct list_head cmds_list;
 };
 
 bool tcmu_dev_in_recovery(struct tcmu_device *dev);


### PR DESCRIPTION
The following patches add infrastructure to allow handlers to cancel/abort commands. The patches currently just log if a command takes longer than tcmur_cmd_time_out seconds. However, for handlers like glfs, we can easily just add a handler callout that the handler can use to clean up/abort a running command.

Notes: Patches are only in the RFC stages.
