### PR TITLE
tcmur_device: skip reporting events if the device is closed

### DIFF
--- a/tcmur_device.c
+++ b/tcmur_device.c
@@ -171,9 +171,11 @@ static void __tcmu_report_event(void *data)
 	sleep(1);
 
 	pthread_mutex_lock(&rdev->rdev_lock);
-	ret = rhandler->report_event(dev);
-	if (ret)
-		tcmu_dev_err(dev, "Could not report events. Error %d.\n", ret);
+	if (rdev->flags & TCMUR_DEV_FLAG_IS_OPEN) {
+		ret = rhandler->report_event(dev);
+		if (ret)
+			tcmu_dev_err(dev, "Could not report events. Error %d.\n", ret);
+	}
 	pthread_mutex_unlock(&rdev->rdev_lock);
 }
 


### PR DESCRIPTION
After the rbd device being blocklisted it will lost the connection and at the same time will timedout all the IOs. While the tcmu-runner will report a 'lock_lost_cnt' event to ceph cluster. And if during this the device is reopened it will cause the use-after-free bug.

When reopening the device it will hold the 'rdev->rdev_lock' lock and then clear the 'TCMUR_DEV_FLAG_IS_OPEN' flag. And we can check this flag and just skip reporting events if the device is closed.