### PR TITLE
darray.h: avoid UB when decrementing zero pointer

### DIFF
--- a/darray.h
+++ b/darray.h
@@ -298,7 +298,8 @@ static inline size_t darray_next_alloc(size_t alloc, size_t need)
  * Like darray_foreach, but traverse in reverse order.
  */
 #define darray_foreach_reverse(i, arr) \
-	for ((i) = &(arr).item[(arr).size]; (i)-- > &(arr).item[0]; )
+	if ((arr).size) \
+		for ((i) = &(arr).item[(arr).size]; (i)-- > &(arr).item[0]; )
 
 
 #endif /* CCAN_DARRAY_H */


### PR DESCRIPTION
Sometimes the `&(arr).item[(arr).size]` is a zero pointer. In these
cases decrementing this pointer aka `i` results in something like
0xfffffff8. This is UB, and UB sanitizer in particular reports it as

../iscsi/tcmu-runner/libtcmu.c:563:2: runtime error: pointer index expression with base 0x000000000000 overflowed to 0xfffffffffffffff8

In these cases size is `zero` as well, so fix this by simply not running
the cycle when the `size` is zero.

Signed-off-by: Konstantin Kharlamov <Hi-Angel@yandex.ru>