### PR TITLE
tcmu_read_config(): check read() return value.

### DIFF
--- a/libtcmu_config.c
+++ b/libtcmu_config.c
@@ -202,7 +202,7 @@ static int tcmu_read_config(int fd, char *buf, int count)
 
 	do {
 		len = read(fd, buf, count);
-	} while (errno == EAGAIN);
+	} while (len < 0 && errno == EAGAIN);
 
 	errno = save;
 	return len;


### PR DESCRIPTION
tcmu-runner doesn't work correctly on Fedora 34 because it
enters an infinite loop while reading the /etc/tcmu/tcmu.conf config
file. The reason is that tcmu_read_config() doesn't check the read()
return value, relying only on errno's value, but the latter should
only be checked when read() returns -1.

Signed-off-by: Maurizio Lombardi <mlombard@redhat.com>