### PR TITLE
tcmur_device: rename lock names in tcmur_device struct

### DIFF
--- a/alua.c
+++ b/alua.c
@@ -432,12 +432,12 @@ static int alua_sync_state(struct tcmu_device *dev,
 				 * the first command sent to us so clear
 				 * lock state to avoid later blacklist errors.
 				 */
-				pthread_mutex_lock(&rdev->state_lock);
+				pthread_mutex_lock(&rdev->rdev_lock);
 				if (rdev->lock_state == TCMUR_DEV_LOCK_WRITE_LOCKED) {
 					tcmu_dev_dbg(dev, "Dropping lock\n");
 					rdev->lock_state = TCMUR_DEV_LOCK_UNLOCKED;
 				}
-				pthread_mutex_unlock(&rdev->state_lock);
+				pthread_mutex_unlock(&rdev->rdev_lock);
 			}
 		}
 
@@ -560,7 +560,7 @@ int alua_implicit_transition(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	if (!lock_is_required(dev))
 		return ret;
 
-	pthread_mutex_lock(&rdev->state_lock);
+	pthread_mutex_lock(&rdev->rdev_lock);
 	if (rdev->lock_state == TCMUR_DEV_LOCK_WRITE_LOCKED) {
 		/* For both read/write cases in this state is good */
 		goto done;
@@ -617,7 +617,7 @@ int alua_implicit_transition(struct tcmu_device *dev, struct tcmulib_cmd *cmd,
 	}
 
 done:
-	pthread_mutex_unlock(&rdev->state_lock);
+	pthread_mutex_unlock(&rdev->rdev_lock);
 	return ret;
 }
 

--- a/target.c
+++ b/target.c
@@ -29,7 +29,7 @@
 static struct list_head tpg_recovery_list = LIST_HEAD_INIT(tpg_recovery_list);
 /*
  * Locking ordering:
- * rdev->state_lock
+ * rdev->rdev_lock
  * tpg_recovery_lock
  */
 static pthread_mutex_t tpg_recovery_lock = PTHREAD_MUTEX_INITIALIZER;

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -2329,9 +2329,9 @@ void tcmur_set_pending_ua(struct tcmu_device *dev, int ua)
 {
 	struct tcmur_device *rdev = tcmu_dev_get_private(dev);
 
-	pthread_mutex_lock(&rdev->state_lock);
+	pthread_mutex_lock(&rdev->rdev_lock);
 	rdev->pending_uas |= (1 << ua);
-	pthread_mutex_unlock(&rdev->state_lock);
+	pthread_mutex_unlock(&rdev->rdev_lock);
 }
 
 /*
@@ -2348,7 +2348,7 @@ static int handle_pending_ua(struct tcmur_device *rdev, struct tcmulib_cmd *cmd)
 		/* The kernel will handle REPORT_LUNS */
 		return TCMU_STS_NOT_HANDLED;
 	}
-	pthread_mutex_lock(&rdev->state_lock);
+	pthread_mutex_lock(&rdev->rdev_lock);
 
 	if (!rdev->pending_uas) {
 		ret = TCMU_STS_NOT_HANDLED;
@@ -2364,7 +2364,7 @@ static int handle_pending_ua(struct tcmur_device *rdev, struct tcmulib_cmd *cmd)
 	rdev->pending_uas &= ~(1 << ua);
 
 unlock:
-	pthread_mutex_unlock(&rdev->state_lock);
+	pthread_mutex_unlock(&rdev->rdev_lock);
 	return ret;
 }
 

--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -40,8 +40,8 @@ void tcmur_tcmulib_cmd_complete(struct tcmu_device *dev,
 	struct tcmur_cmd *tcmur_cmd = cmd->hm_private;
 	struct timespec curr_time;
 
-	pthread_cleanup_push(_cleanup_spin_lock, (void *)&rdev->lock);
-	pthread_spin_lock(&rdev->lock);
+	pthread_cleanup_push(_cleanup_spin_lock, (void *)&rdev->cmds_list_lock);
+	pthread_spin_lock(&rdev->cmds_list_lock);
 
 	if (tcmur_cmd->timed_out) {
 		if (tcmur_get_time(dev, &curr_time)) {
@@ -60,7 +60,7 @@ void tcmur_tcmulib_cmd_complete(struct tcmu_device *dev,
 
 	tcmulib_command_complete(dev, cmd, rc);
 
-	pthread_spin_unlock(&rdev->lock);
+	pthread_spin_unlock(&rdev->cmds_list_lock);
 	pthread_cleanup_pop(0);
 }
 

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -48,6 +48,9 @@ struct tcmur_device {
 
 	pthread_t cmdproc_thread;
 
+	/* General lock for the members from "flags" to "pending_uas" */
+	pthread_mutex_t rdev_lock;
+
 	/* TCMUR_DEV flags */
 	uint32_t flags;
 	uint8_t failover_type;
@@ -63,8 +66,6 @@ struct tcmur_device {
 	bool lock_lost;
 	uint8_t lock_state;
 
-	/* General lock for lock state, thread, dev state, etc */
-	pthread_mutex_t state_lock;
 	int pending_uas;
 
 	/*

--- a/tcmur_device.h
+++ b/tcmur_device.h
@@ -75,13 +75,14 @@ struct tcmur_device {
         struct tcmu_io_queue work_queue;
         struct tcmu_track_aio track_queue;
 
-	pthread_spinlock_t lock; /* protects concurrent updates to mailbox */
 	pthread_mutex_t caw_lock; /* for atomic CAW operation */
 
 	uint32_t format_progress;
 	pthread_mutex_t format_lock; /* for atomic format operations */
 
 	int cmd_time_out;
+
+	pthread_spinlock_t cmds_list_lock; /* protects cmds_list */
 	struct list_head cmds_list;
 };
 


### PR DESCRIPTION
The old names were inappropriate any more,  rename them to appropriate ones.