### PR TITLE
logger: fix posible crash when loging to file

### DIFF
--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -183,6 +183,9 @@ static void log_output(struct log_buf *logbuf, int pri, const char *msg,
 {
 	char timestamp[TCMU_TIME_STRING_BUFLEN] = {0, };
 
+	if (!output)
+		return;
+
 	if (time_string_now(timestamp) < 0)
 		return;
 


### PR DESCRIPTION
When creating the file output object, we allow it failing and then
the logger should skip it later. If the failing really happen for
some reason, the tcmu-runner daemon will crash.

Signed-off-by: Xiubo Li <xiubli@redhat.com>