### PR TITLE
rbd: remove all the stale blacklist entries when opening devices 

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -104,7 +104,7 @@ struct gluster_cacheconn {
 	darray(char *) cfgstring;
 } gluster_cacheconn;
 
-static darray(struct gluster_cacheconn *) glfs_cache = darray_new();
+static darray(struct gluster_cacheconn *) glfs_cache;
 
 const char *const gluster_transport_lookup[] = {
 	[GLUSTER_TRANSPORT_TCP] = "tcp",
@@ -965,6 +965,17 @@ static int tcmu_glfs_unlock(struct tcmu_device *dev)
 }
 #endif
 
+static int tcmu_glfs_init(void)
+{
+	darray_init(glfs_cache);
+	return 0;
+}
+
+static void tcmu_glfs_destroy(void)
+{
+	darray_free(glfs_cache);
+}
+
 /*
  * For backstore creation
  *
@@ -1005,6 +1016,8 @@ struct tcmur_handler glfs_handler = {
 	.lock           = tcmu_glfs_lock,
 	.unlock         = tcmu_glfs_unlock,
 #endif
+	.init           = tcmu_glfs_init,
+	.destroy        = tcmu_glfs_destroy,
 };
 
 /* Entry point must be named "handler_init". */

--- a/main.c
+++ b/main.c
@@ -68,6 +68,7 @@ struct tcmur_handler *tcmu_get_runner_handler(struct tcmu_device *dev)
 int tcmur_register_handler(struct tcmur_handler *handler)
 {
 	struct tcmur_handler *h;
+	int ret;
 	int i;
 
 	for (i = 0; i < darray_size(g_runner_handlers); i++) {
@@ -79,9 +80,16 @@ int tcmur_register_handler(struct tcmur_handler *handler)
 		}
 	}
 
-	if (handler->init)
-		handler->init();
+	if (handler->init) {
+		ret = handler->init();
+		if (ret) {
+			tcmu_err("Failed to init handler %s, ret = %d\n",
+				 handler->subtype, ret);
+			return ret;
+		}
+	}
 
+	tcmu_info("Handler %s is registered\n", handler->subtype);
 	darray_append(g_runner_handlers, handler);
 	return 0;
 }

--- a/main.c
+++ b/main.c
@@ -136,6 +136,20 @@ static bool tcmur_unregister_dbus_handler(struct tcmur_handler *handler)
 	return ret;
 }
 
+static void tcmur_unregister_all_dbus_handlers(void)
+{
+	struct tcmur_handler *handler;
+	int i;
+	for (i = 0; i < darray_size(g_runner_handlers); i++) {
+		handler = darray_item(g_runner_handlers, i);
+		if (handler->_is_dbus_handler == true) {
+			if (tcmur_unregister_handler(handler))
+				free_dbus_handler(handler);
+		}
+	}
+	darray_free(g_runner_handlers);
+}
+
 static int is_handler(const struct dirent *dirent)
 {
 	if (strncmp(dirent->d_name, "handler_", 8))
@@ -1423,6 +1437,8 @@ unwatch_cfg:
 		tcmu_unwatch_config(tcmu_cfg);
 	tcmulib_close(tcmulib_context);
 err_free_handlers:
+	tcmur_unregister_all_dbus_handlers();
+
 	darray_foreach(handler, handlers) {
 		r_handler = handler->hm_private;
 		if (r_handler && r_handler->destroy)

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -194,6 +194,10 @@ struct tcmur_handler {
 	 * Update the logdir called by dynamic config thread.
 	 */
 	bool (*update_logdir)(void);
+
+	/* To init/destroy some global resrouces if needed */
+	int (*init)(void);
+	void (*destroy)(void);
 };
 
 void tcmur_cmd_complete(struct tcmu_device *dev, void *data, int rc);


### PR DESCRIPTION
When a device is closing, we will add its entiry address into a list
cache. It may have already been blacklisted by another tcmu node
in reopen case.

And all the stale blacklist entris recorded in the list cache will
be removed in any new comming device doing the open.

Fallback to use lock owner API to store the blacklist entry if the
rados_getaddrs() is not supported, though using the acquire lock
APIs we may miss some blacklist entries.

Signed-off-by: Xiubo Li <xiubli@redhat.com>