### PR TITLE
tcmur_cmd_handler: To fix the issue on a CentOS 7.9 client where the …

### DIFF
--- a/tcmur_cmd_handler.c
+++ b/tcmur_cmd_handler.c
@@ -685,7 +685,7 @@ static int handle_unmap_in_writesame(struct tcmu_device *dev,
 	int ret;
 
 	/* If not aligned then falls back to the writesame without unmap */
-	if (lba % align || nlbas % align) {
+	if (align == 0 || lba % align || nlbas % align) {
 		tcmu_dev_dbg(dev,
 			     "Start lba: %"PRIu64" or nlbas: %"PRIu64" not aligned to %"PRIu32"\n",
 			     lba, nlbas, align);


### PR DESCRIPTION
…tcmu-runner ver=1.5.4 service faild after using mkfs.xfs to format a LUN device