### PR TITLE
bugfix/DP-650: better recovery from crashes whilst creating a LUN

### DIFF
--- a/Issue668-Aarch64GetNextCmd.txt
+++ b/Issue668-Aarch64GetNextCmd.txt
@@ -1,0 +1,96 @@
+Please see https://github.com/open-iscsi/tcmu-runner/issues/688 for a full
+description and the latest commentary on the issue. I've copied and pasted a
+snapshot below, just in case:
+
+## Repro steps
+
+1. Grab this branch
+(https://github.com/geordieintheshellcode/tcmu-runner/tree/tcmu-get-next-command-broken).
+It's just `master` with some scripts and a fix to `consumer.c` to make it not
+when receiving IO.  2. Build and run the `consumer` example. `consumer` handles
+any TCMU backstores with the "foo" handler. For WRITE SCSI commands we'll simply
+drop them on the floor and return TCMU_STS_OK.  3. Run "create_foo.sh" to create
+a TCMU backstore backed by the `foo` handler and hook it up to a SCSI HBA/LUN.
+4. You'll see a bunch of benign error messages in dmesg, that's purely because
+the "foo" handler is only partially implement and will reject read SCSI commands
+with an error.  5. Now find the block device and run a fio test against it:
+`sudo FILE=/dev/sda BS=4k QD=128 fio randwrite.fio`
+
+Almost immediately you'll see the "cmd_id X not found, ring is broken" message in dmesg, and a bunch of writes will fail:
+
+```
+[Tue Oct  4 15:45:50 2022] cmd_id 0 not found, ring is broken
+[Tue Oct  4 15:45:50 2022] ring broken, not handling completions
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#174 FAILED Result: hostbyte=DID_OK driverbyte=DRIVER_SENSE cmd_age=0s
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#174 Sense Key : Not Ready [current]
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#174 Add. Sense: Logical unit communication failure
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#174 CDB: Write(10) 2a 00 00 17 69 70 00 00 08 00
+[Tue Oct  4 15:45:50 2022] blk_update_request: I/O error, dev sda, sector 1534320 op 0x1:(WRITE) flags 0x8800 phys_seg 1 prio class 0
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#175 FAILED Result: hostbyte=DID_OK driverbyte=DRIVER_SENSE cmd_age=0s
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#175 Sense Key : Not Ready [current]
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#175 Add. Sense: Logical unit communication failure
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#175 CDB: Write(10) 2a 00 00 19 a3 18 00 00 08 00
+[Tue Oct  4 15:45:50 2022] blk_update_request: I/O error, dev sda, sector 1680152 op 0x1:(WRITE) flags 0x8800 phys_seg 1 prio class 0
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#176 FAILED Result: hostbyte=DID_OK driverbyte=DRIVER_SENSE cmd_age=0s
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#176 Sense Key : Not Ready [current]
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#176 Add. Sense: Logical unit communication failure
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#176 CDB: Write(10) 2a 00 00 1c bb 80 00 00 08 00
+[Tue Oct  4 15:45:50 2022] blk_update_request: I/O error, dev sda, sector 1883008 op 0x1:(WRITE) flags 0x8800 phys_seg 1 prio class 0
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#177 FAILED Result: hostbyte=DID_OK driverbyte=DRIVER_SENSE cmd_age=0s
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#177 Sense Key : Not Ready [current]
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#177 Add. Sense: Logical unit communication failure
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#177 CDB: Write(10) 2a 00 00 15 b0 a0 00 00 08 00
+[Tue Oct  4 15:45:50 2022] blk_update_request: I/O error, dev sda, sector 1421472 op 0x1:(WRITE) flags 0x8800 phys_seg 1 prio class 0
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#178 FAILED Result: hostbyte=DID_OK driverbyte=DRIVER_SENSE cmd_age=0s
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#178 Sense Key : Not Ready [current]
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#178 Add. Sense: Logical unit communication failure
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#178 CDB: Write(10) 2a 00 00 0c 4c d0 00 00 08 00
+[Tue Oct  4 15:45:50 2022] blk_update_request: I/O error, dev sda, sector 806096 op 0x1:(WRITE) flags 0x8800 phys_seg 1 prio class 0
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#179 FAILED Result: hostbyte=DID_OK driverbyte=DRIVER_SENSE cmd_age=0s
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#179 Sense Key : Not Ready [current]
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#179 Add. Sense: Logical unit communication failure
+[Tue Oct  4 15:45:50 2022] sd 0:0:1:0: [sda] tag#179 CDB: Write(10) 2a 00 00 17 98 38 00 00 08 00
+```
+
+The same test happily runs for hours on x86.
+
+## Hypothesis
+
+ I think the issue is caused by us not reading the command ring
+`head` index with the correct memory barrier semantics. On the kernel side, in
+`target_core_user.c`, we can see that every time a new command is enqueued we
+first fill the `entry` and then update the ring buffer head index using the
+`UPDATE_HEAD` macro
+(https://elixir.bootlin.com/linux/v4.18/source/drivers/target/target_core_user.c#L1008).
+`UPDATE_HEAD` does an `smp_store_release()` to the head index. From my
+understanding, a store release barrier should be paired with a load acquire
+barrier. i.e. the read of the cmd head index in `tcmulib_get_next_command`
+should use acquire semantics. Running with the following patch causes the issue
+to go away, but I don't know if it's purely fortuitous or actually fixes the
+issue. The idea is to read the head index using an atomic load - which should (I
+think) be equivalent to a load acquire barrier:
+
+```
+diff --git a/libtcmu.c b/libtcmu.c
+index 46a6fbc..ec36309 100644
+--- a/libtcmu.c
++++ b/libtcmu.c
+@@ -1109,7 +1109,9 @@ device_cmd_head(struct tcmu_device *dev)
+ {
+        struct tcmu_mailbox *mb = dev->map;
+
+-       return (struct tcmu_cmd_entry *) ((char *) mb + mb->cmdr_off + mb->cmd_head);
++       uint32_t mb_head = __atomic_load_n(&mb->cmd_head, __ATOMIC_SEQ_CST);
++       struct tcmu_cmd_entry* e = (struct tcmu_cmd_entry *) ((char *) mb + mb->cmdr_off + mb_head);
++       return e;
+ }
+
+ static inline struct tcmu_cmd_entry *
+```
+
+The patch also appears to work with a less punitive `__ATOMIC_ACQUIRE` load.
+
+I'd appreciate someone checking my working here as I'm not massively clued up on
+this area! BTW I found this document useful in describing the expected memory
+barrier semantics for ring buffers:
+https://www.kernel.org/doc/Documentation/core-api/circular-buffers.rst.

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -371,7 +371,7 @@ static struct tcmulib_handler *find_handler(struct tcmulib_context *ctx,
 	len = found_at - cfgstring;
 
 	darray_foreach(handler, ctx->handlers) {
-		if (!strncmp(cfgstring, handler->subtype, len))
+		if (strlen(handler->subtype) == len && !strncmp(cfgstring, handler->subtype, len))
 		    return handler;
 	}
 

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -593,8 +593,14 @@ static int device_add(struct tcmulib_context *ctx, char *dev_name,
 		} else {
 			/*
 			 * Force a retry of the outstanding commands.
+			 *
+			 * Ondat edit: we use "2" to reset the ring rather than "1".
+			 * Looking at the target_core_user.c source "2" causes us to
+			 * do a "hard failure" which seems to work better in terms
+			 * of preventing hangs. We don't care about device recovery
+			 * in the CP/DP.
 			 */
-			rc = tcmu_cfgfs_dev_exec_action(dev, "reset_ring", 1);
+			rc = tcmu_cfgfs_dev_exec_action(dev, "reset_ring", 2);
 			if (rc)
 				tcmu_dev_err(dev, "Could not reset ring %d.\n", rc);
 		}

--- a/libtcmu.c
+++ b/libtcmu.c
@@ -5,6 +5,7 @@
  */
 
 #define _GNU_SOURCE
+#include <stdatomic.h>
 #include <memory.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -890,12 +891,12 @@ void tcmu_set_thread_name(const char *prefix, struct tcmu_device *dev)
 
 void tcmu_dev_set_num_lbas(struct tcmu_device *dev, uint64_t num_lbas)
 {
-	dev->num_lbas = num_lbas;
+	atomic_store(&dev->num_lbas, num_lbas);
 }
 
 uint64_t tcmu_dev_get_num_lbas(struct tcmu_device *dev)
 {
-	return dev->num_lbas;
+	return atomic_load(&dev->num_lbas);
 }
 
 uint64_t tcmu_lba_to_byte(struct tcmu_device *dev, uint64_t lba)

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -87,20 +87,35 @@ struct tcmulib_context;
 /* Claim subtypes you wish to handle. Returns libtcmu's master fd or -error.*/
 struct tcmulib_context *tcmulib_initialize(
 	struct tcmulib_handler *handlers,
-	size_t handler_count);
+	size_t handler_count,
+	bool use_netlink);
 
 /* Register to TCMU DBus service, for the claimed subtypes to be configurable
  * in targetcli. */
 void tcmulib_register(struct tcmulib_context *ctx);
 
-/* Gets the master file descriptor used by tcmulib. */
+/* Gets the master file descriptor used by tcmulib. If you called tcmulib_initialize
+ * with use_netlink=false then we aren't using netlink for device notifications and
+ * you shouldn't use this method.
+ *
+ * TODO(AJReid): what should you call instead.
+ */
 int tcmulib_get_master_fd(struct tcmulib_context *ctx);
 
 /*
  * Call this when the master fd becomes ready, from your main thread.
- * Handlers' callbacks may be called before it returns.
+ * Handlers' callbacks may be called before it returns. If you called
+ * tcmulib_initialize with use_netlink=false then we aren't using netlink
+ * for device notifications and you shouldn't use this method.
+ *
+ * TODO(AJReid): what should you call instead.
  */
 int tcmulib_master_fd_ready(struct tcmulib_context *ctx);
+
+int tcmulib_notify_device_added(struct tcmulib_context *ctx, char *dev_name,
+				char *cfgstring);
+
+void tcmulib_notify_device_removed(struct tcmulib_context *ctx, char *dev_name);
 
 /*
  * When a device fd becomes ready, call this to get SCSI cmd info in

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -117,6 +117,8 @@ int tcmulib_notify_device_added(struct tcmulib_context *ctx, char *dev_name,
 
 void tcmulib_notify_device_removed(struct tcmulib_context *ctx, char *dev_name);
 
+int tcmulib_notify_device_reconfig(struct tcmulib_context* ctx, char* dev_name, uint64_t dev_size);
+
 /*
  * When a device fd becomes ready, call this to get SCSI cmd info in
  * 'cmd' struct. libtcmu will allocate hm_cmd_size bytes for each cmd

--- a/libtcmu.h
+++ b/libtcmu.h
@@ -97,8 +97,6 @@ void tcmulib_register(struct tcmulib_context *ctx);
 /* Gets the master file descriptor used by tcmulib. If you called tcmulib_initialize
  * with use_netlink=false then we aren't using netlink for device notifications and
  * you shouldn't use this method.
- *
- * TODO(AJReid): what should you call instead.
  */
 int tcmulib_get_master_fd(struct tcmulib_context *ctx);
 
@@ -107,16 +105,31 @@ int tcmulib_get_master_fd(struct tcmulib_context *ctx);
  * Handlers' callbacks may be called before it returns. If you called
  * tcmulib_initialize with use_netlink=false then we aren't using netlink
  * for device notifications and you shouldn't use this method.
- *
- * TODO(AJReid): what should you call instead.
  */
 int tcmulib_master_fd_ready(struct tcmulib_context *ctx);
 
+/*
+ * Notify the library that a TCMU backstore has been created. This
+ * function will open the backstore and call the appropriate handler(s)
+ * Use this method if you called tcmulib_initialize with netlink=false.
+ */
 int tcmulib_notify_device_added(struct tcmulib_context *ctx, char *dev_name,
 				char *cfgstring);
 
+/*
+ * Notify the library that the TCMU backstore is about to be removed.
+ * This function will close the backstore and call the removed handler.
+ * Use this method if you called tcmulib_initialize with netlink=false.
+ */
 void tcmulib_notify_device_removed(struct tcmulib_context *ctx, char *dev_name);
 
+/*
+ * Notify the library that the TCMU backstore should be reconfigured.
+ * This function will simply call the reconfig handler. At the moment
+ * only resizing the device is supported (changing the write cache mode
+ * or cfgstring is not supported). Use this method if you called
+ * tcmulib_initialize with netlink=false.
+ */
 int tcmulib_notify_device_reconfig(struct tcmulib_context* ctx, char* dev_name, uint64_t dev_size);
 
 /*

--- a/libtcmu_priv.h
+++ b/libtcmu_priv.h
@@ -43,7 +43,10 @@ struct tcmu_device {
 
 	uint32_t cmd_tail;
 
-	uint64_t num_lbas;
+	// Note: we've made this variable atomic because it's possible to change the
+	// size of a device at runtime whilst IO is on-going. See DP-622. All other
+	// variables in this type are essentially const.
+	_Atomic uint64_t num_lbas;
 	uint32_t block_size;
 	uint32_t block_size_shift;
 	uint32_t max_xfer_len;


### PR DESCRIPTION
Issue a "hard" ring reset on startup when we detect any remnant devices. This seems to work better for the DP when recovering from a crash midway through creating a LUN. See the accompanying DP PR for an explanation: https://ci.storageos.net/view/rhel8/job/dataplane-build/job/bugfix%252FDP-650-better-recovery-from-crashes-whilst-creating-a-lun/