### PR TITLE
tcmur: remove useless code

### DIFF
--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -526,9 +526,6 @@ static int handle_unmap(struct tcmu_device *dev, struct tcmulib_cmd *origcmd)
 
 	ret = handle_unmap_internal(dev, origcmd, bddl, par);
 
-	free(par);
-	return ret;
-
 out_free_par:
 	free(par);
 	return ret;


### PR DESCRIPTION
This very simple fixing won't have any conflict  with https://github.com/open-iscsi/tcmu-runner/pull/568.