### PR TITLE
tcmu_dev_get_memory_info()

### DIFF
--- a/libtcmu_common.h
+++ b/libtcmu_common.h
@@ -109,6 +109,8 @@ void tcmu_dev_set_private(struct tcmu_device *dev, void *priv);
 void *tcmu_get_daemon_dev_private(struct tcmu_device *dev);
 void tcmu_set_daemon_dev_private(struct tcmu_device *dev, void *priv);
 int tcmu_dev_get_fd(struct tcmu_device *dev);
+char *tcmu_dev_get_memory_info(struct tcmu_device *dev, void **base,
+			       size_t *len, off_t *offset);
 char *tcmu_dev_get_cfgstring(struct tcmu_device *dev);
 void tcmu_dev_set_num_lbas(struct tcmu_device *dev, uint64_t num_lbas);
 uint64_t tcmu_dev_get_num_lbas(struct tcmu_device *dev);


### PR DESCRIPTION
Our handler/device needs more information about the tcmu shared memory block (so that it can pass offsets to another process).  This patch adds a function to retrieve that information about the shared memory.

Also updated install_dep.sh so that it works with Debian installations.