### PR TITLE
worker: do not set thread name in the callback fn

### DIFF
--- a/alua.c
+++ b/alua.c
@@ -547,8 +547,6 @@ static void alua_event_work_fn(void *arg)
 {
 	struct tcmu_device *dev = arg;
 
-	tcmu_set_thread_name("alua-lock", dev);
-
 	/* TODO: set UA based on bgly's patches */
 	tcmu_acquire_dev_lock(dev, -1);
 }

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -843,7 +843,20 @@ const char *tcmu_dev_get_uio_name(struct tcmu_device *dev)
 void tcmu_set_thread_name(const char *prefix, struct tcmu_device *dev)
 {
 	const char *uio = dev ? tcmu_dev_get_uio_name(dev) : NULL;
+	char cname[TCMU_THREAD_NAME_LEN];
 	char *pname;
+
+	if (pthread_getname_np(pthread_self(), cname, TCMU_THREAD_NAME_LEN))
+		return;
+
+	/*
+	 * If we are trying to set the pthread name in the
+	 * event work thread, we must ignore it.
+	 */
+	if (!strcmp(cname, "ework-thread")) {
+		tcmu_dev_warn(dev, "Do not set name for event work thread in the callback fn\n");
+		return;
+	}
 
 	if (!prefix) {
 		tcmu_dev_err(dev, "Failed to set name for thread %lu\n",

--- a/target.c
+++ b/target.c
@@ -220,8 +220,6 @@ static void tgt_port_grp_recovery_work_fn(void *arg)
 	bool enable_tpg = false;
 	int ret;
 
-	tcmu_set_thread_name("tpg-recovery", NULL);
-
 	tcmu_dbg("Disabling %s/%s/tpgt_%hu.\n", tpg->fabric, tpg->wwn,
 		  tpg->tpgt);
 	/*


### PR DESCRIPTION
It will overwrite the event worker thread's "ework-thread" name,
which is very important and we will use it to avoid recursive loop.

Signed-off-by: Xiubo Li <xiubli@redhat.com>