### PR TITLE
libtcmu_log: Set tcmu_logbuf before log thread is created

### DIFF
--- a/libtcmu_log.c
+++ b/libtcmu_log.c
@@ -524,8 +524,6 @@ static bool log_dequeue_msg(struct log_buf *logbuf)
 
 static void *log_thread_start(void *arg)
 {
-	tcmu_logbuf = arg;
-
 	tcmu_set_thread_name("logger", NULL);
 
 	pthread_cleanup_push(log_cleanup, arg);
@@ -697,9 +695,11 @@ int tcmu_setup_log(char *log_dir)
 	if (ret < 0)
 		tcmu_err("create file output error \n");
 
+	tcmu_logbuf = logbuf;
 	ret = pthread_create(&logbuf->thread_id, NULL, log_thread_start,
 			     logbuf);
 	if (ret) {
+		tcmu_logbuf = NULL;
 		log_cleanup(logbuf);
 		return ret;
 	}


### PR DESCRIPTION
Accidentally I've observed a race between setting of tcmu_logbuf in
log_thread_start() and accessing the variable in tcmu_destroy_log().

When a tcmu-runner instance is already running and a 2nd one is
started on of my test systems I've seen segfaults before the 2nd
instance terminated, e.g.:

 # ./tcmu-runner
 log file path now is '/var/log/tcmu-runner.log'
 Starting...
 tcmu-runner is already running...
 Segmentation fault (core dumped)

Further information from coredump is

 # coredumpctl gdb

 ...

 Core was generated by `./tcmu-runner'.
 Program terminated with signal SIGSEGV, Segmentation fault.
 #0  0x00007f0ef972424a in tcmu_destroy_log () at /root/aherrmann/tcmu-runner/libtcmu_log.c:781
 781             thread = tcmu_logbuf->thread_id;
 [Current thread is 1 (Thread 0x7f0ef9b328c0 (LWP 57799))]
 (gdb)

It's an "esoteric" bug, but maybe should be fixed.

Note that with this patch applied, early log messages are caught in
log file, ie. you'll just see

 # ./tcmu-runner
 log file path now is '/var/log/tcmu-runner.log'

on console and logfile contains in addition, e.g.

 2020-03-24 08:49:40.009 57975:tcmu-runner [CRIT] main:1269: Starting...
 2020-03-24 08:49:40.010 57975:tcmu-runner [ERROR] main:1280: tcmu-runner is already running...

[mikechristie: Unset tcmu_logbuf in error path]

Signed-off-by: Andreas Herrmann <aherrmann@suse.com>