### PR TITLE
build: resolve 32 bit compilation failure

### DIFF
--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -725,7 +725,7 @@ static int handle_writesame(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 
 	max_xfer_length = tcmu_dev_get_max_xfer_len(dev) * block_size;
 	length = round_up(length, max_xfer_length);
-	length = min(length, tcmu_lba_to_byte(dev, lba_cnt));
+	length = min(length, (size_t)tcmu_lba_to_byte(dev, lba_cnt));
 
 	if (tcmur_cmd_state_init(tcmur_cmd, sizeof(*write_same), length)) {
 		tcmu_dev_err(dev, "Failed to calloc write_same data!\n");


### PR DESCRIPTION
Ensure same type comparison (size_t) on 32 bit architectures,
resolving compilation failure:

```
In file included from /<<PKGBUILDDIR>>/libtcmu.h:24,
                 from /<<PKGBUILDDIR>>/tcmur_cmd_handler.c:20:
/<<PKGBUILDDIR>>/tcmur_cmd_handler.c: In function ‘handle_writesame’:
/<<PKGBUILDDIR>>/libtcmu_common.h:82:14: error: comparison of distinct pointer types lacks a cast [-Werror]
   82 |  (void) (&_a == &_b);  \
      |              ^~
/<<PKGBUILDDIR>>/tcmur_cmd_handler.c:728:11: note: in expansion of macro ‘min’
  728 |  length = min(length, tcmu_lba_to_byte(dev, lba_cnt));
      |
```

when "-Werror" is enabled by the compiler.