### PR TITLE
Fix build on Fedora 31 beta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(tcmu
   ${LIBNL_LIB}
   ${LIBNL_GENL_LIB}
   ${GLIB_LIBRARIES}
+  ${PTHREAD}
   ${TCMALLOC_LIB}
   )
 install(TARGETS tcmu LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Build is failing because of missing `-lpthread` option.