### PR TITLE
tcmur_device: fix racy between reopening devices and reporting events

### DIFF
--- a/target.c
+++ b/target.c
@@ -339,6 +339,7 @@ int tcmu_add_dev_to_recovery_list(struct tcmu_device *dev)
 
 add_to_list:
 	list_add(&tpg->devs, &rdev->recovery_entry);
+	rdev->flags |= TCMUR_DEV_FLAG_IN_RECOVERY;
 done:
 	tcmu_release_alua_grps(&alua_list);
 	pthread_mutex_unlock(&tpg_recovery_lock);


### PR DESCRIPTION
To make sure all the in-flight IOs have been finished before flushing the event_work. Or just after we flush the event_work a new timedout IO callback could come and then it will fire a new event work, which may access the device while we are closing the device later.

Signed-off-by: Xiubo Li <xiubli@redhat.com>