### PR TITLE
rbd: use the new format of the daemon name

### DIFF
--- a/rbd.c
+++ b/rbd.c
@@ -195,10 +195,12 @@ static int tcmu_rbd_service_register(struct tcmu_device *dev)
 		goto free_image_id_buf;
 	}
 
-	ret = asprintf(&metadata_buf, "%s%c%s%c%s%c%s%c%s%c%s%c",
+	ret = asprintf(&metadata_buf, "%s%c%s%c%s%c%s%c%s%c%s%c%s%c%s%c%s%c%s%c",
 		       "pool_name", '\0', state->pool_name, '\0',
 		       "image_name", '\0', state->image_name, '\0',
-		       "image_id", '\0', image_id_buf, '\0');
+		       "image_id", '\0', image_id_buf, '\0',
+		       "daemon_type", '\0', "portal", '\0',
+		       "daemon_prefix", '\0', u.nodename, '\0');
 	if (ret < 0) {
 		tcmu_dev_err(dev, "Could not allocate metadata buf.\n");
 		ret = -ENOMEM;


### PR DESCRIPTION
This will allow the `ceph -s` to classify the daemon names we report
by using the gateway names instead to simplify the `ceph -s` output.

We will keep the service name to make sure it won't break the ceph
dashboard and the third part apps.

Fixes: https://tracker.ceph.com/issues/49057
Signed-off-by: Xiubo Li <xiubli@redhat.com>