### PR TITLE
extra script: Fix install_dep.sh

### DIFF
--- a/extra/install_dep.sh
+++ b/extra/install_dep.sh
@@ -28,8 +28,8 @@ if [ y`uname`y = yLinuxy ]; then
 		$SUDO apt update
 		
 		# for generic
-		$SUDO apt install -y cmake make gcc libnl-3-dev libglib2.0-dev zlib1g kmod
-		$SUDO apt install -y libnl-3-dev libglib2.0-0 libkmod-dev libgoogle-perftools-dev
+		$SUDO apt install -y cmake make gcc zlib1g kmod
+		$SUDO apt install -y libnl-3-dev libnl-genl-3-dev libglib2.0-0 libkmod-dev libgoogle-perftools-dev
 		
 		# for glusterfs
 		$SUDO apt install -y libglusterfs-dev


### PR DESCRIPTION
In `CMakeLists.txt`:

```
find_library(LIBNL_LIB nl-3)
find_library(LIBNL_GENL_LIB nl-genl-3)
set(LIBNL_LIBS
  ${LIBNL_LIB}
  ${LIBNL_GENL_LIB}
  )
```

So we should install `libnl-genl-3-dev` package, which is not included in `install_dep.sh`.