### PR TITLE
spec: fix build error

### DIFF
--- a/tcmu-runner.spec
+++ b/tcmu-runner.spec
@@ -149,6 +149,4 @@ Development header(s) for developing against libtcmu.
 %{_libdir}/libtcmu*.so.*
 
 %files -n libtcmu-devel
-%{_includedir}/libtcmu.h
-%{_includedir}/libtcmu_common.h
 %{_libdir}/libtcmu*.so


### PR DESCRIPTION
Since the header files won't be installed, so we need to remove it
from the spec file too.

Signed-off-by: Xiubo Li <xiubli@redhat.com>