### PR TITLE
file_zbc: Remove unnecessary zone boundary check

### DIFF
--- a/file_zbc.c
+++ b/file_zbc.c
@@ -2129,14 +2129,6 @@ static int zbc_write(struct tcmu_device *dev, struct tcmulib_cmd *cmd)
 
 		/* Get the zone of the current LBA */
 		zone = zbc_get_zone(zdev, lba, false);
-		if (lba + nr_lbas > zone->start + zone->len) {
-			tcmu_dev_err(dev,
-				     "Write boundary violation lba %"PRIu64", xfer len %zu\n",
-				     lba, nr_lbas);
-			return tcmu_sense_set_data(cmd->sense_buf,
-						   ILLEGAL_REQUEST,
-						   ASC_WRITE_BOUNDARY_VIOLATION);
-		}
 
 		/* If the zone is not open, implicitly open it */
 		if (zbc_zone_seq(zone) && !zbc_zone_is_open(zone)) {


### PR DESCRIPTION
Write commands to ZBC devices across zone boundaries shall fail, if the
crossed boundary is between sequential write required zones, or between
a conventional zone and a sequential write required zone. Write commands
across conventional zones shall not fail. Though the commit 87da9fb573a7
("zbc: fix write emulation") relaxed the cross zone boundary check to
allow writes across conventional zones, still such write commands fail.
The commit introduced the helper function zbc_write_check_zones() and
implemented the relaxed boundary check. However, still the old boundary
check is left in zbc_write() and triggers failures for write commands
across conventional zones. To avoid the unnecessary check, remove the
left check code from zbc_write().

Fixes: 87da9fb573a7 ("zbc: fix write emulation")
Signed-off-by: Shin'ichiro Kawasaki <shinichiro.kawasaki@wdc.com>