### PR TITLE
rbd: switch to use rbd_aio_write_zeroes for unmap

### DIFF
--- a/glfs.c
+++ b/glfs.c
@@ -886,29 +886,6 @@ out:
 	return TCMU_STS_NO_RESOURCE;
 }
 
-/*
- * Return scsi status or TCMU_STS_NOT_HANDLED
- */
-static int tcmu_glfs_handle_cmd(struct tcmu_device *dev,
-				struct tcmur_cmd *tcmur_cmd)
-{
-	struct tcmulib_cmd *cmd = tcmur_cmd->lib_cmd;
-	uint8_t *cdb = cmd->cdb;
-	int ret;
-
-	switch(cdb[0]) {
-	case WRITE_SAME:
-	case WRITE_SAME_16:
-		ret = tcmur_handle_writesame(dev, tcmur_cmd,
-					     tcmu_glfs_writesame);
-		break;
-	default:
-		ret = TCMU_STS_NOT_HANDLED;
-	}
-
-	return ret;
-}
-
 #if GFAPI_VERSION766
 static int tcmu_glfs_to_sts(int rc)
 {
@@ -1008,7 +985,7 @@ struct tcmur_handler glfs_handler = {
 	.reconfig       = tcmu_glfs_reconfig,
 	.flush          = tcmu_glfs_flush,
 	.unmap          = tcmu_glfs_discard,
-	.handle_cmd     = tcmu_glfs_handle_cmd,
+	.writesame      = tcmu_glfs_writesame,
 
 	.update_logdir  = tcmu_glfs_update_logdir,
 

--- a/rbd.c
+++ b/rbd.c
@@ -1629,36 +1629,6 @@ out:
 }
 #endif /* RBD_COMPARE_AND_WRITE_SUPPORT */
 
-/*
- * Return scsi status or TCMU_STS_NOT_HANDLED
- */
-static int tcmu_rbd_handle_cmd(struct tcmu_device *dev,
-			       struct tcmur_cmd *tcmur_cmd)
-{
-	struct tcmulib_cmd *cmd = tcmur_cmd->lib_cmd;
-	uint8_t *cdb = cmd->cdb;
-	int ret;
-
-	switch(cdb[0]) {
-#ifdef RBD_WRITE_SAME_SUPPORT
-	case WRITE_SAME:
-	case WRITE_SAME_16:
-		ret = tcmur_handle_writesame(dev, tcmur_cmd,
-					     tcmu_rbd_aio_writesame);
-		break;
-#endif
-#ifdef RBD_COMPARE_AND_WRITE_SUPPORT
-	case COMPARE_AND_WRITE:
-		ret = tcmur_handle_caw(dev, tcmur_cmd, tcmu_rbd_aio_caw);
-		break;
-#endif
-	default:
-		ret = TCMU_STS_NOT_HANDLED;
-	}
-
-	return ret;
-}
-
 static int tcmu_rbd_reconfig(struct tcmu_device *dev,
 			     struct tcmulib_cfg_info *cfg)
 {
@@ -1741,7 +1711,12 @@ struct tcmur_handler tcmu_rbd_handler = {
 #ifdef RBD_DISCARD_SUPPORT
 	.unmap         = tcmu_rbd_unmap,
 #endif
-	.handle_cmd    = tcmu_rbd_handle_cmd,
+#ifdef RBD_WRITE_SAME_SUPPORT
+	.writesame     = tcmu_rbd_aio_writesame,
+#endif
+#ifdef RBD_COMPARE_AND_WRITE_SUPPORT
+	.caw           = tcmu_rbd_aio_caw,
+#endif
 #ifdef RBD_LOCK_ACQUIRE_SUPPORT
 	.lock          = tcmu_rbd_lock,
 	.unlock        = tcmu_rbd_unlock,

--- a/tcmu-runner.h
+++ b/tcmu-runner.h
@@ -151,6 +151,10 @@ struct tcmur_handler {
 	int (*flush)(struct tcmu_device *dev, struct tcmur_cmd *cmd);
 	int (*unmap)(struct tcmu_device *dev, struct tcmur_cmd *cmd,
 		     uint64_t off, uint64_t len);
+	int (*writesame)(struct tcmu_device *dev, struct tcmur_cmd *cmd, uint64_t off,
+			 uint64_t len, struct iovec *iovec, size_t iov_cnt);
+	int (*caw)(struct tcmu_device *dev, struct tcmur_cmd *cmd, uint64_t off,
+		   uint64_t len, struct iovec *iovec, size_t iov_cnt);
 
 	/*
 	 * Notify the handler of an event.

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -365,7 +365,7 @@ static int align_and_split_unmap(struct tcmu_device *dev,
 		pthread_mutex_lock(&state->lock);
 		state->refcount++;
 		pthread_mutex_unlock(&state->lock);
-	
+
 		ret = aio_request_schedule(dev, tcmur_ucmd, unmap_work_fn,
 					   tcmur_cmd_complete);
 		if (ret != TCMU_STS_ASYNC_HANDLED)
@@ -373,9 +373,7 @@ static int align_and_split_unmap(struct tcmu_device *dev,
 
 		nlbas -= lbas;
 		lba += lbas;
-
 		lbas = min(opt_unmap_gran, nlbas);
-
 	}
 
 	return ret;

--- a/tcmur_cmd_handler.h
+++ b/tcmur_cmd_handler.h
@@ -24,17 +24,14 @@ int tcmur_cmd_passthrough_handler(struct tcmu_device *dev, struct tcmulib_cmd *c
 bool tcmur_handler_is_passthrough_only(struct tcmur_handler *rhandler);
 void tcmur_tcmulib_cmd_complete(struct tcmu_device *dev,
 				struct tcmulib_cmd *cmd, int ret);
+
 typedef int (*tcmur_writesame_fn_t)(struct tcmu_device *dev,
 				    struct tcmur_cmd *tcmur_cmd, uint64_t off,
 				    uint64_t len, struct iovec *iov,
 				    size_t iov_cnt);
-int tcmur_handle_writesame(struct tcmu_device *dev, struct tcmur_cmd *tcmur_cmd,
-			   tcmur_writesame_fn_t write_same_fn);
 
 typedef int (*tcmur_caw_fn_t)(struct tcmu_device *dev,
 			      struct tcmur_cmd *tcmur_cmd, uint64_t off,
 			      uint64_t len, struct iovec *iov, size_t iov_cnt);
-int tcmur_handle_caw(struct tcmu_device *dev, struct tcmur_cmd *tcmur_cmd,
-                     tcmur_caw_fn_t caw_fn);
 
 #endif /* __TCMUR_CMD_HANDLER_H */


### PR DESCRIPTION
The write zeroes API will allow the size not to align to the UNMAP
granularity, this can make sure that the specified area will always
be zeroed or discarded. While the discard API will do nothing when
the option rbd_skip_partial_discards is true.

Signed-off-by: Xiubo Li <xiubli@redhat.com>