### PR TITLE
spec: make dist tag optional

### DIFF
--- a/tcmu-runner.spec
+++ b/tcmu-runner.spec
@@ -39,7 +39,7 @@ Version:       1.5.4
 URL:           https://github.com/open-iscsi/tcmu-runner
 
 #%define _RC
-Release:       %{?_RC:%{_RC}}%{dist}
+Release:       %{?_RC:%{_RC}}%{?dist}
 BuildRoot:     %(mktemp -udp %{_tmppath}/%{name}-%{version}%{?_RC:-%{_RC}})
 Source:       %{name}-%{version}%{?_RC:-%{_RC}}.tar.gz
 ExclusiveOS:   Linux


### PR DESCRIPTION
Technically the `%{dist}` RPM macro is optional, so Fedora's convention is to use a question mark in the Release field.

https://docs.fedoraproject.org/en-US/packaging-guidelines/DistTag/

Practically speaking, `%{dist}` is almost always defined, so the question mark is not necessary, but this silences a warning in one of Red Hat's internal linters.